### PR TITLE
feat(url): URL fetch, HTML conversion, and asset pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ pip install "mdengine[all]"
 | `image-ocr` | Heavy OCR backends (pytesseract, paddle, easyocr, …) |
 | `text` | TXT / JSON / XML converter (stdlib-oriented; marker extra) |
 | `archive` | ZIP → Markdown layout (Pillow; optional tesseract for inline image OCR) |
+| `url` | HTTP(S) HTML → Markdown (httpx, readability-lxml, markdownify, BeautifulSoup, lxml) |
+| `url-full` | `url` plus PDF/Word/PPTX/XLSX/archive stack for **post-converting** downloaded linked files to Markdown |
 | `api` | FastAPI, uvicorn, httpx, pydantic-settings |
 | `mcp` | MCP servers (`mcp`, `fastmcp` where used) |
 | `dev` | pytest + API/MCP test helpers |
@@ -113,6 +115,7 @@ If the shell reports “command not found”, ensure the Python **Scripts** dire
 | `md-image` | `md_generator.image.converter:main` | `md-image ./scans page.md` |
 | `md-text` | `md_generator.text.converter:main` | `md-text config.xml out.md` |
 | `md-zip` | `md_generator.archive.converter:main` | `md-zip bundle.zip ./zip-out` |
+| `md-url` | `md_generator.url.converter:main` | `md-url https://example.com/doc ./web-out --artifact-layout` |
 
 Every command accepts **`-h` / `--help`** for full flags (artifact layout, OCR, ZIP options, etc.).
 
@@ -129,6 +132,7 @@ md-xlsx -i export.csv -o ./csv-out
 md-image ./photos ocr.md --engines tess --strategy best
 md-text data.json data.md
 md-zip archive.zip ./unzipped-md
+md-url https://example.com/page ./page-bundle --artifact-layout
 ```
 
 **Windows PowerShell** (same commands; use backslashes for paths if you prefer)
@@ -136,6 +140,7 @@ md-zip archive.zip ./unzipped-md
 ```powershell
 md-pdf .\manual.pdf .\out\doc.md
 md-zip .\archive.zip .\zip-out
+md-url https://example.com/page .\page-bundle --artifact-layout
 ```
 
 **Windows CMD**
@@ -143,11 +148,12 @@ md-zip .\archive.zip .\zip-out
 ```cmd
 md-pdf manual.pdf out\doc.md
 md-zip archive.zip zip-out
+md-url https://example.com/page page-bundle --artifact-layout
 ```
 
 ### 5. Run without `pip install` (repo clone + `PYTHONPATH`)
 
-The folders `pdf-to-md/`, `word-to-md/`, … contain a thin `converter.py` that calls the same code as `md-pdf`, `md-word`, etc. From the **repository root**, point Python at `src` so `md_generator` imports, then run the shim:
+The folders `pdf-to-md/`, `word-to-md/`, `url-to-md/`, … contain a thin `converter.py` that calls the same code as `md-pdf`, `md-word`, etc. From the **repository root**, point Python at `src` so `md_generator` imports, then run the shim:
 
 **PowerShell**
 
@@ -308,12 +314,12 @@ convert_zip(
 
 All format APIs follow a similar pattern:
 
-- **`POST /convert/sync`** — upload a file; response is often a **ZIP** (artifact bundle) for larger formats.
+- **`POST /convert/sync`** — upload a file (most converters) **or** send JSON (`url-to-md`); response is often a **ZIP** (artifact bundle) for larger formats.
 - **`POST /convert/jobs`** — async job; returns `job_id`.
 - **`GET /convert/jobs/{job_id}`** — status.
 - **`GET /convert/jobs/{job_id}/download`** — download result when ready.
 
-Upload field name is **`file`** (multipart form). Use `httpx` or `curl -F "file=@path/to/file"`.
+Upload field name is **`file`** (multipart form) for file-based converters. Use `httpx` or `curl -F "file=@path/to/file"`. **URL** conversion uses a **JSON** body (`url` or `urls`); see [url-to-md/README.md](url-to-md/README.md).
 
 ### Run with Uvicorn
 
@@ -328,6 +334,7 @@ Install `mdengine[api]` plus the format extra(s), then run the **`app`** object 
 | Image | `md_generator.image.api.main:app` | `image`, `api`, `mcp` |
 | Text/JSON/XML | `md_generator.text.api.main:app` | `text`, `api`, `mcp` |
 | ZIP | `md_generator.archive.api.main:app` | `archive`, `api`, `mcp` (+ extras for nested office/PDF) |
+| URL / HTML | `md_generator.url.api.main:app` | `url`, `api`, `mcp` |
 
 Examples:
 
@@ -335,6 +342,7 @@ Examples:
 uvicorn md_generator.pdf.api.main:app --host 127.0.0.1 --port 8001
 uvicorn md_generator.word.api.main:app --host 127.0.0.1 --port 8002
 uvicorn md_generator.archive.api.main:app --host 127.0.0.1 --port 8010
+uvicorn md_generator.url.api.main:app --host 127.0.0.1 --port 8011
 ```
 
 ### MCP over HTTP on the same server
@@ -353,6 +361,7 @@ Prefixes differ per service (often read from a `.env` file next to the process):
 | PPTX | `PPT_TO_MD_` | `PPT_TO_MD_MAX_UPLOAD_MB`, … |
 | Text | `TXT_JSON_XML_TO_MD_` | same pattern |
 | XLSX | `XLSX_TO_MD_` | `XLSX_TO_MD_TEMP_DIR`, `XLSX_TO_MD_CORS_ORIGINS`, etc. (see `md_generator.xlsx.api.app`) |
+| URL | `URL_TO_MD_` | `URL_TO_MD_MAX_SYNC_URLS`, `URL_TO_MD_MAX_SYNC_CRAWL_PAGES`, `URL_TO_MD_MAX_JOB_URLS`, `URL_TO_MD_JOB_TTL_SECONDS`, `URL_TO_MD_TEMP_DIR`, `URL_TO_MD_CORS_ORIGINS` |
 
 Exact variable names match the `ApiSettings` / helper functions in each `api/settings` or `api/app` module.
 
@@ -375,6 +384,7 @@ Two usage patterns:
 | PDF (FastMCP) | `python -m md_generator.pdf.api.mcp_server` / `--transport stdio` / `sse` / `streamable-http` |
 | PPTX | `python -m md_generator.ppt.api.mcp_server` (see module docstring for flags) |
 | Image | `python -m md_generator.image.api.mcp_server` (see module for CLI) |
+| URL / HTML | `python -m md_generator.url.api.mcp_server` / `--transport sse` / `--transport streamable-http` |
 
 **Word** and **XLSX** also ship a small runner script in the repo:
 

--- a/md-generator.code-workspace
+++ b/md-generator.code-workspace
@@ -6,7 +6,8 @@
     { "path": "word-to-md", "name": "word-to-md" },
     { "path": "pdf-to-md", "name": "pdf-to-md" },
     { "path": "ppt-to-md", "name": "ppt-to-md" },
-    { "path": "xlsx-to-md", "name": "xlsx-to-md" }
+    { "path": "xlsx-to-md", "name": "xlsx-to-md" },
+    { "path": "url-to-md", "name": "url-to-md" }
   ],
   "settings": {
     "python.languageServer": "Pylance",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,13 +5,13 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "mdengine"
 version = "0.1.0"
-description = "Convert PDF, Office, images, text/JSON/XML, and ZIP archives to Markdown."
+description = "Convert PDF, Office, images, text/JSON/XML, ZIP archives, and web URLs to Markdown."
 readme = "README.md"
 requires-python = ">=3.10"
 license = "MIT"
 license-files = ["LICENSE"]
 authors = [{ name = "mdengine contributors" }]
-keywords = ["markdown", "pdf", "docx", "pptx", "xlsx", "ocr", "zip"]
+keywords = ["markdown", "pdf", "docx", "pptx", "xlsx", "ocr", "zip", "url", "html"]
 classifiers = [
   "Programming Language :: Python :: 3",
   "Programming Language :: Python :: 3 :: Only",
@@ -47,6 +47,31 @@ image-ocr = [
 ]
 text = []
 archive = ["Pillow>=10.0.0", "pytesseract>=0.3.10"]
+url = [
+  "httpx>=0.27.0",
+  "beautifulsoup4>=4.12.0",
+  "lxml>=5.0.0",
+  "lxml_html_clean>=0.4.0",
+  "markdownify>=0.14.0",
+  "readability-lxml>=0.8.1",
+]
+# Convenience extra for URL fetch + post-convert of downloaded office/PDF/ZIP/etc.
+url-full = [
+  "httpx>=0.27.0",
+  "beautifulsoup4>=4.12.0",
+  "lxml>=5.0.0",
+  "lxml_html_clean>=0.4.0",
+  "markdownify>=0.14.0",
+  "readability-lxml>=0.8.1",
+  "pymupdf>=1.24.0",
+  "pdfplumber>=0.11.0",
+  "mammoth>=1.8.0",
+  "python-pptx>=1.0.0",
+  "Pillow>=10.0.0",
+  "olefile>=0.47",
+  "openpyxl>=3.1.0",
+  "pytesseract>=0.3.10",
+]
 api = [
   "fastapi>=0.115.0",
   "uvicorn[standard]>=0.32.0",
@@ -55,7 +80,13 @@ api = [
   "pydantic-settings>=2.0.0",
 ]
 mcp = ["mcp>=1.2.0", "fastmcp>=2.3.0"]
-dev = ["pytest>=8.0.0", "httpx>=0.27.0", "mdengine[api]", "mdengine[mcp]"]
+dev = [
+  "pytest>=8.0.0",
+  "httpx>=0.27.0",
+  "mdengine[api]",
+  "mdengine[mcp]",
+  "mdengine[url]",
+]
 all = [
   "pymupdf>=1.24.0",
   "pdfplumber>=0.11.0",
@@ -78,6 +109,9 @@ all = [
   "pydantic-settings>=2.0.0",
   "mcp>=1.2.0",
   "fastmcp>=2.3.0",
+  "beautifulsoup4>=4.12.0",
+  "lxml_html_clean>=0.4.0",
+  "readability-lxml>=0.8.1",
 ]
 
 [project.urls]
@@ -93,6 +127,7 @@ md-xlsx = "md_generator.xlsx.converter:main"
 md-image = "md_generator.image.converter:main"
 md-text = "md_generator.text.converter:main"
 md-zip = "md_generator.archive.converter:main"
+md-url = "md_generator.url.converter:main"
 
 [tool.setuptools.packages.find]
 where = ["src"]
@@ -107,5 +142,6 @@ testpaths = [
   "image-to-md/tests",
   "txt-json-xml-to-md/tests",
   "zip-to-md/tests",
+  "url-to-md/tests",
 ]
 markers = ["integration: optional dependency or slower checks"]

--- a/src/md_generator/url/__init__.py
+++ b/src/md_generator/url/__init__.py
@@ -1,0 +1,24 @@
+"""Convert public HTTP(S) HTML pages to Markdown with downloaded assets."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from md_generator.url.options import ConvertOptions
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+__all__ = ["ConvertOptions", "convert_url", "convert_urls_from_list"]
+
+
+def __getattr__(name: str) -> object:
+    if name == "convert_url":
+        from md_generator.url.convert_impl import convert_url as v
+
+        return v
+    if name == "convert_urls_from_list":
+        from md_generator.url.convert_impl import convert_urls_from_list as v
+
+        return v
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/md_generator/url/api/__init__.py
+++ b/src/md_generator/url/api/__init__.py
@@ -1,0 +1,1 @@
+# FastAPI + MCP for url-to-md

--- a/src/md_generator/url/api/convert_runner.py
+++ b/src/md_generator/url/api/convert_runner.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import io
+import zipfile
+from pathlib import Path
+
+from md_generator.url.convert_impl import convert_url_job
+from md_generator.url.options import ConvertOptions
+
+
+def zip_directory(root: Path) -> bytes:
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+        for p in sorted(root.rglob("*")):
+            if p.is_file():
+                arc = p.relative_to(root)
+                zf.write(p, arc.as_posix())
+    return buf.getvalue()
+
+
+def build_artifact_zip_bytes(
+    *,
+    url: str | None,
+    urls: list[str] | None,
+    options: ConvertOptions,
+) -> bytes:
+    """Run conversion into a temp dir; return ZIP bytes (document.md + assets/ + pages/ when applicable)."""
+    import tempfile
+
+    with tempfile.TemporaryDirectory() as td:
+        out = Path(td) / "artifact"
+        out.mkdir(parents=True, exist_ok=True)
+        convert_url_job(url, urls, out, options)
+        return zip_directory(out)

--- a/src/md_generator/url/api/jobs.py
+++ b/src/md_generator/url/api/jobs.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import shutil
+import threading
+import time
+import uuid
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Callable
+
+
+@dataclass
+class Job:
+    job_id: str
+    workspace: Path
+    status: str = "queued"
+    error: str | None = None
+    created_at: float = field(default_factory=time.time)
+    zip_path: Path | None = None
+
+
+class JobStore:
+    def __init__(self, base_temp: Path | None, ttl_seconds: int) -> None:
+        self._base = base_temp
+        self._ttl = ttl_seconds
+        self._jobs: dict[str, Job] = {}
+        self._lock = threading.Lock()
+        self._sweeper_started = False
+
+    def _root(self) -> Path:
+        import tempfile
+
+        if self._base:
+            p = Path(self._base)
+            p.mkdir(parents=True, exist_ok=True)
+            return p
+        return Path(tempfile.gettempdir()) / "url-to-md-jobs"
+
+    def start_sweeper(self) -> None:
+        if self._sweeper_started:
+            return
+        self._sweeper_started = True
+
+        def loop() -> None:
+            while True:
+                time.sleep(60)
+                self.sweep()
+
+        threading.Thread(target=loop, daemon=True).start()
+
+    def sweep(self) -> None:
+        now = time.time()
+        with self._lock:
+            dead: list[str] = []
+            for jid, job in self._jobs.items():
+                if job.status in ("done", "failed") and now - job.created_at > self._ttl:
+                    dead.append(jid)
+            for jid in dead:
+                job = self._jobs.pop(jid, None)
+                if job and job.workspace.exists():
+                    shutil.rmtree(job.workspace, ignore_errors=True)
+
+    def create_job(self) -> Job:
+        jid = str(uuid.uuid4())
+        ws = self._root() / jid
+        ws.mkdir(parents=True, exist_ok=True)
+        job = Job(job_id=jid, workspace=ws)
+        with self._lock:
+            self._jobs[jid] = job
+        return job
+
+    def get(self, job_id: str) -> Job | None:
+        with self._lock:
+            return self._jobs.get(job_id)
+
+    def run_async(self, job: Job, fn: Callable[[], None]) -> None:
+        def target() -> None:
+            try:
+                job.status = "running"
+                fn()
+                job.status = "done"
+            except Exception as e:
+                job.status = "failed"
+                job.error = str(e)
+
+        threading.Thread(target=target, daemon=True).start()
+
+    def remove_after_download(self, job: Job) -> None:
+        with self._lock:
+            self._jobs.pop(job.job_id, None)
+        if job.workspace.exists():
+            shutil.rmtree(job.workspace, ignore_errors=True)

--- a/src/md_generator/url/api/main.py
+++ b/src/md_generator/url/api/main.py
@@ -1,0 +1,377 @@
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from pathlib import Path
+from urllib.parse import urlparse
+
+from fastapi import FastAPI, HTTPException, Request
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import FileResponse, Response
+from pydantic import BaseModel, Field, model_validator
+from starlette.background import BackgroundTask
+
+from md_generator.url.api.convert_runner import build_artifact_zip_bytes, zip_directory
+from md_generator.url.api.jobs import JobStore
+from md_generator.url.api.mcp_setup import build_mcp_stack
+from md_generator.url.api.settings import ApiSettings, cors_list
+from md_generator.url.convert_impl import convert_url_job
+from md_generator.url.options import DEFAULT_IMAGE_TO_MD_ENGINES, ConvertOptions
+
+_mcp, _mcp_http = build_mcp_stack(mount_under_fastapi=True)
+
+
+def _is_http_url(s: str) -> bool:
+    p = urlparse(s.strip())
+    return p.scheme in ("http", "https") and bool(p.netloc)
+
+
+class ConvertJsonBody(BaseModel):
+    url: str | None = None
+    urls: list[str] | None = None
+    crawl: bool = False
+    async_crawl: bool = False
+    crawl_max_concurrency: int = Field(default=4, ge=1, le=32)
+    max_depth: int = Field(default=2, ge=0, le=20)
+    max_pages: int = Field(default=30, ge=1, le=500)
+    crawl_delay_seconds: float = Field(default=0.5, ge=0.0, le=60.0)
+    obey_robots: bool = True
+    include_subdomains: bool = True
+    table_csv: bool = True
+    download_linked_files: bool = True
+    timeout_seconds: float = Field(default=30.0, ge=1.0, le=300.0)
+    max_response_mb: float = Field(default=10.0, ge=0.5, le=100.0)
+    convert_downloaded_assets: bool = True
+    convert_downloaded_images: bool = True
+    convert_downloaded_image_to_md_engines: str = DEFAULT_IMAGE_TO_MD_ENGINES
+    convert_downloaded_image_to_md_strategy: str = "best"
+    convert_downloaded_image_to_md_title: str = ""
+    post_convert_pdf_ocr: bool = False
+    post_convert_pdf_ocr_min_chars: int = Field(default=40, ge=1, le=500)
+    post_convert_ppt_embedded_deep: bool = True
+    max_linked_files: int = Field(default=40, ge=1, le=500)
+    max_downloaded_images: int = Field(default=50, ge=1, le=200)
+
+    @model_validator(mode="after")
+    def check_source(self) -> ConvertJsonBody:
+        has_url = self.url is not None and bool(self.url.strip())
+        has_urls = self.urls is not None and len(self.urls) > 0
+        if not has_url and not has_urls:
+            raise ValueError("Provide url or urls")
+        if has_url and has_urls:
+            raise ValueError("Provide only one of url or urls")
+        if self.urls:
+            for u in self.urls:
+                if not _is_http_url(u):
+                    raise ValueError(f"Invalid URL: {u!r}")
+        if self.url and not _is_http_url(self.url):
+            raise ValueError("Invalid url")
+        return self
+
+
+def _merged_options(
+    body: ConvertJsonBody,
+    *,
+    crawl: bool | None = None,
+    async_crawl: bool | None = None,
+    crawl_max_concurrency: int | None = None,
+    max_depth: int | None = None,
+    max_pages: int | None = None,
+    crawl_delay_seconds: float | None = None,
+    obey_robots: bool | None = None,
+    include_subdomains: bool | None = None,
+    table_csv: bool | None = None,
+    download_linked_files: bool | None = None,
+    timeout_seconds: float | None = None,
+    max_response_bytes: int | None = None,
+    convert_downloaded_assets: bool | None = None,
+    convert_downloaded_images: bool | None = None,
+    convert_downloaded_image_to_md_engines: str | None = None,
+    convert_downloaded_image_to_md_strategy: str | None = None,
+    convert_downloaded_image_to_md_title: str | None = None,
+    post_convert_pdf_ocr: bool | None = None,
+    post_convert_pdf_ocr_min_chars: int | None = None,
+    post_convert_ppt_embedded_deep: bool | None = None,
+    max_linked_files: int | None = None,
+    max_downloaded_images: int | None = None,
+) -> ConvertOptions:
+    return ConvertOptions(
+        artifact_layout=True,
+        crawl=crawl if crawl is not None else body.crawl,
+        async_crawl=async_crawl if async_crawl is not None else body.async_crawl,
+        crawl_max_concurrency=crawl_max_concurrency
+        if crawl_max_concurrency is not None
+        else body.crawl_max_concurrency,
+        max_depth=max_depth if max_depth is not None else body.max_depth,
+        max_pages=max_pages if max_pages is not None else body.max_pages,
+        crawl_delay_seconds=crawl_delay_seconds
+        if crawl_delay_seconds is not None
+        else body.crawl_delay_seconds,
+        obey_robots=obey_robots if obey_robots is not None else body.obey_robots,
+        include_subdomains=include_subdomains
+        if include_subdomains is not None
+        else body.include_subdomains,
+        table_csv=table_csv if table_csv is not None else body.table_csv,
+        download_linked_files=download_linked_files
+        if download_linked_files is not None
+        else body.download_linked_files,
+        timeout_seconds=timeout_seconds if timeout_seconds is not None else body.timeout_seconds,
+        max_response_bytes=max_response_bytes
+        if max_response_bytes is not None
+        else int(body.max_response_mb * 1024 * 1024),
+        convert_downloaded_assets=convert_downloaded_assets
+        if convert_downloaded_assets is not None
+        else body.convert_downloaded_assets,
+        convert_downloaded_images=convert_downloaded_images
+        if convert_downloaded_images is not None
+        else body.convert_downloaded_images,
+        convert_downloaded_image_to_md_engines=(
+            body.convert_downloaded_image_to_md_engines
+            if convert_downloaded_image_to_md_engines is None
+            else (
+                convert_downloaded_image_to_md_engines.strip() or DEFAULT_IMAGE_TO_MD_ENGINES
+            )
+        ),
+        convert_downloaded_image_to_md_strategy=(
+            convert_downloaded_image_to_md_strategy
+            if convert_downloaded_image_to_md_strategy is not None
+            else body.convert_downloaded_image_to_md_strategy
+        ),
+        convert_downloaded_image_to_md_title=(
+            convert_downloaded_image_to_md_title
+            if convert_downloaded_image_to_md_title is not None
+            else body.convert_downloaded_image_to_md_title
+        ),
+        post_convert_pdf_ocr=post_convert_pdf_ocr
+        if post_convert_pdf_ocr is not None
+        else body.post_convert_pdf_ocr,
+        post_convert_pdf_ocr_min_chars=post_convert_pdf_ocr_min_chars
+        if post_convert_pdf_ocr_min_chars is not None
+        else body.post_convert_pdf_ocr_min_chars,
+        post_convert_ppt_embedded_deep=post_convert_ppt_embedded_deep
+        if post_convert_ppt_embedded_deep is not None
+        else body.post_convert_ppt_embedded_deep,
+        max_linked_files=max_linked_files if max_linked_files is not None else body.max_linked_files,
+        max_downloaded_images=max_downloaded_images
+        if max_downloaded_images is not None
+        else body.max_downloaded_images,
+        verbose=False,
+    )
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    settings = ApiSettings()
+    base = Path(settings.temp_dir) if settings.temp_dir else None
+    store = JobStore(base, settings.job_ttl_seconds)
+    store.start_sweeper()
+    app.state.settings = settings
+    app.state.job_store = store
+    async with _mcp.session_manager.run():
+        yield
+
+
+app = FastAPI(title="url-to-md", lifespan=lifespan)
+app.mount("/mcp", _mcp_http)
+
+_bootstrap_settings = ApiSettings()
+_origins = cors_list(_bootstrap_settings)
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=_origins,
+    allow_credentials="*" not in _origins,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+
+def _count_targets(body: ConvertJsonBody) -> int:
+    if body.urls:
+        return len(body.urls)
+    return 1
+
+
+def _sync_allowed(settings: ApiSettings, body: ConvertJsonBody, opts: ConvertOptions) -> bool:
+    if _count_targets(body) > settings.max_sync_urls:
+        return False
+    if opts.crawl and opts.max_pages > settings.max_sync_crawl_pages:
+        return False
+    return True
+
+
+@app.post("/convert/sync")
+async def convert_sync(
+    request: Request,
+    body: ConvertJsonBody,
+    crawl: bool | None = None,
+    async_crawl: bool | None = None,
+    crawl_max_concurrency: int | None = None,
+    max_depth: int | None = None,
+    max_pages: int | None = None,
+    crawl_delay_seconds: float | None = None,
+    obey_robots: bool | None = None,
+    include_subdomains: bool | None = None,
+    table_csv: bool | None = None,
+    download_linked_files: bool | None = None,
+    timeout_seconds: float | None = None,
+    max_response_bytes: int | None = None,
+    convert_downloaded_assets: bool | None = None,
+    convert_downloaded_images: bool | None = None,
+    convert_downloaded_image_to_md_engines: str | None = None,
+    convert_downloaded_image_to_md_strategy: str | None = None,
+    convert_downloaded_image_to_md_title: str | None = None,
+    post_convert_pdf_ocr: bool | None = None,
+    post_convert_pdf_ocr_min_chars: int | None = None,
+    post_convert_ppt_embedded_deep: bool | None = None,
+    max_linked_files: int | None = None,
+    max_downloaded_images: int | None = None,
+) -> Response:
+    settings: ApiSettings = request.app.state.settings
+    if _count_targets(body) > settings.max_job_urls:
+        raise HTTPException(400, detail=f"At most {settings.max_job_urls} URLs per request")
+
+    opts = _merged_options(
+        body,
+        crawl=crawl,
+        async_crawl=async_crawl,
+        crawl_max_concurrency=crawl_max_concurrency,
+        max_depth=max_depth,
+        max_pages=max_pages,
+        crawl_delay_seconds=crawl_delay_seconds,
+        obey_robots=obey_robots,
+        include_subdomains=include_subdomains,
+        table_csv=table_csv,
+        download_linked_files=download_linked_files,
+        timeout_seconds=timeout_seconds,
+        max_response_bytes=max_response_bytes,
+        convert_downloaded_assets=convert_downloaded_assets,
+        convert_downloaded_images=convert_downloaded_images,
+        convert_downloaded_image_to_md_engines=convert_downloaded_image_to_md_engines,
+        convert_downloaded_image_to_md_strategy=convert_downloaded_image_to_md_strategy,
+        convert_downloaded_image_to_md_title=convert_downloaded_image_to_md_title,
+        post_convert_pdf_ocr=post_convert_pdf_ocr,
+        post_convert_pdf_ocr_min_chars=post_convert_pdf_ocr_min_chars,
+        post_convert_ppt_embedded_deep=post_convert_ppt_embedded_deep,
+        max_linked_files=max_linked_files,
+        max_downloaded_images=max_downloaded_images,
+    )
+    if not _sync_allowed(settings, body, opts):
+        raise HTTPException(
+            status_code=409,
+            detail="Too many URLs or crawl size for sync; use POST /convert/jobs",
+        )
+
+    zbytes = build_artifact_zip_bytes(
+        url=body.url.strip() if body.url else None,
+        urls=body.urls,
+        options=opts,
+    )
+    return Response(
+        content=zbytes,
+        media_type="application/zip",
+        headers={"Content-Disposition": 'attachment; filename="artifact.zip"'},
+    )
+
+
+@app.post("/convert/jobs")
+async def convert_jobs(
+    request: Request,
+    body: ConvertJsonBody,
+    crawl: bool | None = None,
+    async_crawl: bool | None = None,
+    crawl_max_concurrency: int | None = None,
+    max_depth: int | None = None,
+    max_pages: int | None = None,
+    crawl_delay_seconds: float | None = None,
+    obey_robots: bool | None = None,
+    include_subdomains: bool | None = None,
+    table_csv: bool | None = None,
+    download_linked_files: bool | None = None,
+    timeout_seconds: float | None = None,
+    max_response_bytes: int | None = None,
+    convert_downloaded_assets: bool | None = None,
+    convert_downloaded_images: bool | None = None,
+    convert_downloaded_image_to_md_engines: str | None = None,
+    convert_downloaded_image_to_md_strategy: str | None = None,
+    convert_downloaded_image_to_md_title: str | None = None,
+    post_convert_pdf_ocr: bool | None = None,
+    post_convert_pdf_ocr_min_chars: int | None = None,
+    post_convert_ppt_embedded_deep: bool | None = None,
+    max_linked_files: int | None = None,
+    max_downloaded_images: int | None = None,
+) -> dict:
+    settings: ApiSettings = request.app.state.settings
+    store: JobStore = request.app.state.job_store
+    if _count_targets(body) > settings.max_job_urls:
+        raise HTTPException(400, detail=f"At most {settings.max_job_urls} URLs per request")
+
+    opts = _merged_options(
+        body,
+        crawl=crawl,
+        async_crawl=async_crawl,
+        crawl_max_concurrency=crawl_max_concurrency,
+        max_depth=max_depth,
+        max_pages=max_pages,
+        crawl_delay_seconds=crawl_delay_seconds,
+        obey_robots=obey_robots,
+        include_subdomains=include_subdomains,
+        table_csv=table_csv,
+        download_linked_files=download_linked_files,
+        timeout_seconds=timeout_seconds,
+        max_response_bytes=max_response_bytes,
+        convert_downloaded_assets=convert_downloaded_assets,
+        convert_downloaded_images=convert_downloaded_images,
+        convert_downloaded_image_to_md_engines=convert_downloaded_image_to_md_engines,
+        convert_downloaded_image_to_md_strategy=convert_downloaded_image_to_md_strategy,
+        convert_downloaded_image_to_md_title=convert_downloaded_image_to_md_title,
+        post_convert_pdf_ocr=post_convert_pdf_ocr,
+        post_convert_pdf_ocr_min_chars=post_convert_pdf_ocr_min_chars,
+        post_convert_ppt_embedded_deep=post_convert_ppt_embedded_deep,
+        max_linked_files=max_linked_files,
+        max_downloaded_images=max_downloaded_images,
+    )
+    job = store.create_job()
+    artifact = job.workspace / "artifact"
+    artifact.mkdir(parents=True, exist_ok=True)
+
+    url_arg = body.url.strip() if body.url else None
+    urls_arg = body.urls
+
+    def work() -> None:
+        convert_url_job(url_arg, urls_arg, artifact, opts)
+        zpath = job.workspace / "artifact.zip"
+        zpath.write_bytes(zip_directory(artifact))
+        job.zip_path = zpath
+
+    store.run_async(job, work)
+    return {"job_id": job.job_id, "status": job.status}
+
+
+@app.get("/convert/jobs/{job_id}")
+async def job_status(request: Request, job_id: str) -> dict:
+    store: JobStore = request.app.state.job_store
+    job = store.get(job_id)
+    if not job:
+        raise HTTPException(404, detail="Unknown job_id")
+    return {
+        "status": job.status,
+        "error": job.error,
+        "created_at": job.created_at,
+    }
+
+
+@app.get("/convert/jobs/{job_id}/download", response_class=FileResponse)
+async def job_download(request: Request, job_id: str) -> FileResponse:
+    store: JobStore = request.app.state.job_store
+    job = store.get(job_id)
+    if not job:
+        raise HTTPException(404, detail="Unknown job_id")
+    if job.status != "done" or not job.zip_path or not job.zip_path.is_file():
+        raise HTTPException(400, detail="Job is not ready for download")
+    path = job.zip_path
+    task = BackgroundTask(store.remove_after_download, job)
+    return FileResponse(
+        path,
+        media_type="application/zip",
+        filename="artifact.zip",
+        background=task,
+    )

--- a/src/md_generator/url/api/mcp_server.py
+++ b/src/md_generator/url/api/mcp_server.py
@@ -1,0 +1,37 @@
+"""
+Standalone MCP server (stdio, SSE, or streamable-http on FASTMCP_PORT / settings.port).
+
+Examples:
+  python -m md_generator.url.api.mcp_server
+  python -m md_generator.url.api.mcp_server --transport sse
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="url-to-md MCP server")
+    parser.add_argument(
+        "--transport",
+        choices=("stdio", "sse", "streamable-http"),
+        default="stdio",
+    )
+    args = parser.parse_args()
+
+    from md_generator.url.api.mcp_setup import build_mcp_stack
+
+    mcp, _ = build_mcp_stack(mount_under_fastapi=False)
+
+    if args.transport == "stdio":
+        asyncio.run(mcp.run_stdio_async())
+    elif args.transport == "sse":
+        asyncio.run(mcp.run_sse_async())
+    else:
+        asyncio.run(mcp.run_streamable_http_async())
+
+
+if __name__ == "__main__":
+    main()

--- a/src/md_generator/url/api/mcp_setup.py
+++ b/src/md_generator/url/api/mcp_setup.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+from mcp.server.fastmcp import FastMCP
+
+from md_generator.url.api.convert_runner import build_artifact_zip_bytes
+from md_generator.url.options import ConvertOptions
+
+
+def build_mcp_stack(*, mount_under_fastapi: bool = False) -> tuple[FastMCP, object]:
+    path = "/" if mount_under_fastapi else "/mcp"
+    mcp = FastMCP(
+        "url-to-md",
+        instructions="Convert public HTTP(S) HTML pages to Markdown artifact ZIP bundles.",
+        streamable_http_path=path,
+    )
+
+    @mcp.tool()
+    def convert_url_to_artifact_zip(
+        url: str,
+        crawl: bool = False,
+        async_crawl: bool = False,
+        crawl_max_concurrency: int = 4,
+        max_depth: int = 2,
+        max_pages: int = 30,
+        obey_robots: bool = True,
+    ) -> str:
+        """Fetch URL(s), convert to Markdown + assets, return a temporary artifact.zip path on the server."""
+        u = url.strip()
+        if not u.startswith(("http://", "https://")):
+            raise ValueError("url must start with http:// or https://")
+        opts = ConvertOptions(
+            artifact_layout=True,
+            crawl=crawl,
+            async_crawl=async_crawl,
+            crawl_max_concurrency=crawl_max_concurrency,
+            max_depth=max_depth,
+            max_pages=max_pages,
+            obey_robots=obey_robots,
+            verbose=False,
+        )
+        data = build_artifact_zip_bytes(url=u, urls=None, options=opts)
+        fd, name = tempfile.mkstemp(suffix=".zip", prefix="url-artifact-")
+        import os
+
+        os.close(fd)
+        out = Path(name)
+        out.write_bytes(data)
+        return str(out)
+
+    sub = mcp.streamable_http_app()
+    return mcp, sub

--- a/src/md_generator/url/api/query_options.py
+++ b/src/md_generator/url/api/query_options.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from md_generator.url.options import DEFAULT_IMAGE_TO_MD_ENGINES, ConvertOptions
+
+
+def convert_options_from_query(
+    *,
+    crawl: bool = False,
+    async_crawl: bool = False,
+    crawl_max_concurrency: int = 4,
+    max_depth: int = 2,
+    max_pages: int = 30,
+    crawl_delay_seconds: float = 0.5,
+    obey_robots: bool = True,
+    include_subdomains: bool = True,
+    table_csv: bool = True,
+    download_linked_files: bool = True,
+    timeout_seconds: float = 30.0,
+    max_response_bytes: int = 10 * 1024 * 1024,
+    convert_downloaded_assets: bool = True,
+    convert_downloaded_images: bool = True,
+    convert_downloaded_image_to_md_engines: str = DEFAULT_IMAGE_TO_MD_ENGINES,
+    convert_downloaded_image_to_md_strategy: str = "best",
+    convert_downloaded_image_to_md_title: str = "",
+    post_convert_pdf_ocr: bool = False,
+    post_convert_pdf_ocr_min_chars: int = 40,
+    post_convert_ppt_embedded_deep: bool = True,
+    max_linked_files: int = 40,
+    max_downloaded_images: int = 50,
+) -> ConvertOptions:
+    """Map API query parameters to ConvertOptions (artifact layout forced at call site)."""
+    return ConvertOptions(
+        artifact_layout=True,
+        crawl=crawl,
+        async_crawl=async_crawl,
+        crawl_max_concurrency=crawl_max_concurrency,
+        max_depth=max_depth,
+        max_pages=max_pages,
+        crawl_delay_seconds=crawl_delay_seconds,
+        obey_robots=obey_robots,
+        include_subdomains=include_subdomains,
+        table_csv=table_csv,
+        download_linked_files=download_linked_files,
+        timeout_seconds=timeout_seconds,
+        max_response_bytes=max_response_bytes,
+        convert_downloaded_assets=convert_downloaded_assets,
+        convert_downloaded_images=convert_downloaded_images,
+        convert_downloaded_image_to_md_engines=(
+            (convert_downloaded_image_to_md_engines or "").strip() or DEFAULT_IMAGE_TO_MD_ENGINES
+        ),
+        convert_downloaded_image_to_md_strategy=convert_downloaded_image_to_md_strategy
+        if convert_downloaded_image_to_md_strategy in ("best", "compare")
+        else "best",
+        convert_downloaded_image_to_md_title=convert_downloaded_image_to_md_title,
+        post_convert_pdf_ocr=post_convert_pdf_ocr,
+        post_convert_pdf_ocr_min_chars=post_convert_pdf_ocr_min_chars,
+        post_convert_ppt_embedded_deep=post_convert_ppt_embedded_deep,
+        max_linked_files=max_linked_files,
+        max_downloaded_images=max_downloaded_images,
+        verbose=False,
+    )

--- a/src/md_generator/url/api/settings.py
+++ b/src/md_generator/url/api/settings.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class ApiSettings(BaseSettings):
+    model_config = SettingsConfigDict(
+        env_prefix="URL_TO_MD_",
+        env_file=".env",
+        extra="ignore",
+    )
+
+    max_sync_urls: int = 3
+    max_sync_crawl_pages: int = 8
+    max_job_urls: int = 50
+    job_ttl_seconds: int = 3600
+    temp_dir: str | None = None
+    cors_origins: str = "*"
+
+
+def cors_list(settings: ApiSettings) -> list[str]:
+    raw = (settings.cors_origins or "*").strip()
+    if raw == "*":
+        return ["*"]
+    return [o.strip() for o in raw.split(",") if o.strip()]

--- a/src/md_generator/url/assets.py
+++ b/src/md_generator/url/assets.py
@@ -1,0 +1,174 @@
+from __future__ import annotations
+
+import hashlib
+import re
+from pathlib import Path
+from urllib.parse import urljoin, urlparse, urlunparse
+
+import httpx
+from bs4 import BeautifulSoup
+
+from md_generator.url.options import ConvertOptions
+
+
+def _short_hash(url: str) -> str:
+    return hashlib.sha256(url.encode("utf-8")).hexdigest()[:12]
+
+
+def _guess_ext(url: str, content_type: str | None) -> str:
+    path = urlparse(url).path.lower()
+    for ext in (".png", ".jpg", ".jpeg", ".gif", ".webp", ".svg", ".ico", ".bmp"):
+        if path.endswith(ext):
+            return ".jpg" if ext == ".jpeg" else ext
+    if content_type:
+        ct = content_type.split(";")[0].strip().lower()
+        if "png" in ct:
+            return ".png"
+        if "jpeg" in ct or "jpg" in ct:
+            return ".jpg"
+        if "gif" in ct:
+            return ".gif"
+        if "webp" in ct:
+            return ".webp"
+        if "svg" in ct:
+            return ".svg"
+    return ".bin"
+
+
+def _safe_name(name: str) -> str:
+    return re.sub(r"[^\w.\-]+", "_", name)[:100] or "file"
+
+
+def download_binary_limited(
+    client: httpx.Client,
+    url: str,
+    max_bytes: int,
+    timeout: float,
+) -> tuple[bytes, str | None]:
+    total = 0
+    chunks: list[bytes] = []
+    ct: str | None = None
+    with client.stream("GET", url, follow_redirects=True, timeout=timeout) as resp:
+        resp.raise_for_status()
+        ct = resp.headers.get("content-type")
+        for chunk in resp.iter_bytes():
+            total += len(chunk)
+            if total > max_bytes:
+                raise ValueError(f"Asset exceeds max_response_bytes when fetching {url!r}")
+            chunks.append(chunk)
+    return b"".join(chunks), ct
+
+
+def collect_and_download_assets(
+    full_html: str,
+    page_url: str,
+    *,
+    output_dir: Path,
+    images_rel: Path,
+    files_rel: Path,
+    client: httpx.Client,
+    options: ConvertOptions,
+    max_images: int | None = None,
+    max_files: int | None = None,
+) -> dict[str, str]:
+    """
+    Download <img src> and selected <a href> targets.
+    Returns map absolute URL (normalized) -> path relative to output_dir (posix).
+    """
+    max_img = max_images if max_images is not None else options.max_downloaded_images
+    max_f = max_files if max_files is not None else options.max_linked_files
+
+    soup = BeautifulSoup(full_html, "lxml")
+    url_map: dict[str, str] = {}
+    seen_target: set[str] = set()
+
+    img_dir = output_dir / images_rel
+    file_dir = output_dir / files_rel
+    img_dir.mkdir(parents=True, exist_ok=True)
+    if options.download_linked_files:
+        file_dir.mkdir(parents=True, exist_ok=True)
+
+    img_count = 0
+    for img in soup.find_all("img", src=True):
+        if img_count >= max_img:
+            break
+        src = str(img.get("src", "")).strip()
+        if not src or src.startswith("data:"):
+            continue
+        abs_u = urljoin(page_url, src)
+        if abs_u in seen_target:
+            continue
+        seen_target.add(abs_u)
+        try:
+            data, ct = download_binary_limited(
+                client,
+                abs_u,
+                options.max_response_bytes,
+                options.timeout_seconds,
+            )
+        except Exception:
+            continue
+        ext = _guess_ext(abs_u, ct)
+        fname = f"img_{img_count + 1:03d}_{_short_hash(abs_u)}{ext}"
+        fname = _safe_name(fname)
+        rel_path = images_rel / fname
+        path = output_dir / rel_path
+        path.write_bytes(data)
+        url_map[_normalize_url(abs_u)] = rel_path.as_posix()
+        img_count += 1
+
+    file_count = 0
+    if options.download_linked_files:
+        exts = tuple(e.lower() for e in options.linked_file_extensions)
+        for a in soup.find_all("a", href=True):
+            if file_count >= max_f:
+                break
+            href = str(a.get("href", "")).strip()
+            if not href or href.startswith(("#", "javascript:", "mailto:", "tel:")):
+                continue
+            abs_u = urljoin(page_url, href)
+            low = abs_u.lower()
+            path_only = low.split("?", 1)[0]
+            if not any(path_only.endswith(ext) for ext in exts):
+                continue
+            if abs_u in seen_target:
+                continue
+            seen_target.add(abs_u)
+            try:
+                data, ct = download_binary_limited(
+                    client,
+                    abs_u,
+                    options.max_response_bytes,
+                    options.timeout_seconds,
+                )
+            except Exception:
+                continue
+            ext = _guess_ext(abs_u, ct)
+            fname = f"file_{file_count + 1:03d}_{_short_hash(abs_u)}{ext}"
+            fname = _safe_name(fname)
+            rel_path = files_rel / fname
+            path = output_dir / rel_path
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_bytes(data)
+            url_map[_normalize_url(abs_u)] = rel_path.as_posix()
+            file_count += 1
+
+    return url_map
+
+
+def _normalize_url(u: str) -> str:
+    p = urlparse(u)
+    return urlunparse(p._replace(fragment=""))
+
+
+def rewrite_markdown_urls(md: str, url_map: dict[str, str]) -> str:
+    out = md
+    for abs_u, rel in sorted(url_map.items(), key=lambda x: -len(x[0])):
+        out = out.replace(abs_u, rel)
+        if abs_u.startswith("https://"):
+            alt = "http://" + abs_u[len("https://") :]
+            out = out.replace(alt, rel)
+        elif abs_u.startswith("http://"):
+            alt = "https://" + abs_u[len("http://") :]
+            out = out.replace(alt, rel)
+    return out

--- a/src/md_generator/url/convert_impl.py
+++ b/src/md_generator/url/convert_impl.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import httpx
+
+from md_generator.url.crawl import run_crawl, run_crawl_async
+from md_generator.url.fetch import fetch_html, new_client
+from md_generator.url.options import ConvertOptions
+from md_generator.url.page_convert import (
+    convert_one_page_artifact,
+    convert_one_page_classic,
+    write_crawl_manifest,
+)
+from md_generator.url.extract import url_to_slug
+
+
+def run_single(
+    seed_url: str,
+    output: Path,
+    options: ConvertOptions,
+    client: httpx.Client,
+) -> None:
+    fr = fetch_html(seed_url, client, options)
+    if options.artifact_layout:
+        output.mkdir(parents=True, exist_ok=True)
+        meta = convert_one_page_artifact(fr.final_url, fr.text, output, options, client)
+        write_crawl_manifest(
+            output,
+            [{"url": fr.final_url, "title": meta.get("title"), "path": "document.md"}],
+        )
+    else:
+        if output.suffix.lower() != ".md":
+            raise ValueError("Classic mode requires output path to end with .md")
+        convert_one_page_classic(fr.final_url, fr.text, output, options, client)
+
+
+def convert_urls_bulk(
+    urls: list[str],
+    output_parent: Path,
+    options: ConvertOptions,
+    client: httpx.Client,
+) -> list[dict]:
+    output_parent.mkdir(parents=True, exist_ok=True)
+    entries: list[dict] = []
+    for i, u in enumerate(urls):
+        slug = url_to_slug(u, i + 1)
+        sub = output_parent / slug
+        sub.mkdir(parents=True, exist_ok=True)
+        leaf = options.with_overrides(artifact_layout=True, crawl=False)
+        try:
+            fr = fetch_html(u, client, leaf)
+            convert_one_page_artifact(fr.final_url, fr.text, sub, leaf, client)
+            entries.append(
+                {
+                    "slug": slug,
+                    "url": fr.final_url,
+                    "path": f"{slug}/document.md",
+                }
+            )
+        except Exception as e:
+            entries.append({"slug": slug, "url": u, "error": str(e)})
+    lines = ["# Bulk URL conversion", ""]
+    for e in entries:
+        if e.get("error"):
+            lines.append(f"- {e['url']}: **{e['error']}**")
+        else:
+            lines.append(f"- [{e['url']}]({e['path']})")
+    lines.append("")
+    (output_parent / "document.md").write_text("\n".join(lines), encoding="utf-8")
+    write_crawl_manifest(output_parent, entries)
+    return entries
+
+
+def convert_url(seed_url: str, output: Path, options: ConvertOptions) -> None:
+    with new_client(options) as client:
+        if options.crawl:
+            if not options.artifact_layout:
+                raise ValueError("--artifact-layout is required when using --crawl")
+            if options.async_crawl:
+                asyncio.run(run_crawl_async(seed_url, output, options, client))
+            else:
+                run_crawl(seed_url, output, options, client)
+        else:
+            run_single(seed_url, output, options, client)
+
+
+def convert_urls_from_list(
+    urls: list[str],
+    output_parent: Path,
+    options: ConvertOptions,
+) -> None:
+    with new_client(options) as client:
+        convert_urls_bulk(urls, output_parent, options, client)
+
+
+def convert_url_job(
+    seed_url: str | None,
+    urls: list[str] | None,
+    output: Path,
+    options: ConvertOptions,
+) -> None:
+    """Used by API: exactly one of seed_url or urls (non-empty)."""
+    with new_client(options) as client:
+        if urls and len(urls) > 1:
+            convert_urls_bulk(urls, output, options, client)
+            return
+        if urls and len(urls) == 1:
+            u = urls[0]
+            if options.crawl:
+                if options.async_crawl:
+                    asyncio.run(run_crawl_async(u, output, options, client))
+                else:
+                    run_crawl(u, output, options, client)
+            else:
+                run_single(u, output, options, client)
+            return
+        if seed_url:
+            if options.crawl:
+                if options.async_crawl:
+                    asyncio.run(run_crawl_async(seed_url, output, options, client))
+                else:
+                    run_crawl(seed_url, output, options, client)
+            else:
+                run_single(seed_url, output, options, client)
+            return
+        raise ValueError("No URL provided")

--- a/src/md_generator/url/converter.py
+++ b/src/md_generator/url/converter.py
@@ -1,0 +1,200 @@
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from urllib.parse import urlparse
+
+from md_generator.url.convert_impl import convert_url, convert_urls_from_list
+from md_generator.url.options import DEFAULT_IMAGE_TO_MD_ENGINES, ConvertOptions
+
+
+def _is_http_url(s: str) -> bool:
+    p = urlparse(s.strip())
+    return p.scheme in ("http", "https") and bool(p.netloc)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(description="Convert public HTTP(S) pages to Markdown.")
+    p.add_argument("url", nargs="?", help="Single HTTP or HTTPS URL")
+    p.add_argument(
+        "output",
+        nargs="?",
+        type=Path,
+        help="Output .md file or directory (with --artifact-layout); omit when using --urls-file with -o",
+    )
+    p.add_argument(
+        "-o",
+        "--output-dir",
+        type=Path,
+        default=None,
+        help="Output directory for --urls-file (bulk) mode",
+    )
+    p.add_argument("--urls-file", type=Path, default=None, help="Text file with one URL per line")
+    p.add_argument("--artifact-layout", action="store_true", help="Write document.md + assets/ under output dir")
+    p.add_argument("--crawl", action="store_true", help="Breadth-first crawl (requires --artifact-layout)")
+    p.add_argument(
+        "--async-crawl",
+        action="store_true",
+        help="Use async HTTP + parallel page fetches (requires --crawl); default is sync crawl",
+    )
+    p.add_argument(
+        "--crawl-max-concurrency",
+        type=int,
+        default=4,
+        help="Max concurrent page fetches when --async-crawl (default: 4, max: 32)",
+    )
+    p.add_argument("--max-depth", type=int, default=2)
+    p.add_argument("--max-pages", type=int, default=30)
+    p.add_argument("--crawl-delay", type=float, default=0.5, help="Seconds between crawl requests")
+    p.add_argument("--no-robots", action="store_true", help="Do not consult robots.txt")
+    p.add_argument("--no-subdomains", action="store_true", help="Only exact same host when following links")
+    p.add_argument("--images-dir", type=Path, default=None, help="Classic mode: image directory (default: <md parent>/images)")
+    p.add_argument("--timeout", type=float, default=30.0)
+    p.add_argument("--max-response-mb", type=float, default=10.0)
+    p.add_argument("--no-table-csv", action="store_true")
+    p.add_argument("--no-linked-files", action="store_true", help="Skip downloading linked PDF/ZIP/etc.")
+    p.add_argument(
+        "--max-linked-files",
+        type=int,
+        default=40,
+        help="Max linked file downloads per page (default: 40)",
+    )
+    p.add_argument(
+        "--max-downloaded-images",
+        type=int,
+        default=50,
+        help="Max image downloads per page (default: 50)",
+    )
+    p.add_argument(
+        "--no-convert-downloaded-assets",
+        action="store_true",
+        help="Do not run internal converters on files under assets/files/",
+    )
+    p.add_argument(
+        "--no-convert-downloaded-images",
+        action="store_true",
+        help="Skip OCR for raster images under assets/images/ (default: run when mdengine[image] is installed)",
+    )
+    p.add_argument(
+        "--convert-downloaded-image-to-md-engines",
+        type=str,
+        default=DEFAULT_IMAGE_TO_MD_ENGINES,
+        metavar="ENGINES",
+        help="Comma-separated OCR engines for downloaded images: tess, paddle, easy (default: %(default)s)",
+    )
+    p.add_argument(
+        "--convert-downloaded-image-to-md-strategy",
+        type=str,
+        choices=("best", "compare"),
+        default="best",
+        help='How to combine engine outputs for downloaded images (default: "best")',
+    )
+    p.add_argument(
+        "--convert-downloaded-image-to-md-title",
+        type=str,
+        default="",
+        help='Markdown title inside the bundled OCR file (default: empty → "Downloaded images (OCR)")',
+    )
+    p.add_argument(
+        "--post-convert-pdf-ocr",
+        action="store_true",
+        help="When converting downloaded PDFs, enable page OCR like md-pdf --ocr",
+    )
+    p.add_argument(
+        "--no-post-convert-ppt-embedded",
+        action="store_true",
+        help="When converting downloaded PPTX, disable deep embedded extraction",
+    )
+    p.add_argument("-v", "--verbose", action="store_true")
+    return p
+
+
+def _options_from_args(ns: argparse.Namespace) -> ConvertOptions:
+    return ConvertOptions(
+        artifact_layout=ns.artifact_layout,
+        images_dir=ns.images_dir,
+        verbose=ns.verbose,
+        timeout_seconds=ns.timeout,
+        max_response_bytes=int(ns.max_response_mb * 1024 * 1024),
+        table_csv=not ns.no_table_csv,
+        download_linked_files=not ns.no_linked_files,
+        crawl=ns.crawl,
+        async_crawl=ns.async_crawl,
+        crawl_max_concurrency=ns.crawl_max_concurrency,
+        max_depth=ns.max_depth,
+        max_pages=ns.max_pages,
+        crawl_delay_seconds=ns.crawl_delay,
+        obey_robots=not ns.no_robots,
+        include_subdomains=not ns.no_subdomains,
+        max_linked_files=ns.max_linked_files,
+        max_downloaded_images=ns.max_downloaded_images,
+        convert_downloaded_assets=not ns.no_convert_downloaded_assets,
+        convert_downloaded_images=not ns.no_convert_downloaded_images,
+        convert_downloaded_image_to_md_engines=str(ns.convert_downloaded_image_to_md_engines).strip()
+        or DEFAULT_IMAGE_TO_MD_ENGINES,
+        convert_downloaded_image_to_md_strategy=str(ns.convert_downloaded_image_to_md_strategy),
+        convert_downloaded_image_to_md_title=str(ns.convert_downloaded_image_to_md_title or "").strip(),
+        post_convert_pdf_ocr=ns.post_convert_pdf_ocr,
+        post_convert_ppt_embedded_deep=not ns.no_post_convert_ppt_embedded,
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _build_parser()
+    ns = parser.parse_args(argv)
+    opts = _options_from_args(ns)
+
+    if ns.urls_file:
+        if not ns.urls_file.is_file():
+            print(f"URLs file not found: {ns.urls_file}", file=sys.stderr)
+            return 2
+        raw_lines = ns.urls_file.read_text(encoding="utf-8").splitlines()
+        urls = [ln.strip() for ln in raw_lines if ln.strip() and not ln.strip().startswith("#")]
+        for u in urls:
+            if not _is_http_url(u):
+                print(f"Invalid URL (need http/https): {u!r}", file=sys.stderr)
+                return 2
+        out = ns.output_dir or ns.output
+        if not out:
+            print("Bulk mode requires -o/--output-dir (or output path as second positional).", file=sys.stderr)
+            return 2
+        if not opts.artifact_layout:
+            opts = opts.with_overrides(artifact_layout=True)
+        if opts.crawl:
+            print("--crawl is not supported with --urls-file", file=sys.stderr)
+            return 2
+        out.mkdir(parents=True, exist_ok=True)
+        try:
+            convert_urls_from_list(urls, out, opts)
+        except Exception as e:
+            print(f"Conversion failed: {e}", file=sys.stderr)
+            if opts.verbose:
+                raise
+            return 1
+        return 0
+
+    if not ns.url or not ns.output:
+        parser.error("Provide URL and output path, or use --urls-file with output directory")
+    if not _is_http_url(ns.url):
+        print("Input must be an http(s) URL", file=sys.stderr)
+        return 2
+    if opts.crawl and not opts.artifact_layout:
+        print("--crawl requires --artifact-layout", file=sys.stderr)
+        return 2
+    if opts.async_crawl and not opts.crawl:
+        print("--async-crawl requires --crawl", file=sys.stderr)
+        return 2
+
+    try:
+        convert_url(ns.url.strip(), ns.output, opts)
+    except Exception as e:
+        print(f"Conversion failed: {e}", file=sys.stderr)
+        if opts.verbose:
+            raise
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/md_generator/url/crawl.py
+++ b/src/md_generator/url/crawl.py
@@ -1,0 +1,223 @@
+from __future__ import annotations
+
+import asyncio
+import time
+from collections import deque
+from pathlib import Path
+from urllib.parse import urlparse
+from urllib.robotparser import RobotFileParser
+
+import httpx
+
+from md_generator.url.extract import extract_same_site_links, normalize_url, url_to_slug
+from md_generator.url.fetch import fetch_html, fetch_html_async, new_async_client
+from md_generator.url.options import ConvertOptions
+from md_generator.url.page_convert import convert_one_page_artifact, write_crawl_manifest
+from md_generator.url.robots_util import (
+    allowed_by_robots,
+    fetch_robots_parser,
+    fetch_robots_parser_async,
+)
+
+
+def run_crawl(
+    seed_url: str,
+    output_parent: Path,
+    options: ConvertOptions,
+    client: httpx.Client,
+) -> None:
+    """Breadth-first crawl starting at seed_url; write pages under pages/<slug>/ and index document.md."""
+    seed = normalize_url(seed_url)
+    output_parent.mkdir(parents=True, exist_ok=True)
+    robots_cache: dict[str, RobotFileParser | None] = {}
+    pending: set[str] = set()
+    visited: set[str] = set()
+    queue: deque[tuple[str, int]] = deque([(seed, 0)])
+    pending.add(seed)
+    manifest_pages: list[dict] = []
+    pages_root = output_parent / "pages"
+    pages_root.mkdir(parents=True, exist_ok=True)
+    page_idx = 0
+
+    def robots_for(u: str) -> RobotFileParser | None:
+        host = urlparse(u).netloc
+        if host not in robots_cache:
+            robots_cache[host] = fetch_robots_parser(client, u)
+        return robots_cache[host]
+
+    while queue and len(visited) < options.max_pages:
+        url, depth = queue.popleft()
+        nu = normalize_url(url)
+        pending.discard(nu)
+        if nu in visited:
+            continue
+        if options.obey_robots:
+            rp = robots_for(nu)
+            if not allowed_by_robots(rp, options.user_agent, nu, obey=True):
+                manifest_pages.append({"url": nu, "skipped": "robots.txt disallow"})
+                visited.add(nu)
+                continue
+        try:
+            fr = fetch_html(nu, client, options)
+        except Exception as e:
+            manifest_pages.append({"url": nu, "error": str(e)})
+            visited.add(nu)
+            continue
+
+        visited.add(nu)
+        page_idx += 1
+        slug = url_to_slug(fr.final_url, page_idx)
+        page_dir = pages_root / slug
+        page_dir.mkdir(parents=True, exist_ok=True)
+        leaf_opts = options.with_overrides(artifact_layout=True, crawl=False)
+        meta = convert_one_page_artifact(fr.final_url, fr.text, page_dir, leaf_opts, client)
+        manifest_pages.append(
+            {
+                "slug": slug,
+                "path": f"pages/{slug}/document.md",
+                **meta,
+            }
+        )
+
+        if depth < options.max_depth and len(visited) < options.max_pages:
+            for lk in extract_same_site_links(
+                fr.text,
+                fr.final_url,
+                include_subdomains=options.include_subdomains,
+            ):
+                lk_n = normalize_url(lk)
+                if lk_n in visited or lk_n in pending:
+                    continue
+                pending.add(lk_n)
+                queue.append((lk_n, depth + 1))
+
+        if options.crawl_delay_seconds > 0:
+            time.sleep(options.crawl_delay_seconds)
+
+    _write_crawl_index(output_parent, manifest_pages)
+
+
+def _write_crawl_index(output_parent: Path, manifest_pages: list[dict]) -> None:
+    index_lines = ["# Crawl results", ""]
+    for p in manifest_pages:
+        if p.get("error") or p.get("skipped"):
+            index_lines.append(f"- {p['url']}: **{p.get('error') or p.get('skipped')}**")
+        elif "path" in p:
+            title = p.get("title") or p.get("url")
+            index_lines.append(f"- [{title}]({p['path']})")
+    index_lines.append("")
+    (output_parent / "document.md").write_text("\n".join(index_lines), encoding="utf-8")
+    write_crawl_manifest(output_parent, manifest_pages)
+
+
+def _crawl_concurrency_cap(options: ConvertOptions) -> int:
+    n = options.crawl_max_concurrency if options.async_crawl else 1
+    return max(1, min(32, n))
+
+
+async def run_crawl_async(
+    seed_url: str,
+    output_parent: Path,
+    options: ConvertOptions,
+    sync_client: httpx.Client,
+) -> None:
+    """Async crawl: httpx.AsyncClient for HTML/robots; sync client for asset downloads in convert."""
+    seed = normalize_url(seed_url)
+    output_parent.mkdir(parents=True, exist_ok=True)
+    robots_cache: dict[str, RobotFileParser | None] = {}
+    robots_lock = asyncio.Lock()
+    pending: set[str] = set()
+    visited: set[str] = set()
+    queue: deque[tuple[str, int]] = deque([(seed, 0)])
+    pending.add(seed)
+    manifest_pages: list[dict] = []
+    pages_root = output_parent / "pages"
+    pages_root.mkdir(parents=True, exist_ok=True)
+    page_idx = 0
+    cap = _crawl_concurrency_cap(options)
+    sem = asyncio.Semaphore(cap)
+
+    async def robots_for_async(aclient: httpx.AsyncClient, u: str) -> RobotFileParser | None:
+        host = urlparse(u).netloc
+        async with robots_lock:
+            if host in robots_cache:
+                return robots_cache[host]
+        pol = await fetch_robots_parser_async(aclient, u)
+        async with robots_lock:
+            if host not in robots_cache:
+                robots_cache[host] = pol
+            return robots_cache[host]
+
+    async with new_async_client(options) as aclient:
+
+        async def fetch_one(nu: str) -> object:
+            async with sem:
+                return await fetch_html_async(nu, aclient, options)
+
+        while queue and len(visited) < options.max_pages:
+            batch: list[tuple[str, int]] = []
+            while queue and len(batch) < cap and len(visited) + len(batch) < options.max_pages:
+                url, depth = queue.popleft()
+                nu = normalize_url(url)
+                pending.discard(nu)
+                if nu in visited:
+                    continue
+                if options.obey_robots:
+                    rp = await robots_for_async(aclient, nu)
+                    if not allowed_by_robots(rp, options.user_agent, nu, obey=True):
+                        manifest_pages.append({"url": nu, "skipped": "robots.txt disallow"})
+                        visited.add(nu)
+                        continue
+                batch.append((nu, depth))
+
+            if not batch:
+                continue
+
+            tasks = [asyncio.create_task(fetch_one(nu)) for nu, _ in batch]
+            raw_results = await asyncio.gather(*tasks, return_exceptions=True)
+
+            for (nu, depth), res in zip(batch, raw_results):
+                if isinstance(res, Exception):
+                    manifest_pages.append({"url": nu, "error": str(res)})
+                    visited.add(nu)
+                    continue
+
+                fr = res
+                visited.add(nu)
+                page_idx += 1
+                slug = url_to_slug(fr.final_url, page_idx)
+                page_dir = pages_root / slug
+                page_dir.mkdir(parents=True, exist_ok=True)
+                leaf_opts = options.with_overrides(artifact_layout=True, crawl=False)
+                meta = await asyncio.to_thread(
+                    convert_one_page_artifact,
+                    fr.final_url,
+                    fr.text,
+                    page_dir,
+                    leaf_opts,
+                    sync_client,
+                )
+                manifest_pages.append(
+                    {
+                        "slug": slug,
+                        "path": f"pages/{slug}/document.md",
+                        **meta,
+                    }
+                )
+
+                if depth < options.max_depth and len(visited) < options.max_pages:
+                    for lk in extract_same_site_links(
+                        fr.text,
+                        fr.final_url,
+                        include_subdomains=options.include_subdomains,
+                    ):
+                        lk_n = normalize_url(lk)
+                        if lk_n in visited or lk_n in pending:
+                            continue
+                        pending.add(lk_n)
+                        queue.append((lk_n, depth + 1))
+
+                if options.crawl_delay_seconds > 0:
+                    await asyncio.sleep(options.crawl_delay_seconds)
+
+    _write_crawl_index(output_parent, manifest_pages)

--- a/src/md_generator/url/extract.py
+++ b/src/md_generator/url/extract.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import re
+from urllib.parse import urldefrag, urljoin, urlparse
+
+from bs4 import BeautifulSoup
+
+
+def normalize_url(url: str) -> str:
+    """Drop fragment; trim whitespace."""
+    u = url.strip()
+    u, _frag = urldefrag(u)
+    return u
+
+
+def same_site(url_a: str, url_b: str, *, include_subdomains: bool) -> bool:
+    pa, pb = urlparse(url_a), urlparse(url_b)
+    if pa.scheme.lower() != pb.scheme.lower():
+        return False
+    ha, hb = pa.netloc.lower(), pb.netloc.lower()
+    if ha == hb:
+        return True
+    if not include_subdomains:
+        return False
+    if ha.endswith("." + hb) or hb.endswith("." + ha):
+        return True
+    return False
+
+
+def extract_same_site_links(html: str, base_url: str, *, include_subdomains: bool) -> list[str]:
+    """Collect absolute HTTP(S) links in the same site as base_url."""
+    soup = BeautifulSoup(html, "lxml")
+    out: list[str] = []
+    seen: set[str] = set()
+    base_n = normalize_url(base_url)
+    for a in soup.find_all("a", href=True):
+        raw = a.get("href", "").strip()
+        if not raw or raw.startswith(("#", "javascript:", "mailto:", "tel:")):
+            continue
+        abs_u = normalize_url(urljoin(base_n, raw))
+        p = urlparse(abs_u)
+        if p.scheme not in ("http", "https"):
+            continue
+        if not same_site(base_n, abs_u, include_subdomains=include_subdomains):
+            continue
+        if abs_u in seen:
+            continue
+        seen.add(abs_u)
+        out.append(abs_u)
+    return out
+
+
+def extract_title_from_html(html: str) -> str | None:
+    soup = BeautifulSoup(html, "lxml")
+    if soup.title and soup.title.string:
+        t = soup.title.string.strip()
+        return t or None
+    h1 = soup.find("h1")
+    if h1 and h1.get_text(strip=True):
+        return h1.get_text(strip=True)
+    return None
+
+
+def url_to_slug(url: str, index: int) -> str:
+    p = urlparse(url)
+    path = (p.path or "/").strip("/").replace("/", "_") or "index"
+    host = p.netloc.replace(":", "_")
+    raw = f"{index:04d}_{host}_{path}"
+    raw = re.sub(r"[^\w.\-]+", "_", raw)
+    return raw[:140] if len(raw) > 140 else raw

--- a/src/md_generator/url/fetch.py
+++ b/src/md_generator/url/fetch.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import httpx
+
+from md_generator.url.options import ConvertOptions
+
+
+@dataclass
+class FetchResult:
+    url: str
+    final_url: str
+    status_code: int
+    content_type: str | None
+    text: str
+
+
+def _is_probably_html(content_type: str | None, text: str) -> bool:
+    if content_type:
+        ct = content_type.split(";")[0].strip().lower()
+        if ct in ("text/html", "application/xhtml+xml"):
+            return True
+        if "html" in ct:
+            return True
+    sample = text[:500].lstrip().lower()
+    return sample.startswith("<!doctype html") or sample.startswith("<html")
+
+
+def fetch_html(url: str, client: httpx.Client, options: ConvertOptions) -> FetchResult:
+    """GET URL and return decoded text, enforcing a response size cap while streaming."""
+    max_b = options.max_response_bytes
+    total = 0
+    chunks: list[bytes] = []
+    ct: str | None = None
+    with client.stream(
+        "GET",
+        url,
+        follow_redirects=True,
+        timeout=options.timeout_seconds,
+    ) as resp:
+        resp.raise_for_status()
+        ct = resp.headers.get("content-type")
+        for chunk in resp.iter_bytes():
+            total += len(chunk)
+            if total > max_b:
+                raise ValueError(
+                    f"Response exceeds max_response_bytes ({max_b} bytes); "
+                    "raise limit or use a smaller page."
+                )
+            chunks.append(chunk)
+        final_url = str(resp.url)
+        status_code = resp.status_code
+        encoding = resp.encoding or "utf-8"
+
+    raw = b"".join(chunks)
+    text = raw.decode(encoding, errors="replace")
+    if not _is_probably_html(ct, text):
+        raise ValueError(
+            f"URL did not return HTML (content-type={ct!r}). "
+            "Only text/html responses are supported in v1."
+        )
+    return FetchResult(
+        url=url,
+        final_url=final_url,
+        status_code=status_code,
+        content_type=ct,
+        text=text,
+    )
+
+
+def new_client(options: ConvertOptions) -> httpx.Client:
+    return httpx.Client(
+        headers={"User-Agent": options.user_agent},
+        follow_redirects=True,
+        timeout=options.timeout_seconds,
+    )
+
+
+async def fetch_html_async(
+    url: str, client: httpx.AsyncClient, options: ConvertOptions
+) -> FetchResult:
+    """Async GET with the same size cap and HTML checks as fetch_html."""
+    max_b = options.max_response_bytes
+    total = 0
+    chunks: list[bytes] = []
+    ct: str | None = None
+    async with client.stream(
+        "GET",
+        url,
+        follow_redirects=True,
+        timeout=options.timeout_seconds,
+    ) as resp:
+        resp.raise_for_status()
+        ct = resp.headers.get("content-type")
+        async for chunk in resp.aiter_bytes():
+            total += len(chunk)
+            if total > max_b:
+                raise ValueError(
+                    f"Response exceeds max_response_bytes ({max_b} bytes); "
+                    "raise limit or use a smaller page."
+                )
+            chunks.append(chunk)
+        final_url = str(resp.url)
+        status_code = resp.status_code
+        encoding = resp.encoding or "utf-8"
+
+    raw = b"".join(chunks)
+    text = raw.decode(encoding, errors="replace")
+    if not _is_probably_html(ct, text):
+        raise ValueError(
+            f"URL did not return HTML (content-type={ct!r}). "
+            "Only text/html responses are supported in v1."
+        )
+    return FetchResult(
+        url=url,
+        final_url=final_url,
+        status_code=status_code,
+        content_type=ct,
+        text=text,
+    )
+
+
+def new_async_client(options: ConvertOptions) -> httpx.AsyncClient:
+    return httpx.AsyncClient(
+        headers={"User-Agent": options.user_agent},
+        follow_redirects=True,
+        timeout=options.timeout_seconds,
+    )

--- a/src/md_generator/url/html_to_md.py
+++ b/src/md_generator/url/html_to_md.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import csv
+import re
+from pathlib import Path
+
+from bs4 import BeautifulSoup
+from markdownify import markdownify as html_to_markdown
+from readability import Document
+
+
+def readability_main_html(html: str, page_url: str) -> tuple[str, str | None]:
+    """Return (summary_html, document_title) using readability-lxml."""
+    doc = Document(html, url=page_url)
+    title = doc.title()
+    summary = doc.summary()
+    return summary, (title.strip() if title else None)
+
+
+def html_fragment_to_markdown(fragment_html: str) -> str:
+    return html_to_markdown(
+        fragment_html,
+        heading_style="ATX",
+        bullets="-",
+        strip=["script", "style", "noscript"],
+    ).strip()
+
+
+def append_table_csv_sidecars(
+    summary_html: str,
+    tables_dir: Path,
+    *,
+    filename_prefix: str,
+    link_prefix: str = "assets/tables",
+) -> str:
+    """Write each <table> to CSV; return Markdown appendix with links."""
+    soup = BeautifulSoup(summary_html, "lxml")
+    tables = soup.find_all("table")
+    if not tables:
+        return ""
+
+    tables_dir.mkdir(parents=True, exist_ok=True)
+    lines: list[str] = ["", "## Tables (CSV)", ""]
+    for idx, table in enumerate(tables, start=1):
+        rows: list[list[str]] = []
+        for tr in table.find_all("tr"):
+            cells = tr.find_all(["th", "td"])
+            if not cells:
+                continue
+            rows.append([re.sub(r"\s+", " ", c.get_text(strip=True)) for c in cells])
+        if not rows:
+            continue
+        name = f"{filename_prefix}_table_{idx}.csv"
+        path = tables_dir / name
+        max_cols = max(len(r) for r in rows)
+        norm = [r + [""] * (max_cols - len(r)) for r in rows]
+        with path.open("w", encoding="utf-8", newline="") as f:
+            w = csv.writer(f)
+            w.writerows(norm)
+        lp = link_prefix.strip("/")
+        rel = f"{lp}/{name}" if lp else name
+        lines.append(f"- [{name}]({rel})")
+    lines.append("")
+    return "\n".join(lines) if len(lines) > 2 else ""

--- a/src/md_generator/url/options.py
+++ b/src/md_generator/url/options.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, fields, replace
+from pathlib import Path
+from typing import Any
+
+# Default OCR stack for the image-to-md post-pass (order matters for "best" tie-break).
+DEFAULT_IMAGE_TO_MD_ENGINES = "paddle,easy,tess"
+
+
+@dataclass
+class ConvertOptions:
+    """CLI and API flags for URL → Markdown conversion."""
+
+    artifact_layout: bool = False
+    images_dir: Path | None = None
+    verbose: bool = False
+
+    timeout_seconds: float = 30.0
+    max_response_bytes: int = 10 * 1024 * 1024
+    user_agent: str = "mdengine-url-to-md/0.1 (+https://github.com/vishal7090/md-generator)"
+
+    table_csv: bool = True
+    download_linked_files: bool = True
+    linked_file_extensions: tuple[str, ...] = (
+        ".pdf",
+        ".zip",
+        ".docx",
+        ".xlsx",
+        ".xlsm",
+        ".csv",
+        ".pptx",
+        ".txt",
+        ".json",
+        ".xml",
+    )
+    max_linked_files: int = 40
+    max_downloaded_images: int = 50
+
+    crawl: bool = False
+    max_depth: int = 2
+    max_pages: int = 30
+    crawl_delay_seconds: float = 0.5
+    async_crawl: bool = False
+    crawl_max_concurrency: int = 4
+    obey_robots: bool = True
+    same_site_only: bool = True
+    include_subdomains: bool = True
+
+    convert_downloaded_assets: bool = True
+    convert_downloaded_images: bool = True
+    convert_downloaded_image_to_md_engines: str = DEFAULT_IMAGE_TO_MD_ENGINES
+    convert_downloaded_image_to_md_strategy: str = "best"  # best | compare
+    convert_downloaded_image_to_md_title: str = ""
+    post_convert_pdf_ocr: bool = False
+    post_convert_pdf_ocr_min_chars: int = 40
+    post_convert_ppt_embedded_deep: bool = True
+
+    @classmethod
+    def field_names(cls) -> set[str]:
+        return {f.name for f in fields(cls)}
+
+    def with_overrides(self, **kwargs: Any) -> ConvertOptions:
+        known = self.field_names()
+        clean = {k: v for k, v in kwargs.items() if k in known and v is not None}
+        return replace(self, **clean)

--- a/src/md_generator/url/page_convert.py
+++ b/src/md_generator/url/page_convert.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import httpx
+
+from md_generator.url.assets import collect_and_download_assets, rewrite_markdown_urls
+from md_generator.url.html_to_md import (
+    append_table_csv_sidecars,
+    html_fragment_to_markdown,
+    readability_main_html,
+)
+from md_generator.url.options import ConvertOptions
+from md_generator.url.post_convert_assets import process_downloaded_files
+
+
+def write_crawl_manifest(out_root: Path, pages: list[dict]) -> None:
+    manifest_dir = out_root / "assets"
+    manifest_dir.mkdir(parents=True, exist_ok=True)
+    (manifest_dir / "crawl_manifest.json").write_text(
+        json.dumps({"pages": pages}, indent=2),
+        encoding="utf-8",
+    )
+
+
+def convert_one_page_artifact(
+    page_url: str,
+    html: str,
+    artifact_root: Path,
+    options: ConvertOptions,
+    client: httpx.Client,
+) -> dict[str, str | None]:
+    artifact_root.mkdir(parents=True, exist_ok=True)
+    summary, title = readability_main_html(html, page_url)
+    body = html_fragment_to_markdown(summary)
+
+    images_rel = Path("assets") / "images"
+    files_rel = Path("assets") / "files"
+    tables_dir = artifact_root / "assets" / "tables"
+
+    url_map = collect_and_download_assets(
+        html,
+        page_url,
+        output_dir=artifact_root,
+        images_rel=images_rel,
+        files_rel=files_rel,
+        client=client,
+        options=options,
+    )
+    body = rewrite_markdown_urls(body, url_map)
+
+    if options.table_csv:
+        # Use full document HTML so tables readability dropped are still captured as CSV.
+        body += append_table_csv_sidecars(
+            html,
+            tables_dir,
+            filename_prefix="page",
+            link_prefix="assets/tables",
+        )
+
+    header = f"# {title or 'Page'}\n\n_Source: [{page_url}]({page_url})_\n\n"
+    doc_text = header + body + "\n"
+    doc_text += process_downloaded_files(artifact_root, options)
+    (artifact_root / "document.md").write_text(doc_text, encoding="utf-8")
+    return {"url": page_url, "title": title, "final_url": page_url}
+
+
+def convert_one_page_classic(
+    page_url: str,
+    html: str,
+    md_path: Path,
+    options: ConvertOptions,
+    client: httpx.Client,
+) -> dict[str, str | None]:
+    md_path.parent.mkdir(parents=True, exist_ok=True)
+    summary, title = readability_main_html(html, page_url)
+    body = html_fragment_to_markdown(summary)
+    out_dir = md_path.parent
+    url_map = collect_and_download_assets(
+        html,
+        page_url,
+        output_dir=out_dir,
+        images_rel=Path("images"),
+        files_rel=Path("files"),
+        client=client,
+        options=options,
+    )
+    body = rewrite_markdown_urls(body, url_map)
+    if options.table_csv:
+        tdir = out_dir / "tables"
+        body += append_table_csv_sidecars(
+            summary,
+            tdir,
+            filename_prefix="page",
+            link_prefix="tables",
+        )
+    header = f"# {title or 'Page'}\n\n_Source: [{page_url}]({page_url})_\n\n"
+    doc_text = header + body + "\n"
+    doc_text += process_downloaded_files(md_path.parent, options)
+    md_path.write_text(doc_text, encoding="utf-8")
+    return {"url": page_url, "title": title}

--- a/src/md_generator/url/post_convert_assets.py
+++ b/src/md_generator/url/post_convert_assets.py
@@ -1,0 +1,387 @@
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+from pathlib import Path
+
+from md_generator.url.options import DEFAULT_IMAGE_TO_MD_ENGINES, ConvertOptions
+
+INLINE_CAP = 48_000
+
+_RASTER_IMAGE_EXT = frozenset({".png", ".jpg", ".jpeg", ".webp", ".gif", ".bmp"})
+
+
+def _slug(stem: str) -> str:
+    s = re.sub(r"[^\w\-]+", "_", stem, flags=re.UNICODE).strip("_")
+    return s[:72] or "file"
+
+
+def _idx_slug(path: Path, idx: int) -> str:
+    import hashlib
+
+    h = hashlib.sha256(path.name.encode("utf-8")).hexdigest()[:8]
+    return f"{idx:04d}_{_slug(path.stem)}_{h}"
+
+
+def _rel_from_root(target: Path, page_root: Path) -> str:
+    return target.resolve().relative_to(page_root.resolve()).as_posix()
+
+
+def _log_append(entries: list[dict], path: str, status: str, detail: str = "") -> None:
+    entries.append({"path": path, "status": status, "detail": detail})
+
+
+def _files_and_assets_parent(page_root: Path, options: ConvertOptions) -> tuple[Path | None, Path]:
+    if options.artifact_layout:
+        files_dir = page_root / "assets" / "files"
+        assets_parent = page_root / "assets"
+    else:
+        files_dir = page_root / "files"
+        assets_parent = page_root
+    if not files_dir.is_dir():
+        return None, assets_parent
+    return files_dir, assets_parent
+
+
+def _images_dir(page_root: Path, options: ConvertOptions) -> Path | None:
+    if options.artifact_layout:
+        d = page_root / "assets" / "images"
+    else:
+        d = page_root / "images"
+    return d if d.is_dir() else None
+
+
+def process_downloaded_files(page_root: Path, options: ConvertOptions) -> str:
+    """
+    Convert files under assets/files (or files/ in classic mode) using internal md_generator
+    converters. Returns Markdown appendix for document.md (may be empty).
+    """
+    if not options.convert_downloaded_assets and not options.convert_downloaded_images:
+        return ""
+
+    files_dir, assets_parent = _files_and_assets_parent(page_root, options)
+    log_entries: list[dict] = []
+    blocks: list[str] = []
+
+    extracted_md = assets_parent / "extracted_md"
+    extracted_md.mkdir(parents=True, exist_ok=True)
+
+    if options.convert_downloaded_assets and files_dir is not None:
+        file_paths = sorted(p for p in files_dir.iterdir() if p.is_file())
+    else:
+        file_paths = []
+
+    for idx, src in enumerate(file_paths, start=1):
+        slug = _idx_slug(src, idx)
+        suf = src.suffix.lower()
+
+        if suf in (".doc", ".ppt"):
+            _log_append(log_entries, src.name, "skip", "legacy .doc/.ppt not supported")
+            continue
+
+        if suf == ".pdf":
+            _try_pdf(src, slug, extracted_md, page_root, options, log_entries, blocks)
+        elif suf == ".docx":
+            _try_docx(src, slug, extracted_md, assets_parent, page_root, options, log_entries, blocks)
+        elif suf == ".pptx":
+            _try_pptx(src, slug, extracted_md, page_root, options, log_entries, blocks)
+        elif suf in (".xlsx", ".xlsm", ".csv"):
+            _try_xlsx(src, slug, extracted_md, page_root, options, log_entries, blocks)
+        elif suf == ".zip":
+            _try_zip(src, slug, extracted_md, page_root, options, log_entries, blocks)
+        elif suf in (".txt", ".json", ".xml"):
+            _try_text(src, slug, extracted_md, page_root, options, log_entries, blocks)
+        else:
+            _log_append(log_entries, src.name, "skip", f"no converter for {suf!r}")
+
+    if options.convert_downloaded_images:
+        _try_images_ocr(page_root, extracted_md, options, log_entries, blocks)
+
+    log_path = assets_parent / "asset_convert_log.json"
+    log_path.write_text(json.dumps({"entries": log_entries}, indent=2), encoding="utf-8")
+
+    if not blocks:
+        return ""
+
+    return "\n## Downloaded files converted to Markdown\n\n" + "\n".join(blocks) + "\n"
+
+
+def _try_pdf(
+    src: Path,
+    slug: str,
+    extracted_md: Path,
+    page_root: Path,
+    options: ConvertOptions,
+    log_entries: list[dict],
+    blocks: list[str],
+) -> None:
+    try:
+        from md_generator.pdf.pdf_extract import ConvertOptions as PdfConvertOptions
+        from md_generator.pdf.pdf_extract import convert_pdf_to_artifact_dir
+    except ImportError as e:
+        _log_append(log_entries, src.name, "error", f"missing pdf extra: {e}")
+        return
+    out_sub = extracted_md / f"{slug}_pdf"
+    try:
+        out_sub.mkdir(parents=True, exist_ok=True)
+        convert_pdf_to_artifact_dir(
+            src,
+            out_sub,
+            PdfConvertOptions(
+                use_ocr=options.post_convert_pdf_ocr,
+                ocr_min_chars=options.post_convert_pdf_ocr_min_chars,
+                verbose=options.verbose,
+            ),
+        )
+        doc = out_sub / "document.md"
+        if doc.is_file():
+            rel = _rel_from_root(doc, page_root)
+            body = doc.read_text(encoding="utf-8", errors="replace")
+            snippet = body if len(body) <= INLINE_CAP else f"[View extracted PDF]({rel})"
+            blocks.append(f"### `{src.name}` (PDF)\n\n{snippet}\n")
+            _log_append(log_entries, src.name, "ok", "pdf")
+        else:
+            _log_append(log_entries, src.name, "error", "no document.md after pdf convert")
+    except Exception as e:
+        _log_append(log_entries, src.name, "error", str(e))
+        if options.verbose:
+            print(f"url post-convert pdf {src}: {e}", file=sys.stderr)
+
+
+def _try_docx(
+    src: Path,
+    slug: str,
+    extracted_md: Path,
+    assets_parent: Path,
+    page_root: Path,
+    options: ConvertOptions,
+    log_entries: list[dict],
+    blocks: list[str],
+) -> None:
+    try:
+        from md_generator.word.converter import convert_docx_to_markdown
+    except ImportError as e:
+        _log_append(log_entries, src.name, "error", f"missing word extra: {e}")
+        return
+    media = assets_parent / "extracted_md_media" / slug
+    md_out = extracted_md / f"{slug}.md"
+    try:
+        media.mkdir(parents=True, exist_ok=True)
+        convert_docx_to_markdown(src, md_out, images_dir=media, verbose=options.verbose)
+        if md_out.is_file():
+            rel = _rel_from_root(md_out, page_root)
+            body = md_out.read_text(encoding="utf-8", errors="replace")
+            snippet = body if len(body) <= INLINE_CAP else f"[View extracted Word]({rel})"
+            blocks.append(f"### `{src.name}` (DOCX)\n\n{snippet}\n")
+            _log_append(log_entries, src.name, "ok", "docx")
+        else:
+            _log_append(log_entries, src.name, "error", "no output md")
+    except Exception as e:
+        _log_append(log_entries, src.name, "error", str(e))
+        if options.verbose:
+            print(f"url post-convert docx {src}: {e}", file=sys.stderr)
+
+
+def _try_pptx(
+    src: Path,
+    slug: str,
+    extracted_md: Path,
+    page_root: Path,
+    options: ConvertOptions,
+    log_entries: list[dict],
+    blocks: list[str],
+) -> None:
+    try:
+        from md_generator.ppt.convert_impl import convert_pptx
+        from md_generator.ppt.options import ConvertOptions as PptConvertOptions
+    except ImportError as e:
+        _log_append(log_entries, src.name, "error", f"missing ppt extra: {e}")
+        return
+    out_sub = extracted_md / f"{slug}_ppt"
+    try:
+        ppt_opts = PptConvertOptions(
+            artifact_layout=True,
+            extract_embedded_deep=options.post_convert_ppt_embedded_deep,
+            verbose=options.verbose,
+        )
+        convert_pptx(src, out_sub, ppt_opts)
+        doc = out_sub / "document.md"
+        if doc.is_file():
+            rel = _rel_from_root(doc, page_root)
+            body = doc.read_text(encoding="utf-8", errors="replace")
+            snippet = body if len(body) <= INLINE_CAP else f"[View extracted PPTX]({rel})"
+            blocks.append(f"### `{src.name}` (PPTX)\n\n{snippet}\n")
+            _log_append(log_entries, src.name, "ok", "pptx")
+        else:
+            _log_append(log_entries, src.name, "error", "no document.md after pptx convert")
+    except Exception as e:
+        _log_append(log_entries, src.name, "error", str(e))
+        if options.verbose:
+            print(f"url post-convert pptx {src}: {e}", file=sys.stderr)
+
+
+def _try_xlsx(
+    src: Path,
+    slug: str,
+    extracted_md: Path,
+    page_root: Path,
+    options: ConvertOptions,
+    log_entries: list[dict],
+    blocks: list[str],
+) -> None:
+    try:
+        from md_generator.xlsx.converter_core import convert_excel_to_markdown
+    except ImportError as e:
+        _log_append(log_entries, src.name, "error", f"missing xlsx extra: {e}")
+        return
+    out_sub = extracted_md / f"{slug}_xlsx"
+    try:
+        out_sub.mkdir(parents=True, exist_ok=True)
+        convert_excel_to_markdown(src, out_sub, config=None)
+        md_files = sorted(out_sub.glob("*.md"))
+        if not md_files:
+            _log_append(log_entries, src.name, "error", "no markdown from xlsx")
+            return
+        primary = md_files[0]
+        rel = _rel_from_root(primary, page_root)
+        body = primary.read_text(encoding="utf-8", errors="replace")
+        snippet = body if len(body) <= INLINE_CAP else f"[View extracted spreadsheet]({rel})"
+        blocks.append(f"### `{src.name}` (Excel/CSV)\n\n{snippet}\n")
+        _log_append(log_entries, src.name, "ok", "xlsx")
+    except Exception as e:
+        _log_append(log_entries, src.name, "error", str(e))
+        if options.verbose:
+            print(f"url post-convert xlsx {src}: {e}", file=sys.stderr)
+
+
+def _try_zip(
+    src: Path,
+    slug: str,
+    extracted_md: Path,
+    page_root: Path,
+    options: ConvertOptions,
+    log_entries: list[dict],
+    blocks: list[str],
+) -> None:
+    try:
+        from md_generator.archive.convert_impl import convert_zip
+        from md_generator.archive.options import ConvertOptions as ArchiveConvertOptions
+    except ImportError as e:
+        _log_append(log_entries, src.name, "error", f"missing archive extra: {e}")
+        return
+    out_sub = extracted_md / f"{slug}_zip"
+    try:
+        convert_zip(
+            src,
+            out_sub,
+            ArchiveConvertOptions(verbose=options.verbose, artifact_layout=True),
+        )
+        doc = out_sub / "document.md"
+        if doc.is_file():
+            rel = _rel_from_root(doc, page_root)
+            body = doc.read_text(encoding="utf-8", errors="replace")
+            snippet = body if len(body) <= INLINE_CAP else f"[View extracted ZIP]({rel})"
+            blocks.append(f"### `{src.name}` (ZIP)\n\n{snippet}\n")
+            _log_append(log_entries, src.name, "ok", "zip")
+        else:
+            _log_append(log_entries, src.name, "error", "no document.md after zip convert")
+    except Exception as e:
+        _log_append(log_entries, src.name, "error", str(e))
+        if options.verbose:
+            print(f"url post-convert zip {src}: {e}", file=sys.stderr)
+
+
+def _try_text(
+    src: Path,
+    slug: str,
+    extracted_md: Path,
+    page_root: Path,
+    options: ConvertOptions,
+    log_entries: list[dict],
+    blocks: list[str],
+) -> None:
+    try:
+        from md_generator.text.convert_impl import convert_text_file
+        from md_generator.text.options import ConvertOptions as TextConvertOptions
+    except ImportError as e:
+        _log_append(log_entries, src.name, "error", f"missing text module: {e}")
+        return
+    out_sub = extracted_md / f"{slug}_text"
+    try:
+        topts = TextConvertOptions(artifact_layout=True, verbose=options.verbose)
+        convert_text_file(src, out_sub, topts)
+        doc = out_sub / "document.md"
+        if doc.is_file():
+            rel = _rel_from_root(doc, page_root)
+            body = doc.read_text(encoding="utf-8", errors="replace")
+            snippet = body if len(body) <= INLINE_CAP else f"[View extracted text]({rel})"
+            blocks.append(f"### `{src.name}` (text/JSON/XML)\n\n{snippet}\n")
+            _log_append(log_entries, src.name, "ok", "text")
+        else:
+            _log_append(log_entries, src.name, "error", "no document.md after text convert")
+    except Exception as e:
+        _log_append(log_entries, src.name, "error", str(e))
+        if options.verbose:
+            print(f"url post-convert text {src}: {e}", file=sys.stderr)
+
+
+def _try_images_ocr(
+    page_root: Path,
+    extracted_md: Path,
+    options: ConvertOptions,
+    log_entries: list[dict],
+    blocks: list[str],
+) -> None:
+    try:
+        from md_generator.image.convert_impl import ConvertOptions as ImageConvertOptions
+        from md_generator.image.convert_impl import convert_image_paths
+    except ImportError as e:
+        _log_append(log_entries, "(images)", "error", f"missing image extra: {e}")
+        return
+
+    img_root = _images_dir(page_root, options)
+    if not img_root:
+        return
+
+    paths = sorted(
+        p for p in img_root.iterdir() if p.is_file() and p.suffix.lower() in _RASTER_IMAGE_EXT
+    )[:30]
+    if not paths:
+        return
+
+    raw_engines = options.convert_downloaded_image_to_md_engines.strip() or DEFAULT_IMAGE_TO_MD_ENGINES
+    engines = tuple(p.strip().lower() for p in raw_engines.split(",") if p.strip())
+    strategy: str = (
+        options.convert_downloaded_image_to_md_strategy
+        if options.convert_downloaded_image_to_md_strategy in ("best", "compare")
+        else "best"
+    )
+    title = (options.convert_downloaded_image_to_md_title or "Downloaded images (OCR)").strip()[:240]
+    tess_cmd = os.environ.get("TESSERACT_CMD") or os.environ.get("TESSERACT_PATH")
+
+    img_opts = ImageConvertOptions(
+        engines=engines,
+        strategy=strategy,  # type: ignore[arg-type]
+        title=title,
+        tess_lang="eng",
+        tesseract_cmd=tess_cmd,
+        paddle_lang="en",
+        paddle_use_angle_cls=True,
+        easy_langs=("en",),
+        verbose=options.verbose,
+    )
+    out_md = extracted_md / "downloaded_images_ocr.md"
+    try:
+        convert_image_paths(paths, out_md, img_opts)
+        if out_md.is_file():
+            rel = _rel_from_root(out_md, page_root)
+            body = out_md.read_text(encoding="utf-8", errors="replace")
+            snippet = body if len(body) <= INLINE_CAP else f"[View OCR bundle]({rel})"
+            blocks.append(f"### {title}\n\n{snippet}\n")
+            _log_append(log_entries, "images_ocr", "ok", str(len(paths)))
+    except Exception as e:
+        _log_append(log_entries, "images_ocr", "error", str(e))
+        if options.verbose:
+            print(f"url post-convert images: {e}", file=sys.stderr)

--- a/src/md_generator/url/robots_util.py
+++ b/src/md_generator/url/robots_util.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from urllib.parse import urlparse
+from urllib.robotparser import RobotFileParser
+
+import httpx
+
+
+def fetch_robots_parser(client: httpx.Client, page_url: str) -> RobotFileParser | None:
+    """Load robots.txt for the origin of page_url; return None if missing or unreadable."""
+    p = urlparse(page_url)
+    if p.scheme not in ("http", "https") or not p.netloc:
+        return None
+    robots_url = f"{p.scheme}://{p.netloc}/robots.txt"
+    try:
+        r = client.get(robots_url, timeout=15.0)
+        if r.status_code != 200:
+            return None
+    except Exception:
+        return None
+    rp = RobotFileParser()
+    rp.set_url(robots_url)
+    rp.parse(r.text.splitlines())
+    return rp
+
+
+async def fetch_robots_parser_async(
+    client: httpx.AsyncClient, page_url: str
+) -> RobotFileParser | None:
+    """Async load of robots.txt for the origin of page_url."""
+    p = urlparse(page_url)
+    if p.scheme not in ("http", "https") or not p.netloc:
+        return None
+    robots_url = f"{p.scheme}://{p.netloc}/robots.txt"
+    try:
+        r = await client.get(robots_url, timeout=15.0)
+        if r.status_code != 200:
+            return None
+    except Exception:
+        return None
+    rp = RobotFileParser()
+    rp.set_url(robots_url)
+    rp.parse(r.text.splitlines())
+    return rp
+
+
+def allowed_by_robots(
+    rp: RobotFileParser | None,
+    user_agent: str,
+    url: str,
+    *,
+    obey: bool,
+) -> bool:
+    if not obey or rp is None:
+        return True
+    return rp.can_fetch(user_agent, url)

--- a/url-to-md/Dockerfile.api
+++ b/url-to-md/Dockerfile.api
@@ -1,0 +1,19 @@
+# Build from repository root, e.g.:
+#   docker build -f url-to-md/Dockerfile.api -t url-to-md-api .
+FROM python:3.11-slim
+
+WORKDIR /app
+
+RUN useradd -m -u 1000 appuser
+
+COPY pyproject.toml README.md LICENSE ./
+COPY src ./src
+COPY url-to-md/requirements.txt url-to-md/requirements-api.txt ./url-to-md/
+
+RUN pip install --no-cache-dir -e ".[url,api,mcp]"
+
+USER appuser
+
+EXPOSE 8000
+
+CMD ["uvicorn", "md_generator.url.api.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/url-to-md/README.md
+++ b/url-to-md/README.md
@@ -1,0 +1,116 @@
+# url-to-md
+
+Convert public **HTTP/HTTPS** HTML pages to Markdown with downloaded images and linked files (optional), plus optional same-site crawl.
+
+Server-rendered HTML only: there is no headless browser; heavy client-side SPAs may not convert fully until a future Playwright-based pass.
+
+## Setup
+
+From the repository root (so `md_generator` is importable):
+
+```bash
+cd url-to-md
+python -m venv .venv
+.venv\Scripts\activate
+pip install -e "..[url]"
+```
+
+To **post-convert** downloaded files (PDF, DOCX, PPTX, XLSX/CSV, ZIP, TXT/JSON/XML) into `assets/extracted_md/` using the same engines as the other `md-*` tools, install the convenience extra:
+
+```bash
+pip install -e "..[url-full]"
+```
+
+(`url-full` includes PDF, Word, PPTX, XLSX, archive, and OCR-related deps used by those converters; optional `image` / `image-ocr` is only needed for `--convert-downloaded-images`.)
+
+For the **HTTP API** (FastAPI + ZIP download + MCP on the same port):
+
+```bash
+pip install -e "..[url,api,mcp]"
+# or with post-convert deps:
+pip install -e "..[url-full,api,mcp]"
+```
+
+## HTTP API (FastAPI)
+
+Run locally:
+
+```bash
+uvicorn md_generator.url.api.main:app --reload --host 127.0.0.1 --port 8011
+```
+
+- **OpenAPI / Swagger UI:** [http://127.0.0.1:8011/docs](http://127.0.0.1:8011/docs)
+- **`POST /convert/sync`** — JSON body with `url` **or** `urls` (list). Returns `application/zip` containing `document.md` and `assets/` (and `pages/` when crawling or bulk). If there are too many URLs or `crawl` + `max_pages` exceeds sync limits, returns **409** with a hint to use jobs.
+- **`POST /convert/jobs`** — same JSON body; returns `{ "job_id", "status" }`.
+- **`GET /convert/jobs/{id}`** — `{ "status": "queued"|"running"|"done"|"failed", "error", "created_at" }`
+- **`GET /convert/jobs/{id}/download`** — ZIP when `done`; removes the job workspace after the response is sent.
+
+**JSON body fields** (subset): `url`, `urls`, `crawl`, `max_depth`, `max_pages`, `crawl_delay_seconds`, `obey_robots`, `include_subdomains`, `table_csv`, `download_linked_files`, `timeout_seconds`, `max_response_mb`, `convert_downloaded_assets`, `convert_downloaded_images`, `post_convert_pdf_ocr`, `post_convert_pdf_ocr_min_chars`, `post_convert_ppt_embedded_deep`, `max_linked_files`, `max_downloaded_images`. Query parameters with the same names override the body where supported (see `/docs`).
+
+**Environment variables** (prefix `URL_TO_MD_`):
+
+| Name | Default | Meaning |
+|------|---------|---------|
+| `URL_TO_MD_MAX_SYNC_URLS` | 3 | Max URLs in one sync request |
+| `URL_TO_MD_MAX_SYNC_CRAWL_PAGES` | 8 | If `crawl` is true, `max_pages` above this forces **409** → jobs |
+| `URL_TO_MD_MAX_JOB_URLS` | 50 | Max URLs per request (sync or jobs) |
+| `URL_TO_MD_JOB_TTL_SECONDS` | 3600 | Completed/failed job dirs removed by sweeper |
+| `URL_TO_MD_TEMP_DIR` | (empty) | Optional base directory for job workspaces |
+| `URL_TO_MD_CORS_ORIGINS` | `*` | Comma-separated origins, or `*` |
+
+### MCP
+
+Mounted at **`/mcp`** on the same server as the API. Standalone:
+
+```bash
+python -m md_generator.url.api.mcp_server
+python -m md_generator.url.api.mcp_server --transport streamable-http
+```
+
+Tool: **`convert_url_to_artifact_zip(url, crawl=False, ...)`** — returns a server temp path to `artifact.zip`.
+
+### Docker
+
+Build from the **repository root**:
+
+```bash
+docker build -f url-to-md/Dockerfile.api -t url-to-md-api .
+docker run --rm -p 8011:8000 url-to-md-api
+```
+
+## CLI
+
+From `url-to-md` (or use `md-url` after `pip install -e "..[url]"`):
+
+```bash
+python converter.py https://example.com/article ./out --artifact-layout
+```
+
+- **Artifact layout:** `out/document.md`, `out/assets/images/`, `out/assets/files/`, optional `out/assets/tables/*.csv`, `out/assets/crawl_manifest.json`.
+- **Classic:** `python converter.py https://example.com/page ./page.md` — images under `./images/` (or `--images-dir`).
+- **Bulk:** `python converter.py --urls-file urls.txt -o ./bulk_out` (forces artifact layout; one subdirectory per URL + root `document.md` index).
+- **Crawl:** `python converter.py https://example.com/ ./crawl --artifact-layout --crawl --max-depth 2 --max-pages 30` — root index + `pages/<slug>/document.md` per page.
+- **Post-convert linked files:** by default, each page run converts files under `assets/files/` (PDF, DOCX, PPTX, XLSX/CSV, ZIP, TXT/JSON/XML) into `assets/extracted_md/` and appends a section to `document.md`. Disable with `--no-convert-downloaded-assets`. Optional `--convert-downloaded-images` runs OCR on downloaded rasters in `assets/images/` (needs `mdengine[image]` and Tesseract). Tuning: `--max-linked-files`, `--max-downloaded-images`, `--post-convert-pdf-ocr`, `--no-post-convert-ppt-embedded`.
+
+Respect site terms, rate limits, and `robots.txt`. Defaults include a crawl delay and `robots.txt` checks (`--no-robots` to disable).
+
+## Tests
+
+```bash
+cd ..
+pytest url-to-md/tests -v
+```
+
+## Pipeline
+
+1. **httpx** — fetch HTML with size limit and timeout.
+2. **readability-lxml** — main article HTML; **markdownify** — Markdown body.
+3. **BeautifulSoup** — discover images and whitelisted file links; download under `assets/` (or `images/` in classic mode).
+4. Optional **CSV** sidecars for `<table>` elements in the full HTML.
+5. **Post-convert** — each file in `assets/files/` with a known extension is passed to the matching in-repo converter; outputs live under `assets/extracted_md/` (and `assets/extracted_md_media/` for Word images). A JSON log is written to `assets/asset_convert_log.json`.
+
+## Limitations
+
+- No JavaScript execution; dynamic-only sites need a different tool chain.
+- Crawl scope is same-site (scheme + host, optional subdomains via `--no-subdomains` / API `include_subdomains`).
+- Binary non-HTML responses are rejected with a clear error.

--- a/url-to-md/converter.py
+++ b/url-to-md/converter.py
@@ -1,0 +1,8 @@
+"""Shim CLI: prefer `md-url` after `pip install mdengine[url]`."""
+
+from __future__ import annotations
+
+from md_generator.url.converter import main
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/url-to-md/pytest.ini
+++ b/url-to-md/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+pythonpath = ..

--- a/url-to-md/requirements-api.txt
+++ b/url-to-md/requirements-api.txt
@@ -1,0 +1,6 @@
+fastapi>=0.115.0
+uvicorn[standard]>=0.32.0
+python-multipart>=0.0.12
+mcp>=1.0.0
+pydantic-settings>=2.0.0
+httpx>=0.27.0

--- a/url-to-md/requirements-mcp.txt
+++ b/url-to-md/requirements-mcp.txt
@@ -1,0 +1,8 @@
+mcp>=1.2.0
+fastmcp>=2.3.0
+httpx>=0.27.0
+beautifulsoup4>=4.12.0
+lxml>=5.0.0
+lxml_html_clean>=0.4.0
+markdownify>=0.14.0
+readability-lxml>=0.8.1

--- a/url-to-md/requirements.txt
+++ b/url-to-md/requirements.txt
@@ -1,0 +1,9 @@
+# Install from repository root so `md_generator` is importable:
+#   pip install -e "..[url]"
+pytest>=8.0.0
+httpx>=0.27.0
+beautifulsoup4>=4.12.0
+lxml>=5.0.0
+lxml_html_clean>=0.4.0
+markdownify>=0.14.0
+readability-lxml>=0.8.1

--- a/url-to-md/tests/test_url_api.py
+++ b/url-to-md/tests/test_url_api.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import zipfile
+from io import BytesIO
+
+import pytest
+
+pytest.importorskip("fastapi")
+
+from fastapi.testclient import TestClient
+
+from md_generator.url.api.main import app
+
+
+@pytest.fixture(scope="module")
+def api_client() -> TestClient:
+    """One TestClient for the module so MCP lifespan runs only once."""
+    with TestClient(app) as c:
+        yield c
+
+
+def test_convert_sync_zip(api_client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
+    from md_generator.url.fetch import FetchResult
+
+    def fake_fetch(url: str, client, options):
+        html = """<!DOCTYPE html><html><head><title>T</title></head>
+        <body><h1>Heading</h1><p>Body</p></body></html>"""
+        return FetchResult(
+            url=url,
+            final_url=url,
+            status_code=200,
+            content_type="text/html",
+            text=html,
+        )
+
+    monkeypatch.setattr("md_generator.url.convert_impl.fetch_html", fake_fetch)
+
+    r = api_client.post("/convert/sync", json={"url": "https://example.com/"})
+    assert r.status_code == 200, r.text
+    zf = zipfile.ZipFile(BytesIO(r.content))
+    names = zf.namelist()
+    assert "document.md" in names
+
+
+def test_sync_rejects_too_many_urls(api_client: TestClient) -> None:
+    r = api_client.post(
+        "/convert/sync",
+        json={"urls": ["https://a.com/1", "https://a.com/2", "https://a.com/3", "https://a.com/4"]},
+    )
+    assert r.status_code == 409
+
+
+def test_jobs_flow(api_client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
+    from md_generator.url.fetch import FetchResult
+
+    def fake_fetch(url: str, client, options):
+        html = "<!DOCTYPE html><html><body><p>x</p></body></html>"
+        return FetchResult(
+            url=url,
+            final_url=url,
+            status_code=200,
+            content_type="text/html",
+            text=html,
+        )
+
+    monkeypatch.setattr("md_generator.url.convert_impl.fetch_html", fake_fetch)
+
+    r = api_client.post("/convert/jobs", json={"url": "https://example.com/z"})
+    assert r.status_code == 200, r.text
+    job_id = r.json()["job_id"]
+    for _ in range(50):
+        st = api_client.get(f"/convert/jobs/{job_id}")
+        if st.json()["status"] == "done":
+            break
+    assert st.json()["status"] == "done"
+    dl = api_client.get(f"/convert/jobs/{job_id}/download")
+    assert dl.status_code == 200
+    zf = zipfile.ZipFile(BytesIO(dl.content))
+    assert "document.md" in zf.namelist()

--- a/url-to-md/tests/test_url_core.py
+++ b/url-to-md/tests/test_url_core.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import httpx
+import pytest
+
+from md_generator.url.extract import extract_same_site_links, normalize_url, same_site
+from md_generator.url.options import ConvertOptions
+from md_generator.url.page_convert import convert_one_page_artifact
+
+
+@pytest.fixture()
+def noop_client() -> httpx.Client:
+    transport = httpx.MockTransport(lambda r: httpx.Response(404))
+    return httpx.Client(transport=transport)
+
+
+def test_same_site_subdomain() -> None:
+    assert same_site(
+        "https://a.example.com/p",
+        "https://b.example.com/q",
+        include_subdomains=True,
+    ) is False
+    assert same_site(
+        "https://sub.example.com/",
+        "https://example.com/",
+        include_subdomains=True,
+    ) is True
+
+
+def test_extract_same_site_links() -> None:
+    html = """
+    <html><body>
+    <a href="/rel">rel</a>
+    <a href="https://other.com/x">ext</a>
+    <a href="https://example.com/other">same</a>
+    </body></html>
+    """
+    links = extract_same_site_links(html, "https://example.com/start", include_subdomains=True)
+    assert "https://example.com/rel" in links
+    assert "https://example.com/other" in links
+    assert not any("other.com" in u for u in links)
+
+
+def test_convert_one_page_artifact_minimal(tmp_path: Path, noop_client: httpx.Client) -> None:
+    html = """<!DOCTYPE html>
+<html><head><title>Fixture</title></head><body>
+<article><h1>Hello</h1><p>Paragraph text.</p>
+<table><tr><th>A</th><th>B</th></tr><tr><td>1</td><td>2</td></tr></table>
+</article></body></html>"""
+    out = tmp_path / "art"
+    opts = ConvertOptions(artifact_layout=True, table_csv=True)
+    convert_one_page_artifact("https://example.com/doc", html, out, opts, noop_client)
+    doc = (out / "document.md").read_text(encoding="utf-8")
+    assert "Hello" in doc or "Fixture" in doc
+    assert "Paragraph" in doc
+    tables = list((out / "assets" / "tables").glob("*.csv"))
+    assert tables
+
+
+def test_normalize_url_strips_fragment() -> None:
+    assert normalize_url("https://a.com/x#y") == "https://a.com/x"

--- a/url-to-md/tests/test_url_crawl.py
+++ b/url-to-md/tests/test_url_crawl.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import httpx
+import pytest
+
+from md_generator.url.crawl import run_crawl, run_crawl_async
+from md_generator.url.fetch import FetchResult
+from md_generator.url.options import ConvertOptions
+
+
+def test_run_crawl_two_pages(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Breadth-first crawl with fetch_html patched to a tiny two-page site."""
+
+    def fake_fetch(url: str, client, options):
+        u = url.rstrip("/")
+        if u.endswith("two") or "two" in url.split("/")[-1]:
+            html = "<!DOCTYPE html><html><body><p>Page two</p></body></html>"
+            final = "https://crawl.test/two"
+        else:
+            html = """<!DOCTYPE html><html><body>
+            <h1>One</h1>
+            <a href="https://crawl.test/two">next</a>
+            </body></html>"""
+            final = "https://crawl.test/"
+        return FetchResult(
+            url=url,
+            final_url=final,
+            status_code=200,
+            content_type="text/html",
+            text=html,
+        )
+
+    monkeypatch.setattr("md_generator.url.crawl.fetch_html", fake_fetch)
+
+    transport = httpx.MockTransport(lambda r: httpx.Response(404))
+    client = httpx.Client(transport=transport)
+    opts = ConvertOptions(
+        artifact_layout=True,
+        crawl=True,
+        max_depth=2,
+        max_pages=5,
+        crawl_delay_seconds=0,
+        obey_robots=False,
+        include_subdomains=True,
+    )
+    out = tmp_path / "crawl_out"
+    run_crawl("https://crawl.test/", out, opts, client)
+    client.close()
+
+    index = (out / "document.md").read_text(encoding="utf-8")
+    assert "Crawl results" in index
+    pages = list((out / "pages").glob("*/document.md"))
+    assert len(pages) >= 2
+
+
+def test_run_crawl_async_two_pages(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    async def fake_fetch_async(url: str, client, options):
+        u = url.rstrip("/")
+        if u.endswith("two") or "two" in url.split("/")[-1]:
+            html = "<!DOCTYPE html><html><body><p>Page two</p></body></html>"
+            final = "https://crawl.test/two"
+        else:
+            html = """<!DOCTYPE html><html><body>
+            <h1>One</h1>
+            <a href="https://crawl.test/two">next</a>
+            </body></html>"""
+            final = "https://crawl.test/"
+        return FetchResult(
+            url=url,
+            final_url=final,
+            status_code=200,
+            content_type="text/html",
+            text=html,
+        )
+
+    monkeypatch.setattr("md_generator.url.crawl.fetch_html_async", fake_fetch_async)
+
+    transport = httpx.MockTransport(lambda r: httpx.Response(404))
+    client = httpx.Client(transport=transport)
+    opts = ConvertOptions(
+        artifact_layout=True,
+        crawl=True,
+        async_crawl=True,
+        crawl_max_concurrency=2,
+        max_depth=2,
+        max_pages=5,
+        crawl_delay_seconds=0,
+        obey_robots=False,
+        include_subdomains=True,
+    )
+    out = tmp_path / "crawl_async_out"
+    asyncio.run(run_crawl_async("https://crawl.test/", out, opts, client))
+    client.close()
+
+    index = (out / "document.md").read_text(encoding="utf-8")
+    assert "Crawl results" in index
+    pages = list((out / "pages").glob("*/document.md"))
+    assert len(pages) >= 2

--- a/url-to-md/tests/test_url_post_convert.py
+++ b/url-to-md/tests/test_url_post_convert.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from md_generator.url.options import ConvertOptions
+from md_generator.url.post_convert_assets import process_downloaded_files
+
+
+def test_post_convert_skips_when_disabled(tmp_path: Path) -> None:
+    root = tmp_path / "page"
+    (root / "assets" / "files").mkdir(parents=True)
+    (root / "assets" / "files" / "a.pdf").write_bytes(b"%PDF-1.4\n%\xe2\xe3\xcf\xd3\n")
+    opts = ConvertOptions(
+        artifact_layout=True,
+        convert_downloaded_assets=False,
+        convert_downloaded_images=False,
+    )
+    assert process_downloaded_files(root, opts) == ""
+
+
+def test_post_convert_pdf_creates_extracted(tmp_path: Path) -> None:
+    fitz = pytest.importorskip("fitz")
+    root = tmp_path / "page"
+    files = root / "assets" / "files"
+    files.mkdir(parents=True)
+    pdf_path = files / "hello.pdf"
+    doc = fitz.open()
+    doc.new_page().insert_text((72, 72), "Hello PDF")
+    doc.save(pdf_path)
+    doc.close()
+
+    opts = ConvertOptions(artifact_layout=True, convert_downloaded_assets=True, verbose=False)
+    appendix = process_downloaded_files(root, opts)
+    log = json.loads((root / "assets" / "asset_convert_log.json").read_text(encoding="utf-8"))
+    assert any(e.get("status") == "ok" for e in log.get("entries", []))
+    assert "Downloaded files converted to Markdown" in appendix or "Hello PDF" in appendix


### PR DESCRIPTION
- Add md_generator.url package (fetch, extract, crawl, html_to_md, page convert)
- Post-convert asset handling and related options
- FastAPI app, jobs/runner, MCP wiring under url/api
- md-url console entry point; tests under url-to-md/tests