### PR TITLE
feat(media): add audio-to-md and video-to-md (Whisper pipeline, CLI, API, MCP)

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,7 +347,7 @@ pip install "mdengine[video,api,mcp]"   # video CLI + HTTP + MCP (same ML stack 
 from pathlib import Path
 from md_generator.media.audio import AudioToMarkdownService, AudioConverter
 
-svc = AudioToMarkdownService(whisper_model="base", language=None)
+svc = AudioToMarkdownService(whisper_model="base")  # language omitted → Whisper auto-detect; pass e.g. language="en" to force
 text = svc.to_markdown(Path("input.mp3"), title="My title")
 svc.write_markdown(Path("input.mp3"), Path("out/transcript.md"))
 
@@ -360,7 +360,7 @@ result = svc.transcribe(Path("input.wav"))  # metadata + segments + plain_text
 from pathlib import Path
 from md_generator.media.video import VideoToMarkdownService
 
-svc = VideoToMarkdownService(whisper_model="base")
+svc = VideoToMarkdownService(whisper_model="base")  # transcription language omitted → auto-detect
 md = svc.to_markdown(Path("input.mp4"), title=None)
 svc.write_markdown(Path("input.mp4"), Path("out/transcript.md"))
 ```
@@ -373,7 +373,7 @@ Each service exposes the same job pattern as other converters:
 
 | Endpoint | Description |
 |----------|-------------|
-| `POST /convert/sync` | Multipart field **`file`**; returns **Markdown** body. Query: `whisper_model`, `language`, `title`. |
+| `POST /convert/sync` | Multipart field **`file`**; returns **Markdown** body. Query: `whisper_model`, `language` (omit or `auto` for detection; pass a code to force), `title`. |
 | `POST /convert/jobs` | Async upload; returns `{ "job_id", "status" }`. |
 | `GET /convert/jobs/{job_id}` | Status JSON. |
 | `GET /convert/jobs/{job_id}/download` | Markdown when `done`; workspace removed after download. |

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # mdengine
 
-Single Python distribution for converting **PDF**, **Word (.docx)**, **PowerPoint (.pptx)**, **Excel (.xlsx/.xlsm)**, **images** (OCR), **plain text / JSON / XML**, and **ZIP archives** into **Markdown** (and related assets). Install only the extras you need; everything imports under the **`md_generator`** package.
+Single Python distribution for converting **PDF**, **Word (.docx)**, **PowerPoint (.pptx)**, **Excel (.xlsx/.xlsm)**, **images** (OCR), **plain text / JSON / XML**, **ZIP archives**, and **audio / video** (Whisper transcription → Markdown) into **Markdown** (and related assets). Install only the extras you need; everything imports under the **`md_generator`** package.
 
 - **PyPI name:** `mdengine` (import package: `md_generator`)
 - **Source:** [github.com/vishal7090/md-generator](https://github.com/vishal7090/md-generator)
 - **Python:** 3.10+
 - **License:** [MIT](LICENSE)
 
-**Quick links:** [On a new computer](#on-a-new-computer) · [Command-line execution](#command-line-execution) · [Python library](#python-library) · [HTTP API](#http-api-fastapi) · [MCP](#mcp-model-context-protocol) · [Development](#development) · [Code of Conduct](CODE_OF_CONDUCT.md)
+**Quick links:** [On a new computer](#on-a-new-computer) · [Command-line execution](#command-line-execution) · [Python library](#python-library) · [Audio and video](#audio-and-video-to-markdown) · [HTTP API](#http-api-fastapi) · [MCP](#mcp-model-context-protocol) · [Development](#development) · [Code of Conduct](CODE_OF_CONDUCT.md)
 
 ---
 
@@ -74,6 +74,8 @@ pip install "mdengine[all]"
 | `archive` | ZIP → Markdown layout (Pillow; optional tesseract for inline image OCR) |
 | `url` | HTTP(S) HTML → Markdown (httpx, readability-lxml, markdownify, BeautifulSoup, lxml) |
 | `url-full` | `url` plus PDF/Word/PPTX/XLSX/archive stack for **post-converting** downloaded linked files to Markdown |
+| `audio` | **Audio → Markdown** via Whisper (`openai-whisper`); ships `imageio-ffmpeg` for a bundled **ffmpeg** when none is on `PATH` |
+| `video` | **Video → Markdown** (ffmpeg extracts mono 16 kHz WAV, then same Whisper stack as `audio`) |
 | `api` | FastAPI, uvicorn, httpx, pydantic-settings |
 | `mcp` | MCP servers (`mcp`, `fastmcp` where used) |
 | `dev` | pytest + API/MCP test helpers |
@@ -116,6 +118,12 @@ If the shell reports “command not found”, ensure the Python **Scripts** dire
 | `md-text` | `md_generator.text.converter:main` | `md-text config.xml out.md` |
 | `md-zip` | `md_generator.archive.converter:main` | `md-zip bundle.zip ./zip-out` |
 | `md-url` | `md_generator.url.converter:main` | `md-url https://example.com/doc ./web-out --artifact-layout` |
+| `md-audio` | `md_generator.media.audio.converter:main` | `md-audio clip.mp3 transcript.md --model base` |
+| `md-video` | `md_generator.media.video.converter:main` | `md-video clip.mp4 transcript.md --model base` |
+| `md-audio-api` | `md_generator.media.audio.api.run:main` | REST + MCP on port **8011** (see [Audio and video to Markdown](#audio-and-video-to-markdown)) |
+| `md-video-api` | `md_generator.media.video.api.run:main` | REST + MCP on port **8012** |
+| `md-audio-mcp` | `md_generator.media.audio.api.mcp_server:main` | Standalone MCP (`--transport stdio` \| `sse` \| `streamable-http`) |
+| `md-video-mcp` | `md_generator.media.video.api.mcp_server:main` | Same for video |
 
 Every command accepts **`-h` / `--help`** for full flags (artifact layout, OCR, ZIP options, etc.).
 
@@ -133,6 +141,8 @@ md-image ./photos ocr.md --engines tess --strategy best
 md-text data.json data.md
 md-zip archive.zip ./unzipped-md
 md-url https://example.com/page ./page-bundle --artifact-layout
+md-audio ./voice.mp3 ./voice.md --model tiny
+md-video ./screen.mp4 ./screen.md --model base
 ```
 
 **Windows PowerShell** (same commands; use backslashes for paths if you prefer)
@@ -141,6 +151,8 @@ md-url https://example.com/page ./page-bundle --artifact-layout
 md-pdf .\manual.pdf .\out\doc.md
 md-zip .\archive.zip .\zip-out
 md-url https://example.com/page .\page-bundle --artifact-layout
+md-audio .\voice.mp3 .\voice.md --model tiny
+md-video .\screen.mp4 .\screen.md --model base
 ```
 
 **Windows CMD**
@@ -310,6 +322,106 @@ convert_zip(
 
 ---
 
+## Audio and video to Markdown
+
+Library code lives under **`md_generator.media`**: shared probing in [`document_converter.py`](src/md_generator/media/document_converter.py), **audio** in [`media/audio/`](src/md_generator/media/audio/) (Whisper + ffprobe / ffmpeg metadata), **video** in [`media/video/`](src/md_generator/media/video/) (ffmpeg extracts audio only; transcription always goes through the audio service—no duplicate Whisper path in video).
+
+### System requirements
+
+- **ffmpeg** (and **ffprobe** when available) on `PATH` for metadata and for **video** demux. If `ffprobe` is missing or misbehaving, metadata falls back to parsing `ffmpeg -i` stderr.
+- Optional **`FFMPEG`** environment variable: absolute path to an `ffmpeg` executable (see [`resolve_ffmpeg_executable()`](src/md_generator/media/document_converter.py)).
+- **GPU** is optional; Whisper runs on CPU if needed (may log FP16→FP32 on CPU).
+
+### Install
+
+```bash
+pip install "mdengine[audio,api,mcp]"    # audio CLI + HTTP + MCP
+pip install "mdengine[video,api,mcp]"   # video CLI + HTTP + MCP (same ML stack as audio)
+```
+
+### Python library
+
+**Audio** — structured result + Markdown:
+
+```python
+from pathlib import Path
+from md_generator.media.audio import AudioToMarkdownService, AudioConverter
+
+svc = AudioToMarkdownService(whisper_model="base", language=None)
+text = svc.to_markdown(Path("input.mp3"), title="My title")
+svc.write_markdown(Path("input.mp3"), Path("out/transcript.md"))
+
+result = svc.transcribe(Path("input.wav"))  # metadata + segments + plain_text
+```
+
+**Video** — extract → transcribe (via audio) → Markdown:
+
+```python
+from pathlib import Path
+from md_generator.media.video import VideoToMarkdownService
+
+svc = VideoToMarkdownService(whisper_model="base")
+md = svc.to_markdown(Path("input.mp4"), title=None)
+svc.write_markdown(Path("input.mp4"), Path("out/transcript.md"))
+```
+
+Public symbols are also re-exported from [`md_generator.media`](src/md_generator/media/__init__.py) for ffprobe helpers (`ffprobe_json`, `VideoProbeResult`, …).
+
+### REST API (FastAPI)
+
+Each service exposes the same job pattern as other converters:
+
+| Endpoint | Description |
+|----------|-------------|
+| `POST /convert/sync` | Multipart field **`file`**; returns **Markdown** body. Query: `whisper_model`, `language`, `title`. |
+| `POST /convert/jobs` | Async upload; returns `{ "job_id", "status" }`. |
+| `GET /convert/jobs/{job_id}` | Status JSON. |
+| `GET /convert/jobs/{job_id}/download` | Markdown when `done`; workspace removed after download. |
+
+**Audio** defaults: `MD_AUDIO_MAX_UPLOAD_MB=200`, `MD_AUDIO_MAX_SYNC_UPLOAD_MB=40`, `MD_AUDIO_API_PORT=8011`.  
+**Video** defaults: `MD_VIDEO_MAX_UPLOAD_MB=500`, `MD_VIDEO_MAX_SYNC_UPLOAD_MB=80`, `MD_VIDEO_API_PORT=8012`.
+
+Run with the bundled runners (each call builds the app with **`factory=True`** for a clean MCP session manager):
+
+```bash
+md-audio-api --host 127.0.0.1 --port 8011
+md-video-api --host 127.0.0.1 --port 8012
+```
+
+Or with Uvicorn directly (the ASGI app is built by **`create_app()`** so each worker gets its own MCP session manager):
+
+```bash
+uvicorn md_generator.media.audio.api.main:create_app --factory --host 127.0.0.1 --port 8011
+uvicorn md_generator.media.video.api.main:create_app --factory --host 127.0.0.1 --port 8012
+```
+
+The module also defines **`app = create_app()`** for a single-process target: `uvicorn md_generator.media.audio.api.main:app` (no `--factory`).
+
+Swagger is at **`/docs`** when the app is running.
+
+### MCP (stdio, SSE, streamable HTTP)
+
+1. **With FastAPI** — start `md-audio-api` or `md-video-api`; mount Streamable HTTP MCP at **`http://<host>:<port>/mcp`** (same host as REST).
+2. **Standalone** — process speaks MCP only:
+
+```bash
+md-audio-mcp --transport stdio
+md-audio-mcp --transport sse
+md-audio-mcp --transport streamable-http
+md-video-mcp --transport stdio
+```
+
+**Audio MCP tools:** `transcribe_audio_path`, `transcribe_audio_base64`.  
+**Video MCP tools:** `transcribe_video_path`, `transcribe_video_base64`.
+
+Equivalent modules: `python -m md_generator.media.audio.api.mcp_server`, `python -m md_generator.media.video.api.mcp_server`.
+
+### Thin shims (repo clone)
+
+[`audio-to-md/converter.py`](audio-to-md/converter.py) and [`video-to-md/converter.py`](video-to-md/converter.py) delegate to the same `main` as `md-audio` / `md-video`. Tests and `pytest.ini` live under `audio-to-md/tests/` and `video-to-md/tests/`.
+
+---
+
 ## HTTP API (FastAPI)
 
 All format APIs follow a similar pattern:
@@ -335,6 +447,8 @@ Install `mdengine[api]` plus the format extra(s), then run the **`app`** object 
 | Text/JSON/XML | `md_generator.text.api.main:app` | `text`, `api`, `mcp` |
 | ZIP | `md_generator.archive.api.main:app` | `archive`, `api`, `mcp` (+ extras for nested office/PDF) |
 | URL / HTML | `md_generator.url.api.main:app` | `url`, `api`, `mcp` |
+| Audio (Whisper) | `md_generator.media.audio.api.main:create_app` (use **`--factory`**) or `…main:app` | `audio`, `api`, `mcp` |
+| Video (Whisper) | `md_generator.media.video.api.main:create_app` (use **`--factory`**) or `…main:app` | `video`, `api`, `mcp` |
 
 Examples:
 
@@ -343,6 +457,8 @@ uvicorn md_generator.pdf.api.main:app --host 127.0.0.1 --port 8001
 uvicorn md_generator.word.api.main:app --host 127.0.0.1 --port 8002
 uvicorn md_generator.archive.api.main:app --host 127.0.0.1 --port 8010
 uvicorn md_generator.url.api.main:app --host 127.0.0.1 --port 8011
+uvicorn md_generator.media.audio.api.main:create_app --factory --host 127.0.0.1 --port 8011
+uvicorn md_generator.media.video.api.main:create_app --factory --host 127.0.0.1 --port 8012
 ```
 
 ### MCP over HTTP on the same server
@@ -362,6 +478,8 @@ Prefixes differ per service (often read from a `.env` file next to the process):
 | Text | `TXT_JSON_XML_TO_MD_` | same pattern |
 | XLSX | `XLSX_TO_MD_` | `XLSX_TO_MD_TEMP_DIR`, `XLSX_TO_MD_CORS_ORIGINS`, etc. (see `md_generator.xlsx.api.app`) |
 | URL | `URL_TO_MD_` | `URL_TO_MD_MAX_SYNC_URLS`, `URL_TO_MD_MAX_SYNC_CRAWL_PAGES`, `URL_TO_MD_MAX_JOB_URLS`, `URL_TO_MD_JOB_TTL_SECONDS`, `URL_TO_MD_TEMP_DIR`, `URL_TO_MD_CORS_ORIGINS` |
+| Audio API | `MD_AUDIO_` | `MD_AUDIO_MAX_UPLOAD_MB`, `MD_AUDIO_MAX_SYNC_UPLOAD_MB`, `MD_AUDIO_JOB_TTL_SECONDS`, `MD_AUDIO_TEMP_DIR`, `MD_AUDIO_CORS_ORIGINS`, `MD_AUDIO_API_HOST`, `MD_AUDIO_API_PORT` |
+| Video API | `MD_VIDEO_` | Same pattern as audio with `MD_VIDEO_*` (defaults: larger upload/sync caps, port **8012**) |
 
 Exact variable names match the `ApiSettings` / helper functions in each `api/settings` or `api/app` module.
 
@@ -385,6 +503,8 @@ Two usage patterns:
 | PPTX | `python -m md_generator.ppt.api.mcp_server` (see module docstring for flags) |
 | Image | `python -m md_generator.image.api.mcp_server` (see module for CLI) |
 | URL / HTML | `python -m md_generator.url.api.mcp_server` / `--transport sse` / `--transport streamable-http` |
+| Audio | `md-audio-mcp` or `python -m md_generator.media.audio.api.mcp_server` — `--transport stdio` (default), `sse`, `streamable-http` |
+| Video | `md-video-mcp` or `python -m md_generator.media.video.api.mcp_server` — same transports |
 
 **Word** and **XLSX** also ship a small runner script in the repo:
 
@@ -419,7 +539,7 @@ Tests live under each legacy folder’s `tests/` directory (e.g. `pdf-to-md/test
 |------|------|
 | `LICENSE` | MIT license text |
 | `CODE_OF_CONDUCT.md` | [Contributor Covenant](https://www.contributor-covenant.org/) 2.1 |
-| `src/md_generator/` | **Library source** (all formats + `api` subpackages) |
+| `src/md_generator/` | **Library source** (all formats + `api` subpackages); **audio/video** under [`media/audio/`](src/md_generator/media/audio/) and [`media/video/`](src/md_generator/media/video/) |
 | `pyproject.toml` | Packaging, extras, CLI entry points, pytest |
 | `*-to-md/` | **Docs, tests, fixtures**, thin `converter.py` shims, some `run.py` helpers |
 | `README.md` | This document |

--- a/audio-to-md/converter.py
+++ b/audio-to-md/converter.py
@@ -1,0 +1,8 @@
+"""Shim CLI: prefer `md-audio` after `pip install mdengine[audio]`."""
+
+from __future__ import annotations
+
+from md_generator.media.audio.converter import main
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/audio-to-md/pytest.ini
+++ b/audio-to-md/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+pythonpath = ../src
+testpaths = tests

--- a/audio-to-md/requirements.txt
+++ b/audio-to-md/requirements.txt
@@ -1,0 +1,2 @@
+openai-whisper>=20231117
+pytest>=8.0.0

--- a/audio-to-md/tests/test_audio_api.py
+++ b/audio-to-md/tests/test_audio_api.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from md_generator.media.audio.service import AudioToMarkdownService
+
+
+@pytest.fixture()
+def _patch_write(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_write_markdown(
+        self: AudioToMarkdownService,
+        input_audio: Path,
+        output_md: Path,
+        *,
+        title: str | None = None,
+        encoding: str = "utf-8",
+    ) -> Path:
+        output_md = Path(output_md)
+        output_md.parent.mkdir(parents=True, exist_ok=True)
+        output_md.write_text("# stub\n", encoding=encoding)
+        return output_md
+
+    monkeypatch.setattr(AudioToMarkdownService, "write_markdown", fake_write_markdown)
+
+
+def test_sync_rejects_bad_extension(_patch_write: None) -> None:
+    pytest.importorskip("fastapi")
+    from fastapi.testclient import TestClient
+
+    from md_generator.media.audio.api.main import create_app
+
+    with TestClient(create_app()) as client:
+        r = client.post(
+            "/convert/sync",
+            files={"file": ("x.txt", b"hi", "text/plain")},
+        )
+        assert r.status_code == 400
+
+
+def test_sync_accepts_mp3(_patch_write: None) -> None:
+    pytest.importorskip("fastapi")
+    from fastapi.testclient import TestClient
+
+    from md_generator.media.audio.api.main import create_app
+
+    with TestClient(create_app()) as client:
+        r = client.post(
+            "/convert/sync",
+            files={"file": ("a.mp3", b"fake", "audio/mpeg")},
+        )
+        assert r.status_code == 200, r.text
+        assert r.text.startswith("# stub")
+
+
+def test_jobs_flow(_patch_write: None) -> None:
+    pytest.importorskip("fastapi")
+    import time
+
+    from fastapi.testclient import TestClient
+
+    from md_generator.media.audio.api.main import create_app
+
+    with TestClient(create_app()) as client:
+        r = client.post(
+            "/convert/jobs",
+            files={"file": ("a.mp3", b"fake", "audio/mpeg")},
+        )
+        assert r.status_code == 200, r.text
+        jid = r.json()["job_id"]
+        for _ in range(50):
+            st = client.get(f"/convert/jobs/{jid}").json()
+            if st["status"] == "done":
+                break
+            if st["status"] == "failed":
+                pytest.fail(st.get("error"))
+            time.sleep(0.05)
+        dl = client.get(f"/convert/jobs/{jid}/download")
+        assert dl.status_code == 200
+        assert "# stub" in dl.text

--- a/audio-to-md/tests/test_audio_formatter.py
+++ b/audio-to-md/tests/test_audio_formatter.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from md_generator.media.audio.converter import MediaMetadata, TranscriptSegment, TranscriptionResult
+from md_generator.media.audio.formatter import AudioMarkdownFormatter, format_timestamped_transcript
+
+
+def test_format_timestamped_transcript_skips_empty_text() -> None:
+    segs = (
+        TranscriptSegment(0.0, 1.0, "hello", 0),
+        TranscriptSegment(1.0, 2.0, "   ", 1),
+        TranscriptSegment(2.0, 3.0, "world", 2),
+    )
+    out = format_timestamped_transcript(segs)
+    assert "hello" in out
+    assert "world" in out
+    assert "[0:00.000 --> 0:01.000]" in out
+
+
+def test_audio_markdown_formatter_sections() -> None:
+    meta = MediaMetadata(
+        title="T",
+        duration_seconds=12.345,
+        container="wav",
+        audio_codec="pcm_s16le",
+        sample_rate=16000,
+        whisper_language="en",
+        whisper_model="base",
+        source_path="/tmp/x.wav",
+    )
+    tr = TranscriptionResult(
+        metadata=meta,
+        segments=(TranscriptSegment(0.0, 1.0, "Hi", 0),),
+        plain_text="Hi",
+    )
+    md = AudioMarkdownFormatter().format(tr, title_override="Custom")
+    assert md.startswith("# Custom\n")
+    assert "## Metadata" in md
+    assert "## Transcript" in md
+    assert "Whisper model" in md
+    assert "[0:00.000 --> 0:01.000] Hi" in md
+
+
+def test_audio_formatter_uses_metadata_title_when_no_override() -> None:
+    meta = MediaMetadata(
+        title="FromMeta",
+        duration_seconds=None,
+        container=None,
+        audio_codec=None,
+        sample_rate=None,
+        whisper_language=None,
+        whisper_model="tiny",
+        source_path="s.wav",
+    )
+    tr = TranscriptionResult(metadata=meta, segments=(), plain_text="")
+    md = AudioMarkdownFormatter().format(tr)
+    assert md.startswith("# FromMeta\n")

--- a/audio-to-md/tests/test_ffprobe_helpers.py
+++ b/audio-to-md/tests/test_ffprobe_helpers.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from md_generator.media.document_converter import ffprobe_json, video_probe_from_ffprobe
+
+
+def test_ffprobe_json_success(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    p = tmp_path / "dummy.bin"
+    p.write_bytes(b"x")
+    monkeypatch.setattr(
+        "md_generator.media.document_converter.shutil.which",
+        lambda name: "ffprobe" if name == "ffprobe" else None,
+    )
+
+    def fake_run(cmd, **kwargs):  # noqa: ANN001
+        class Proc:
+            returncode = 0
+            stdout = '{"format":{"duration":"2.5","format_name":"mov,mp4","tags":{"title":"Hello"}},"streams":[{"codec_type":"video","codec_name":"h264","width":1280,"height":720},{"codec_type":"audio","codec_name":"aac","sample_rate":"48000"}]}'
+            stderr = ""
+
+        return Proc()
+
+    monkeypatch.setattr("md_generator.media.document_converter.subprocess.run", fake_run)
+    data = ffprobe_json(p)
+    assert data["format"]["duration"] == "2.5"
+    probe = video_probe_from_ffprobe(p, data)
+    assert probe.duration_seconds == 2.5
+    assert probe.format_tags_title == "Hello"
+    assert probe.video_codec == "h264"
+    assert probe.video_width == 1280
+    assert probe.audio_codec == "aac"
+    assert probe.sample_rate == 48000
+
+
+def test_ffprobe_json_falls_back_to_ffmpeg_stderr(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """When ffprobe fails, probing uses ``ffmpeg -i`` stderr parsing."""
+    p = tmp_path / "dummy.bin"
+    p.write_bytes(b"x")
+    monkeypatch.setattr(
+        "md_generator.media.document_converter.shutil.which",
+        lambda name: "ffprobe" if name == "ffprobe" else None,
+    )
+
+    def fake_run(cmd, **kwargs):  # noqa: ANN001
+        if "-show_streams" in cmd:
+            class Bad:
+                returncode = 1
+                stdout = ""
+                stderr = "ffprobe boom"
+
+            return Bad()
+        ff_err = (
+            "Duration: 00:01:02.50, start: 0.000000, bitrate: 128 kb/s\n"
+            "  Stream #0:0: Audio: mp3 (mp3float), 44100 Hz, stereo, fltp, 128 kb/s\n"
+        )
+
+        class Ff:
+            returncode = 1
+            stdout = ""
+            stderr = ff_err
+
+        return Ff()
+
+    monkeypatch.setattr("md_generator.media.document_converter.subprocess.run", fake_run)
+    data = ffprobe_json(p)
+    assert float(data["format"]["duration"]) == pytest.approx(62.5)
+    probe = video_probe_from_ffprobe(p, data)
+    assert probe.audio_codec == "mp3"
+    assert probe.sample_rate == 44100

--- a/audio-to-md/tests/test_whisper_language.py
+++ b/audio-to-md/tests/test_whisper_language.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.mark.parametrize(
+    ("inp", "exp_lang", "has_prompt", "exp_profile"),
+    [
+        (None, None, False, None),
+        ("", None, False, None),
+        ("auto", None, False, None),
+        ("en", "en", False, None),
+        ("english", "en", False, None),
+        ("hi", "hi", False, None),
+        ("hindi", "hi", False, None),
+        ("hi,en", None, True, "hi+en (mixed, auto-detect)"),
+        ("en hi", None, True, "hi+en (mixed, auto-detect)"),
+        ("hinglish", None, True, "Hindi+English (Hinglish)"),
+        ("Hindi and English mix", None, True, "hi+en (mixed, auto-detect)"),
+        ("xyztypo", None, False, "xyztypo"),
+        ("fr,de", None, True, "fr+de (mixed, auto-detect)"),
+    ],
+)
+def test_resolve_whisper_language(
+    inp: str | None,
+    exp_lang: str | None,
+    has_prompt: bool,
+    exp_profile: str | None,
+) -> None:
+    pytest.importorskip("whisper")
+    from md_generator.media.whisper_language import resolve_whisper_language
+
+    lang, prompt, profile = resolve_whisper_language(inp)
+    assert lang == exp_lang
+    assert (prompt is not None) == has_prompt
+    assert profile == exp_profile

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,8 +4,8 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mdengine"
-version = "0.2.2"
-description = "Convert PDF, Office, images, text/JSON/XML, ZIP archives, and web URLs to Markdown."
+version = "0.3.0"
+description = "Convert PDF, Office, images, audio, video, text/JSON/XML, ZIP archives, and web URLs to Markdown."
 readme = "README.md"
 requires-python = ">=3.10"
 license = "MIT"
@@ -72,6 +72,10 @@ url-full = [
   "openpyxl>=3.1.0",
   "pytesseract>=0.3.10",
 ]
+# Whisper + PyTorch; metadata uses ffprobe when available, else ``ffmpeg -i`` (see imageio-ffmpeg).
+audio = ["openai-whisper>=20231117", "imageio-ffmpeg>=0.5.1"]
+# Same ML stack as audio; ships a bundled ``ffmpeg`` binary when the system has none.
+video = ["openai-whisper>=20231117", "imageio-ffmpeg>=0.5.1"]
 api = [
   "fastapi>=0.115.0",
   "uvicorn[standard]>=0.32.0",
@@ -128,6 +132,12 @@ md-image = "md_generator.image.converter:main"
 md-text = "md_generator.text.converter:main"
 md-zip = "md_generator.archive.converter:main"
 md-url = "md_generator.url.converter:main"
+md-audio = "md_generator.media.audio.converter:main"
+md-video = "md_generator.media.video.converter:main"
+md-audio-api = "md_generator.media.audio.api.run:main"
+md-video-api = "md_generator.media.video.api.run:main"
+md-audio-mcp = "md_generator.media.audio.api.mcp_server:main"
+md-video-mcp = "md_generator.media.video.api.mcp_server:main"
 
 [tool.setuptools.packages.find]
 where = ["src"]
@@ -143,5 +153,7 @@ testpaths = [
   "txt-json-xml-to-md/tests",
   "zip-to-md/tests",
   "url-to-md/tests",
+  "audio-to-md/tests",
+  "video-to-md/tests",
 ]
 markers = ["integration: optional dependency or slower checks"]

--- a/src/md_generator/__init__.py
+++ b/src/md_generator/__init__.py
@@ -1,5 +1,5 @@
 """md_generator: PDF, Office, image, text, and ZIP to Markdown conversion."""
 
-__version__ = "0.2.2"
+__version__ = "0.3.0"
 
 __all__ = ["__version__"]

--- a/src/md_generator/media/__init__.py
+++ b/src/md_generator/media/__init__.py
@@ -1,0 +1,21 @@
+"""Media helpers: document probing (ffprobe/ffmpeg) and audio/video to Markdown."""
+
+from md_generator.media.document_converter import (
+    DocumentConverter,
+    MediaToolsError,
+    VideoProbeResult,
+    ffprobe_json,
+    require_ffmpeg_tools,
+    resolve_ffmpeg_executable,
+    video_probe_from_ffprobe,
+)
+
+__all__ = [
+    "DocumentConverter",
+    "MediaToolsError",
+    "VideoProbeResult",
+    "ffprobe_json",
+    "require_ffmpeg_tools",
+    "resolve_ffmpeg_executable",
+    "video_probe_from_ffprobe",
+]

--- a/src/md_generator/media/audio/__init__.py
+++ b/src/md_generator/media/audio/__init__.py
@@ -1,0 +1,18 @@
+from md_generator.media.audio.converter import (
+    AudioConverter,
+    MediaMetadata,
+    TranscriptSegment,
+    TranscriptionResult,
+)
+from md_generator.media.audio.formatter import AudioMarkdownFormatter, format_timestamped_transcript
+from md_generator.media.audio.service import AudioToMarkdownService
+
+__all__ = [
+    "AudioConverter",
+    "AudioMarkdownFormatter",
+    "AudioToMarkdownService",
+    "MediaMetadata",
+    "TranscriptSegment",
+    "TranscriptionResult",
+    "format_timestamped_transcript",
+]

--- a/src/md_generator/media/audio/api/__init__.py
+++ b/src/md_generator/media/audio/api/__init__.py
@@ -1,0 +1,1 @@
+"""REST + MCP (Streamable HTTP under ``/mcp``) for audio-to-Markdown."""

--- a/src/md_generator/media/audio/api/main.py
+++ b/src/md_generator/media/audio/api/main.py
@@ -1,0 +1,175 @@
+"""FastAPI: REST (sync + jobs) and Streamable HTTP MCP at ``/mcp``."""
+
+from __future__ import annotations
+
+import re
+import tempfile
+from contextlib import asynccontextmanager
+from pathlib import Path
+
+from fastapi import FastAPI, File, HTTPException, Request, UploadFile
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import FileResponse, Response
+from starlette.background import BackgroundTask
+
+from md_generator.media.audio.api.mcp_setup import build_mcp_stack
+from md_generator.media.audio.api.settings import AudioApiSettings, cors_list
+from md_generator.media.audio.service import AudioToMarkdownService
+from md_generator.media.job_store import MediaJobStore
+
+_AUDIO_EXTS = frozenset(
+    {".mp3", ".wav", ".ogg", ".opus", ".flac", ".m4a", ".aac", ".wma", ".webm", ".oga"}
+)
+
+
+def _safe_upload_name(name: str | None) -> str:
+    raw = (name or "upload.bin").strip()
+    return re.sub(r"[^\w.\-]+", "_", raw) or "upload.bin"
+
+
+def _require_audio_ext(path: Path) -> None:
+    if path.suffix.lower() not in _AUDIO_EXTS:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Unsupported audio extension (allowed: {', '.join(sorted(_AUDIO_EXTS))})",
+        )
+
+
+async def _read_upload_limited(upload: UploadFile, max_bytes: int) -> bytes:
+    data = bytearray()
+    chunk_size = 1024 * 1024
+    while True:
+        chunk = await upload.read(chunk_size)
+        if not chunk:
+            break
+        data += chunk
+        if len(data) > max_bytes:
+            raise HTTPException(
+                status_code=413,
+                detail="Upload exceeds MD_AUDIO_MAX_UPLOAD_MB",
+            )
+    return bytes(data)
+
+
+def create_app() -> FastAPI:
+    """Build a new app (new MCP session manager) — use with uvicorn ``factory=True`` and in tests."""
+    mcp, mcp_http = build_mcp_stack(mount_under_fastapi=True)
+
+    @asynccontextmanager
+    async def lifespan(app: FastAPI):
+        settings = AudioApiSettings()
+        base = Path(settings.temp_dir) if settings.temp_dir else None
+        store = MediaJobStore(base, settings.job_ttl_seconds)
+        store.start_sweeper()
+        app.state.settings = settings
+        app.state.job_store = store
+        async with mcp.session_manager.run():
+            yield
+
+    app = FastAPI(title="audio-to-md", lifespan=lifespan)
+    app.mount("/mcp", mcp_http)
+
+    _bootstrap = AudioApiSettings()
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=cors_list(_bootstrap),
+        allow_credentials="*" not in cors_list(_bootstrap),
+        allow_methods=["*"],
+        allow_headers=["*"],
+    )
+
+    @app.post("/convert/sync")
+    async def convert_sync(
+        request: Request,
+        file: UploadFile = File(...),
+        whisper_model: str = "base",
+        language: str | None = None,
+        title: str | None = None,
+    ) -> Response:
+        settings: AudioApiSettings = request.app.state.settings
+        max_u = settings.max_upload_mb * 1024 * 1024
+        max_sync = settings.max_sync_upload_mb * 1024 * 1024
+        body = await _read_upload_limited(file, max_u)
+        if len(body) > max_sync:
+            raise HTTPException(
+                status_code=409,
+                detail="File too large for synchronous conversion; use POST /convert/jobs",
+            )
+        safe = _safe_upload_name(file.filename)
+        _require_audio_ext(Path(safe))
+
+        with tempfile.TemporaryDirectory() as td:
+            src = Path(td) / safe
+            src.write_bytes(body)
+            out = Path(td) / "transcript.md"
+            svc = AudioToMarkdownService(whisper_model=whisper_model, language=language)
+            svc.write_markdown(src, out, title=title)
+            md = out.read_text(encoding="utf-8")
+        return Response(
+            content=md.encode("utf-8"),
+            media_type="text/markdown; charset=utf-8",
+            headers={"Content-Disposition": 'attachment; filename="transcript.md"'},
+        )
+
+    @app.post("/convert/jobs")
+    async def convert_jobs(
+        request: Request,
+        file: UploadFile = File(...),
+        whisper_model: str = "base",
+        language: str | None = None,
+        title: str | None = None,
+    ) -> dict:
+        settings: AudioApiSettings = request.app.state.settings
+        store: MediaJobStore = request.app.state.job_store
+        max_u = settings.max_upload_mb * 1024 * 1024
+        body = await _read_upload_limited(file, max_u)
+        safe = _safe_upload_name(file.filename)
+        _require_audio_ext(Path(safe))
+
+        job = store.create_job()
+        src = job.workspace / safe
+        src.write_bytes(body)
+        out = job.workspace / "transcript.md"
+
+        def work() -> None:
+            svc = AudioToMarkdownService(whisper_model=whisper_model, language=language)
+            svc.write_markdown(src, out, title=title)
+            job.result_path = out
+
+        store.run_async(job, work)
+        return {"job_id": job.job_id, "status": job.status}
+
+    @app.get("/convert/jobs/{job_id}")
+    async def job_status(request: Request, job_id: str) -> dict:
+        store: MediaJobStore = request.app.state.job_store
+        job = store.get(job_id)
+        if not job:
+            raise HTTPException(404, detail="Unknown job_id")
+        return {
+            "status": job.status,
+            "error": job.error,
+            "created_at": job.created_at,
+        }
+
+    @app.get("/convert/jobs/{job_id}/download", response_class=FileResponse)
+    async def job_download(request: Request, job_id: str) -> FileResponse:
+        store: MediaJobStore = request.app.state.job_store
+        job = store.get(job_id)
+        if not job:
+            raise HTTPException(404, detail="Unknown job_id")
+        if job.status != "done" or not job.result_path or not job.result_path.is_file():
+            raise HTTPException(400, detail="Job is not ready for download")
+        path = job.result_path
+        task = BackgroundTask(store.remove_after_download, job)
+        return FileResponse(
+            path,
+            media_type="text/markdown; charset=utf-8",
+            filename="transcript.md",
+            background=task,
+        )
+
+    return app
+
+
+# Default ASGI object for ``uvicorn md_generator.media.audio.api.main:app`` (single process).
+app = create_app()

--- a/src/md_generator/media/audio/api/mcp_server.py
+++ b/src/md_generator/media/audio/api/mcp_server.py
@@ -1,0 +1,38 @@
+"""
+Standalone MCP server: stdio, SSE, or streamable HTTP (see ``--transport``).
+
+Examples:
+  python -m md_generator.media.audio.api.mcp_server
+  python -m md_generator.media.audio.api.mcp_server --transport sse
+  python -m md_generator.media.audio.api.mcp_server --transport streamable-http
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="audio-to-md MCP server")
+    parser.add_argument(
+        "--transport",
+        choices=("stdio", "sse", "streamable-http"),
+        default="stdio",
+    )
+    args = parser.parse_args()
+
+    from md_generator.media.audio.api.mcp_setup import build_mcp_stack
+
+    mcp, _ = build_mcp_stack(mount_under_fastapi=False)
+
+    if args.transport == "stdio":
+        asyncio.run(mcp.run_stdio_async())
+    elif args.transport == "sse":
+        asyncio.run(mcp.run_sse_async())
+    else:
+        asyncio.run(mcp.run_streamable_http_async())
+
+
+if __name__ == "__main__":
+    main()

--- a/src/md_generator/media/audio/api/mcp_setup.py
+++ b/src/md_generator/media/audio/api/mcp_setup.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import base64
+import os
+import re
+import tempfile
+from pathlib import Path
+
+from mcp.server.fastmcp import FastMCP
+
+from md_generator.media.audio.api.settings import AudioApiSettings
+from md_generator.media.audio.service import AudioToMarkdownService
+
+
+def _decode_base64(data: str) -> bytes:
+    s = data.strip()
+    if s.startswith("data:"):
+        parts = s.split(",", 1)
+        if len(parts) == 2:
+            s = parts[1]
+    return base64.b64decode(s, validate=False)
+
+
+def build_mcp_stack(*, mount_under_fastapi: bool = False) -> tuple[FastMCP, object]:
+    path = "/" if mount_under_fastapi else "/mcp"
+    mcp = FastMCP(
+        "audio-to-md",
+        instructions="Transcribe audio files to Markdown using Whisper (local paths or base64 uploads).",
+        streamable_http_path=path,
+    )
+    settings = AudioApiSettings()
+
+    @mcp.tool()
+    def transcribe_audio_path(
+        audio_path: str,
+        whisper_model: str = "base",
+        language: str | None = None,
+        title: str | None = None,
+    ) -> str:
+        """Transcribe an audio file on disk; returns path to a temporary ``.md`` file on the server."""
+        src = Path(audio_path).expanduser().resolve()
+        if not src.is_file():
+            raise ValueError("audio_path must be an existing file")
+        svc = AudioToMarkdownService(whisper_model=whisper_model, language=language)
+        fd, name = tempfile.mkstemp(suffix=".md", prefix="audio-mcp-")
+        os.close(fd)
+        out = Path(name)
+        try:
+            svc.write_markdown(src, out, title=title)
+        except Exception:
+            out.unlink(missing_ok=True)
+            raise
+        return str(out)
+
+    @mcp.tool()
+    def transcribe_audio_base64(
+        audio_base64: str,
+        filename: str = "upload.mp3",
+        whisper_model: str = "base",
+        language: str | None = None,
+        title: str | None = None,
+    ) -> str:
+        """Decode base64 audio (optional ``data:*;base64,`` prefix), transcribe, return path to temporary ``.md``."""
+        raw = _decode_base64(audio_base64)
+        max_b = settings.max_upload_mb * 1024 * 1024
+        if len(raw) > max_b:
+            raise ValueError(f"Decoded file exceeds MD_AUDIO_MAX_UPLOAD_MB ({settings.max_upload_mb})")
+        safe = re.sub(r"[^\w.\-]+", "_", filename) or "upload.mp3"
+        with tempfile.TemporaryDirectory() as td:
+            p = Path(td) / safe
+            p.write_bytes(raw)
+            svc = AudioToMarkdownService(whisper_model=whisper_model, language=language)
+            fd, name = tempfile.mkstemp(suffix=".md", prefix="audio-mcp-b64-")
+            os.close(fd)
+            out = Path(name)
+            try:
+                svc.write_markdown(p, out, title=title)
+            except Exception:
+                out.unlink(missing_ok=True)
+                raise
+        return str(out)
+
+    sub = mcp.streamable_http_app()
+    return mcp, sub

--- a/src/md_generator/media/audio/api/run.py
+++ b/src/md_generator/media/audio/api/run.py
@@ -1,0 +1,30 @@
+"""Run the audio REST + MCP FastAPI app with uvicorn."""
+
+from __future__ import annotations
+
+import argparse
+
+
+def main(argv: list[str] | None = None) -> int:
+    import uvicorn
+
+    from md_generator.media.audio.api.settings import AudioApiSettings
+
+    p = argparse.ArgumentParser(description="audio-to-md HTTP API (REST + MCP at /mcp)")
+    p.add_argument("--host", default=None)
+    p.add_argument("--port", type=int, default=None)
+    ns = p.parse_args(argv)
+    s = AudioApiSettings()
+    host = ns.host or s.api_host
+    port = ns.port if ns.port is not None else s.api_port
+    uvicorn.run(
+        "md_generator.media.audio.api.main:create_app",
+        host=host,
+        port=port,
+        factory=True,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/md_generator/media/audio/api/settings.py
+++ b/src/md_generator/media/audio/api/settings.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class AudioApiSettings(BaseSettings):
+    model_config = SettingsConfigDict(
+        env_prefix="MD_AUDIO_",
+        env_file=".env",
+        extra="ignore",
+    )
+
+    max_upload_mb: int = 200
+    max_sync_upload_mb: int = 40
+    job_ttl_seconds: int = 3600
+    temp_dir: str | None = None
+    cors_origins: str = "*"
+    api_host: str = "127.0.0.1"
+    api_port: int = 8011
+
+
+def cors_list(settings: AudioApiSettings) -> list[str]:
+    raw = (settings.cors_origins or "*").strip()
+    if raw == "*":
+        return ["*"]
+    return [o.strip() for o in raw.split(",") if o.strip()]

--- a/src/md_generator/media/audio/converter.py
+++ b/src/md_generator/media/audio/converter.py
@@ -1,0 +1,160 @@
+"""Whisper transcription + ffprobe metadata (``AudioConverter``)."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from md_generator.media.document_converter import (
+    DocumentConverter,
+    MediaToolsError,
+    ffprobe_json,
+    video_probe_from_ffprobe,
+)
+
+
+@dataclass(frozen=True)
+class TranscriptSegment:
+    start: float
+    end: float
+    text: str
+    id: int | None = None
+
+
+@dataclass
+class MediaMetadata:
+    title: str
+    duration_seconds: float | None
+    container: str | None
+    audio_codec: str | None
+    sample_rate: int | None
+    whisper_language: str | None
+    whisper_model: str
+    source_path: str
+
+
+@dataclass
+class TranscriptionResult:
+    metadata: MediaMetadata
+    segments: tuple[TranscriptSegment, ...]
+    plain_text: str
+
+
+def _metadata_from_ffprobe(path: Path, whisper_model: str, whisper_language: str | None) -> MediaMetadata:
+    data = ffprobe_json(path)
+    probe = video_probe_from_ffprobe(path, data)
+    title = probe.format_tags_title or path.stem or "Untitled"
+    return MediaMetadata(
+        title=title,
+        duration_seconds=probe.duration_seconds,
+        container=probe.format_name,
+        audio_codec=probe.audio_codec,
+        sample_rate=probe.sample_rate,
+        whisper_language=whisper_language,
+        whisper_model=whisper_model,
+        source_path=str(path.resolve()),
+    )
+
+
+class AudioConverter(DocumentConverter):
+    """Transcribe audio with Whisper and attach ffprobe metadata."""
+
+    def __init__(
+        self,
+        *,
+        model_name: str = "base",
+        language: str | None = None,
+        device: str | None = None,
+    ) -> None:
+        self._model_name = model_name
+        self._language = language
+        self._device = device
+        self._model: Any = None
+
+    @property
+    def model_name(self) -> str:
+        return self._model_name
+
+    def _load_model(self) -> Any:
+        if self._model is None:
+            import whisper
+
+            self._model = whisper.load_model(self._model_name, device=self._device)
+        return self._model
+
+    def convert(self, input_path: Path) -> TranscriptionResult:
+        path = Path(input_path).resolve()
+        if not path.is_file():
+            raise FileNotFoundError(path)
+
+        meta = _metadata_from_ffprobe(path, self._model_name, None)
+        model = self._load_model()
+        kwargs: dict = {"verbose": False}
+        if self._language:
+            kwargs["language"] = self._language
+        asr = model.transcribe(str(path), **kwargs)
+        whisper_lang = asr.get("language")
+        text = (asr.get("text") or "").strip()
+        raw_segments = asr.get("segments") or []
+        segments: list[TranscriptSegment] = []
+        for i, seg in enumerate(raw_segments):
+            try:
+                start = float(seg.get("start", 0.0))
+                end = float(seg.get("end", 0.0))
+            except (TypeError, ValueError):
+                start, end = 0.0, 0.0
+            t = (seg.get("text") or "").strip()
+            seg_id = seg.get("id")
+            try:
+                sid = int(seg_id) if seg_id is not None else i
+            except (TypeError, ValueError):
+                sid = i
+            segments.append(TranscriptSegment(start=start, end=end, text=t, id=sid))
+
+        meta = MediaMetadata(
+            title=meta.title,
+            duration_seconds=meta.duration_seconds,
+            container=meta.container,
+            audio_codec=meta.audio_codec,
+            sample_rate=meta.sample_rate,
+            whisper_language=whisper_lang,
+            whisper_model=self._model_name,
+            source_path=meta.source_path,
+        )
+        return TranscriptionResult(
+            metadata=meta,
+            segments=tuple(segments),
+            plain_text=text,
+        )
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(description="Transcribe audio to Markdown via Whisper.")
+    p.add_argument("input", type=Path, help="Input audio file path")
+    p.add_argument("output", type=Path, help="Output .md file path")
+    p.add_argument("--model", default="base", help="Whisper model name (default: base)")
+    p.add_argument("--language", default=None, help="Force Whisper language code (optional)")
+    p.add_argument("--title", default=None, help="Override document title in Markdown")
+    p.add_argument("-v", "--verbose", action="store_true")
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    try:
+        from md_generator.media.audio.service import AudioToMarkdownService
+
+        svc = AudioToMarkdownService(whisper_model=args.model, language=args.language)
+        out = svc.write_markdown(args.input, args.output, title=args.title)
+        if args.verbose:
+            print(f"Wrote {out}", file=sys.stderr)
+        return 0
+    except MediaToolsError as e:
+        print(str(e), file=sys.stderr)
+        return 2
+    except FileNotFoundError as e:
+        print(str(e), file=sys.stderr)
+        return 1

--- a/src/md_generator/media/audio/converter.py
+++ b/src/md_generator/media/audio/converter.py
@@ -14,6 +14,7 @@ from md_generator.media.document_converter import (
     ffprobe_json,
     video_probe_from_ffprobe,
 )
+from md_generator.media.whisper_language import resolve_whisper_language
 
 
 @dataclass(frozen=True)
@@ -34,6 +35,7 @@ class MediaMetadata:
     whisper_language: str | None
     whisper_model: str
     source_path: str
+    language_profile: str | None = None
 
 
 @dataclass
@@ -92,9 +94,12 @@ class AudioConverter(DocumentConverter):
 
         meta = _metadata_from_ffprobe(path, self._model_name, None)
         model = self._load_model()
+        lang_kw, init_prompt, profile = resolve_whisper_language(self._language)
         kwargs: dict = {"verbose": False}
-        if self._language:
-            kwargs["language"] = self._language
+        if lang_kw:
+            kwargs["language"] = lang_kw
+        if init_prompt:
+            kwargs["initial_prompt"] = init_prompt
         asr = model.transcribe(str(path), **kwargs)
         whisper_lang = asr.get("language")
         text = (asr.get("text") or "").strip()
@@ -123,6 +128,7 @@ class AudioConverter(DocumentConverter):
             whisper_language=whisper_lang,
             whisper_model=self._model_name,
             source_path=meta.source_path,
+            language_profile=profile,
         )
         return TranscriptionResult(
             metadata=meta,
@@ -136,7 +142,15 @@ def _build_parser() -> argparse.ArgumentParser:
     p.add_argument("input", type=Path, help="Input audio file path")
     p.add_argument("output", type=Path, help="Output .md file path")
     p.add_argument("--model", default="base", help="Whisper model name (default: base)")
-    p.add_argument("--language", default=None, help="Force Whisper language code (optional)")
+    p.add_argument(
+        "--language",
+        default=None,
+        help=(
+            "Whisper language (default: auto-detect if omitted). Single code/name (e.g. en, hi) to force, "
+            "or hi,en / hinglish for Hindi+English mixed (auto-detect + bilingual prompt). "
+            "Explicit auto / detect is the same as omitting this flag."
+        ),
+    )
     p.add_argument("--title", default=None, help="Override document title in Markdown")
     p.add_argument("-v", "--verbose", action="store_true")
     return p
@@ -158,3 +172,7 @@ def main(argv: list[str] | None = None) -> int:
     except FileNotFoundError as e:
         print(str(e), file=sys.stderr)
         return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/md_generator/media/audio/formatter.py
+++ b/src/md_generator/media/audio/formatter.py
@@ -43,8 +43,10 @@ def _metadata_lines(meta: MediaMetadata) -> list[str]:
         lines.append(f"- **Audio codec:** {meta.audio_codec}")
     if meta.sample_rate is not None:
         lines.append(f"- **Sample rate (Hz):** {meta.sample_rate}")
+    if meta.language_profile:
+        lines.append(f"- **Language option:** {meta.language_profile}")
     if meta.whisper_language:
-        lines.append(f"- **Detected / set language:** {meta.whisper_language}")
+        lines.append(f"- **Detected language (Whisper):** {meta.whisper_language}")
     return lines
 
 

--- a/src/md_generator/media/audio/formatter.py
+++ b/src/md_generator/media/audio/formatter.py
@@ -1,0 +1,68 @@
+"""Render ``TranscriptionResult`` as Markdown (title, metadata, timestamped transcript)."""
+
+from __future__ import annotations
+
+from md_generator.media.audio.converter import MediaMetadata, TranscriptSegment, TranscriptionResult
+
+
+def _format_timestamp(seconds: float) -> str:
+    if seconds < 0:
+        seconds = 0.0
+    ms = int(round((seconds % 1.0) * 1000))
+    total = int(seconds)
+    h, rem = divmod(total, 3600)
+    m, s = divmod(rem, 60)
+    if h > 0:
+        return f"{h:d}:{m:02d}:{s:02d}.{ms:03d}"
+    return f"{m:d}:{s:02d}.{ms:03d}"
+
+
+def format_timestamped_transcript(segments: tuple[TranscriptSegment, ...]) -> str:
+    """Format segments as timestamped lines (shared with video module)."""
+    lines: list[str] = []
+    for seg in segments:
+        a = _format_timestamp(seg.start)
+        b = _format_timestamp(seg.end)
+        t = seg.text.strip()
+        if not t:
+            continue
+        lines.append(f"[{a} --> {b}] {t}")
+    return "\n".join(lines) if lines else "_(no speech detected)_"
+
+
+def _metadata_lines(meta: MediaMetadata) -> list[str]:
+    lines = [
+        f"- **Source:** `{meta.source_path}`",
+        f"- **Whisper model:** {meta.whisper_model}",
+    ]
+    if meta.duration_seconds is not None:
+        lines.append(f"- **Duration (seconds):** {meta.duration_seconds:.3f}")
+    if meta.container:
+        lines.append(f"- **Container / format:** {meta.container}")
+    if meta.audio_codec:
+        lines.append(f"- **Audio codec:** {meta.audio_codec}")
+    if meta.sample_rate is not None:
+        lines.append(f"- **Sample rate (Hz):** {meta.sample_rate}")
+    if meta.whisper_language:
+        lines.append(f"- **Detected / set language:** {meta.whisper_language}")
+    return lines
+
+
+class AudioMarkdownFormatter:
+    """Build Markdown with title, metadata, and timestamped transcript."""
+
+    def format(self, result: TranscriptionResult, *, title_override: str | None = None) -> str:
+        title = (title_override or result.metadata.title or "Untitled").strip()
+        parts = [
+            f"# {title}",
+            "",
+            "## Metadata",
+            "",
+            *_metadata_lines(result.metadata),
+            "",
+            "## Transcript",
+            "",
+            format_timestamped_transcript(result.segments),
+            "",
+        ]
+        return "\n".join(parts).rstrip() + "\n"

--- a/src/md_generator/media/audio/service.py
+++ b/src/md_generator/media/audio/service.py
@@ -1,0 +1,52 @@
+"""Audio → Markdown orchestration service."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from md_generator.media.audio.converter import AudioConverter, TranscriptionResult
+from md_generator.media.audio.formatter import AudioMarkdownFormatter
+
+
+class AudioToMarkdownService:
+    """Transcribe audio and render Markdown using ``AudioConverter`` + ``AudioMarkdownFormatter``."""
+
+    def __init__(
+        self,
+        *,
+        converter: AudioConverter | None = None,
+        formatter: AudioMarkdownFormatter | None = None,
+        whisper_model: str = "base",
+        language: str | None = None,
+    ) -> None:
+        self._converter = converter or AudioConverter(model_name=whisper_model, language=language)
+        self._formatter = formatter or AudioMarkdownFormatter()
+
+    @property
+    def converter(self) -> AudioConverter:
+        return self._converter
+
+    @property
+    def formatter(self) -> AudioMarkdownFormatter:
+        return self._formatter
+
+    def transcribe(self, input_audio: Path) -> TranscriptionResult:
+        return self._converter.convert(Path(input_audio))
+
+    def to_markdown(self, input_audio: Path, *, title: str | None = None) -> str:
+        result = self.transcribe(Path(input_audio))
+        return self._formatter.format(result, title_override=title)
+
+    def write_markdown(
+        self,
+        input_audio: Path,
+        output_md: Path,
+        *,
+        title: str | None = None,
+        encoding: str = "utf-8",
+    ) -> Path:
+        output_md = Path(output_md)
+        output_md.parent.mkdir(parents=True, exist_ok=True)
+        body = self.to_markdown(input_audio, title=title)
+        output_md.write_text(body, encoding=encoding)
+        return output_md

--- a/src/md_generator/media/document_converter.py
+++ b/src/md_generator/media/document_converter.py
@@ -1,0 +1,239 @@
+"""Shared document conversion primitives for media-to-Markdown."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import shutil
+import subprocess
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+
+class MediaToolsError(RuntimeError):
+    """Raised when ffprobe/ffmpeg are missing or return an error."""
+
+
+def resolve_ffmpeg_executable() -> str:
+    """Return an ``ffmpeg`` executable path (PATH, ``FFMPEG`` env, or ``imageio-ffmpeg``)."""
+    env = (os.environ.get("FFMPEG") or "").strip()
+    if env and Path(env).is_file():
+        return env
+    w = shutil.which("ffmpeg")
+    if w:
+        return w
+    try:
+        import imageio_ffmpeg
+
+        exe = imageio_ffmpeg.get_ffmpeg_exe()
+        if exe and Path(exe).is_file():
+            return exe
+    except Exception:
+        pass
+    raise MediaToolsError("ffmpeg not found on PATH; install FFmpeg or pip install imageio-ffmpeg.")
+
+
+def require_ffmpeg_tools() -> None:
+    """Ensure ``ffmpeg`` is available (``ffprobe`` is optional; probing falls back to ``ffmpeg -i``)."""
+    resolve_ffmpeg_executable()
+
+
+def _duration_hms_to_seconds(h: str, m: str, s: str) -> float | None:
+    try:
+        return int(h) * 3600 + int(m) * 60 + float(s)
+    except (TypeError, ValueError):
+        return None
+
+
+def _ffprobe_json_via_ffmpeg_stderr(path: Path, *, timeout: int = 120) -> dict[str, Any]:
+    """Best-effort ffprobe-like JSON using ``ffmpeg -i`` stderr (when ``ffprobe`` is unavailable)."""
+    ffmpeg = resolve_ffmpeg_executable()
+    cmd = [ffmpeg, "-hide_banner", "-i", str(path)]
+    try:
+        proc = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+        )
+    except FileNotFoundError as exc:
+        raise MediaToolsError("ffmpeg not found for metadata probing.") from exc
+    text = (proc.stderr or "") + "\n" + (proc.stdout or "")
+    dur_m = re.search(
+        r"Duration:\s*(\d+):(\d+):(\d+(?:\.\d+)?)",
+        text,
+    )
+    duration_seconds: float | None = None
+    if dur_m:
+        duration_seconds = _duration_hms_to_seconds(dur_m.group(1), dur_m.group(2), dur_m.group(3))
+
+    streams: list[dict[str, Any]] = []
+    for line in text.splitlines():
+        if "Stream #" not in line or ":" not in line:
+            continue
+        if " Video:" in line:
+            vm = re.search(r"Stream\s+#\d+:\d+(?:\([^)]*\))?:\s*Video:\s*([^,\n]+)", line)
+            res_m = re.search(r",\s*(\d+)\s*x\s*(\d+)", line)
+            codec = (vm.group(1).strip().split()[0] if vm else None) or None
+            w = int(res_m.group(1)) if res_m else None
+            h = int(res_m.group(2)) if res_m else None
+            if codec:
+                streams.append(
+                    {
+                        "codec_type": "video",
+                        "codec_name": codec,
+                        "width": w,
+                        "height": h,
+                    }
+                )
+        elif " Audio:" in line:
+            am = re.search(r"Stream\s+#\d+:\d+(?:\([^)]*\))?:\s*Audio:\s*([^,\n]+)", line)
+            hz_m = re.search(r"(\d+)\s+Hz", line)
+            raw = am.group(1).strip() if am else ""
+            codec = raw.split()[0] if raw else None
+            sr = hz_m.group(1) if hz_m else None
+            if codec:
+                streams.append(
+                    {
+                        "codec_type": "audio",
+                        "codec_name": codec,
+                        "sample_rate": sr,
+                    }
+                )
+
+    try:
+        size_bytes = path.stat().st_size
+    except OSError:
+        size_bytes = None
+    suffix = path.suffix.lstrip(".") or None
+    return {
+        "format": {
+            "duration": str(duration_seconds) if duration_seconds is not None else None,
+            "format_name": suffix,
+            "size": str(size_bytes) if size_bytes is not None else None,
+            "tags": {},
+        },
+        "streams": streams,
+    }
+
+
+def ffprobe_json(path: Path, *, timeout: int = 120) -> dict[str, Any]:
+    """Run ffprobe and return parsed JSON (format + streams), or fall back to ``ffmpeg -i`` parsing."""
+    path = path.resolve()
+    if not path.is_file():
+        raise FileNotFoundError(path)
+    if shutil.which("ffprobe"):
+        cmd = [
+            "ffprobe",
+            "-v",
+            "quiet",
+            "-print_format",
+            "json",
+            "-show_format",
+            "-show_streams",
+            str(path),
+        ]
+        try:
+            proc = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                timeout=timeout,
+                check=False,
+            )
+        except FileNotFoundError as exc:
+            raise MediaToolsError("ffprobe not found on PATH; install FFmpeg.") from exc
+        if proc.returncode != 0:
+            return _ffprobe_json_via_ffmpeg_stderr(path, timeout=timeout)
+        try:
+            data = json.loads(proc.stdout or "{}")
+        except json.JSONDecodeError:
+            return _ffprobe_json_via_ffmpeg_stderr(path, timeout=timeout)
+        if not data.get("format") and not data.get("streams"):
+            return _ffprobe_json_via_ffmpeg_stderr(path, timeout=timeout)
+        return data
+
+    return _ffprobe_json_via_ffmpeg_stderr(path, timeout=timeout)
+
+
+@dataclass(frozen=True)
+class VideoProbeResult:
+    """ffprobe-derived view of a media file (no transcription)."""
+
+    path: Path
+    duration_seconds: float | None
+    format_name: str | None
+    format_tags_title: str | None
+    size_bytes: int | None
+    video_codec: str | None
+    video_width: int | None
+    video_height: int | None
+    audio_codec: str | None
+    sample_rate: int | None
+    raw_ffprobe: dict[str, Any] = field(default_factory=dict, repr=False)
+
+
+def video_probe_from_ffprobe(path: Path, data: dict[str, Any] | None = None) -> VideoProbeResult:
+    """Build ``VideoProbeResult`` from ffprobe JSON (fetches ffprobe when ``data`` is None)."""
+    if data is None:
+        data = ffprobe_json(path)
+    fmt = data.get("format") or {}
+    tags = fmt.get("tags") or {}
+    title = tags.get("title") or tags.get("TITLE")
+    duration_raw = fmt.get("duration")
+    duration: float | None
+    try:
+        duration = float(duration_raw) if duration_raw is not None else None
+    except (TypeError, ValueError):
+        duration = None
+    size_raw = fmt.get("size")
+    try:
+        size_bytes = int(size_raw) if size_raw is not None else None
+    except (TypeError, ValueError):
+        size_bytes = None
+    format_name = fmt.get("format_name")
+
+    video_codec = video_w = video_h = None
+    audio_codec = sample_rate = None
+    for stream in data.get("streams") or []:
+        ctype = stream.get("codec_type")
+        if ctype == "video" and video_codec is None:
+            video_codec = stream.get("codec_name")
+            try:
+                video_w = int(stream["width"]) if stream.get("width") is not None else None
+                video_h = int(stream["height"]) if stream.get("height") is not None else None
+            except (TypeError, ValueError):
+                video_w = video_h = None
+        elif ctype == "audio" and audio_codec is None:
+            audio_codec = stream.get("codec_name")
+            sr = stream.get("sample_rate")
+            try:
+                sample_rate = int(float(sr)) if sr is not None else None
+            except (TypeError, ValueError):
+                sample_rate = None
+
+    return VideoProbeResult(
+        path=path,
+        duration_seconds=duration,
+        format_name=format_name,
+        format_tags_title=str(title).strip() if title else None,
+        size_bytes=size_bytes,
+        video_codec=video_codec,
+        video_width=video_w,
+        video_height=video_h,
+        audio_codec=audio_codec,
+        sample_rate=sample_rate,
+        raw_ffprobe=data,
+    )
+
+
+class DocumentConverter(ABC):
+    """Abstract base for converters that turn a file on disk into structured output."""
+
+    @abstractmethod
+    def convert(self, input_path: Path) -> Any:
+        """Run conversion/analysis for ``input_path``."""

--- a/src/md_generator/media/job_store.py
+++ b/src/md_generator/media/job_store.py
@@ -1,0 +1,94 @@
+"""Background job store for media REST APIs (Markdown output on disk)."""
+
+from __future__ import annotations
+
+import shutil
+import threading
+import time
+import uuid
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Callable
+
+
+@dataclass
+class MediaJob:
+    job_id: str
+    workspace: Path
+    status: str = "queued"
+    error: str | None = None
+    created_at: float = field(default_factory=time.time)
+    result_path: Path | None = None
+
+
+class MediaJobStore:
+    def __init__(self, base_temp: Path | None, ttl_seconds: int) -> None:
+        self._base = base_temp
+        self._ttl = ttl_seconds
+        self._jobs: dict[str, MediaJob] = {}
+        self._lock = threading.Lock()
+        self._sweeper_started = False
+
+    def _root(self) -> Path:
+        import tempfile
+
+        if self._base:
+            p = Path(self._base)
+            p.mkdir(parents=True, exist_ok=True)
+            return p
+        return Path(tempfile.gettempdir()) / "mdengine-media-jobs"
+
+    def start_sweeper(self) -> None:
+        if self._sweeper_started:
+            return
+        self._sweeper_started = True
+
+        def loop() -> None:
+            while True:
+                time.sleep(60)
+                self.sweep()
+
+        threading.Thread(target=loop, daemon=True).start()
+
+    def sweep(self) -> None:
+        now = time.time()
+        with self._lock:
+            dead: list[str] = []
+            for jid, job in self._jobs.items():
+                if job.status in ("done", "failed") and now - job.created_at > self._ttl:
+                    dead.append(jid)
+            for jid in dead:
+                job = self._jobs.pop(jid, None)
+                if job and job.workspace.exists():
+                    shutil.rmtree(job.workspace, ignore_errors=True)
+
+    def create_job(self) -> MediaJob:
+        jid = str(uuid.uuid4())
+        ws = self._root() / jid
+        ws.mkdir(parents=True, exist_ok=True)
+        job = MediaJob(job_id=jid, workspace=ws)
+        with self._lock:
+            self._jobs[jid] = job
+        return job
+
+    def get(self, job_id: str) -> MediaJob | None:
+        with self._lock:
+            return self._jobs.get(job_id)
+
+    def run_async(self, job: MediaJob, fn: Callable[[], None]) -> None:
+        def target() -> None:
+            try:
+                job.status = "running"
+                fn()
+                job.status = "done"
+            except Exception as e:
+                job.status = "failed"
+                job.error = str(e)
+
+        threading.Thread(target=target, daemon=True).start()
+
+    def remove_after_download(self, job: MediaJob) -> None:
+        with self._lock:
+            self._jobs.pop(job.job_id, None)
+        if job.workspace.exists():
+            shutil.rmtree(job.workspace, ignore_errors=True)

--- a/src/md_generator/media/video/__init__.py
+++ b/src/md_generator/media/video/__init__.py
@@ -1,0 +1,9 @@
+from md_generator.media.video.converter import VideoConverter
+from md_generator.media.video.formatter import VideoMarkdownFormatter
+from md_generator.media.video.service import VideoToMarkdownService
+
+__all__ = [
+    "VideoConverter",
+    "VideoMarkdownFormatter",
+    "VideoToMarkdownService",
+]

--- a/src/md_generator/media/video/api/__init__.py
+++ b/src/md_generator/media/video/api/__init__.py
@@ -1,0 +1,1 @@
+"""REST + MCP (Streamable HTTP under ``/mcp``) for video-to-Markdown."""

--- a/src/md_generator/media/video/api/main.py
+++ b/src/md_generator/media/video/api/main.py
@@ -1,0 +1,174 @@
+"""FastAPI: REST (sync + jobs) and Streamable HTTP MCP at ``/mcp``."""
+
+from __future__ import annotations
+
+import re
+import tempfile
+from contextlib import asynccontextmanager
+from pathlib import Path
+
+from fastapi import FastAPI, File, HTTPException, Request, UploadFile
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import FileResponse, Response
+from starlette.background import BackgroundTask
+
+from md_generator.media.job_store import MediaJobStore
+from md_generator.media.video.api.mcp_setup import build_mcp_stack
+from md_generator.media.video.api.settings import VideoApiSettings, cors_list
+from md_generator.media.video.service import VideoToMarkdownService
+
+_VIDEO_EXTS = frozenset(
+    {".mp4", ".mov", ".avi", ".mkv", ".webm", ".m4v", ".wmv", ".mpg", ".mpeg", ".ogv"}
+)
+
+
+def _safe_upload_name(name: str | None) -> str:
+    raw = (name or "upload.bin").strip()
+    return re.sub(r"[^\w.\-]+", "_", raw) or "upload.bin"
+
+
+def _require_video_ext(path: Path) -> None:
+    if path.suffix.lower() not in _VIDEO_EXTS:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Unsupported video extension (allowed: {', '.join(sorted(_VIDEO_EXTS))})",
+        )
+
+
+async def _read_upload_limited(upload: UploadFile, max_bytes: int) -> bytes:
+    data = bytearray()
+    chunk_size = 1024 * 1024
+    while True:
+        chunk = await upload.read(chunk_size)
+        if not chunk:
+            break
+        data += chunk
+        if len(data) > max_bytes:
+            raise HTTPException(
+                status_code=413,
+                detail="Upload exceeds MD_VIDEO_MAX_UPLOAD_MB",
+            )
+    return bytes(data)
+
+
+def create_app() -> FastAPI:
+    """Build a new app (new MCP session manager) — use with uvicorn ``factory=True`` and in tests."""
+    mcp, mcp_http = build_mcp_stack(mount_under_fastapi=True)
+
+    @asynccontextmanager
+    async def lifespan(application: FastAPI):
+        settings = VideoApiSettings()
+        base = Path(settings.temp_dir) if settings.temp_dir else None
+        store = MediaJobStore(base, settings.job_ttl_seconds)
+        store.start_sweeper()
+        application.state.settings = settings
+        application.state.job_store = store
+        async with mcp.session_manager.run():
+            yield
+
+    app = FastAPI(title="video-to-md", lifespan=lifespan)
+    app.mount("/mcp", mcp_http)
+
+    _bootstrap = VideoApiSettings()
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=cors_list(_bootstrap),
+        allow_credentials="*" not in cors_list(_bootstrap),
+        allow_methods=["*"],
+        allow_headers=["*"],
+    )
+
+    @app.post("/convert/sync")
+    async def convert_sync(
+        request: Request,
+        file: UploadFile = File(...),
+        whisper_model: str = "base",
+        language: str | None = None,
+        title: str | None = None,
+    ) -> Response:
+        settings: VideoApiSettings = request.app.state.settings
+        max_u = settings.max_upload_mb * 1024 * 1024
+        max_sync = settings.max_sync_upload_mb * 1024 * 1024
+        body = await _read_upload_limited(file, max_u)
+        if len(body) > max_sync:
+            raise HTTPException(
+                status_code=409,
+                detail="File too large for synchronous conversion; use POST /convert/jobs",
+            )
+        safe = _safe_upload_name(file.filename)
+        _require_video_ext(Path(safe))
+
+        with tempfile.TemporaryDirectory() as td:
+            src = Path(td) / safe
+            src.write_bytes(body)
+            out = Path(td) / "transcript.md"
+            svc = VideoToMarkdownService(whisper_model=whisper_model, language=language)
+            svc.write_markdown(src, out, title=title)
+            md = out.read_text(encoding="utf-8")
+        return Response(
+            content=md.encode("utf-8"),
+            media_type="text/markdown; charset=utf-8",
+            headers={"Content-Disposition": 'attachment; filename="transcript.md"'},
+        )
+
+    @app.post("/convert/jobs")
+    async def convert_jobs(
+        request: Request,
+        file: UploadFile = File(...),
+        whisper_model: str = "base",
+        language: str | None = None,
+        title: str | None = None,
+    ) -> dict:
+        settings: VideoApiSettings = request.app.state.settings
+        store: MediaJobStore = request.app.state.job_store
+        max_u = settings.max_upload_mb * 1024 * 1024
+        body = await _read_upload_limited(file, max_u)
+        safe = _safe_upload_name(file.filename)
+        _require_video_ext(Path(safe))
+
+        job = store.create_job()
+        src = job.workspace / safe
+        src.write_bytes(body)
+        out = job.workspace / "transcript.md"
+
+        def work() -> None:
+            svc = VideoToMarkdownService(whisper_model=whisper_model, language=language)
+            svc.write_markdown(src, out, title=title)
+            job.result_path = out
+
+        store.run_async(job, work)
+        return {"job_id": job.job_id, "status": job.status}
+
+    @app.get("/convert/jobs/{job_id}")
+    async def job_status(request: Request, job_id: str) -> dict:
+        store: MediaJobStore = request.app.state.job_store
+        job = store.get(job_id)
+        if not job:
+            raise HTTPException(404, detail="Unknown job_id")
+        return {
+            "status": job.status,
+            "error": job.error,
+            "created_at": job.created_at,
+        }
+
+    @app.get("/convert/jobs/{job_id}/download", response_class=FileResponse)
+    async def job_download(request: Request, job_id: str) -> FileResponse:
+        store: MediaJobStore = request.app.state.job_store
+        job = store.get(job_id)
+        if not job:
+            raise HTTPException(404, detail="Unknown job_id")
+        if job.status != "done" or not job.result_path or not job.result_path.is_file():
+            raise HTTPException(400, detail="Job is not ready for download")
+        path = job.result_path
+        task = BackgroundTask(store.remove_after_download, job)
+        return FileResponse(
+            path,
+            media_type="text/markdown; charset=utf-8",
+            filename="transcript.md",
+            background=task,
+        )
+
+    return app
+
+
+app = create_app()

--- a/src/md_generator/media/video/api/mcp_server.py
+++ b/src/md_generator/media/video/api/mcp_server.py
@@ -1,0 +1,38 @@
+"""
+Standalone MCP server: stdio, SSE, or streamable HTTP (see ``--transport``).
+
+Examples:
+  python -m md_generator.media.video.api.mcp_server
+  python -m md_generator.media.video.api.mcp_server --transport sse
+  python -m md_generator.media.video.api.mcp_server --transport streamable-http
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="video-to-md MCP server")
+    parser.add_argument(
+        "--transport",
+        choices=("stdio", "sse", "streamable-http"),
+        default="stdio",
+    )
+    args = parser.parse_args()
+
+    from md_generator.media.video.api.mcp_setup import build_mcp_stack
+
+    mcp, _ = build_mcp_stack(mount_under_fastapi=False)
+
+    if args.transport == "stdio":
+        asyncio.run(mcp.run_stdio_async())
+    elif args.transport == "sse":
+        asyncio.run(mcp.run_sse_async())
+    else:
+        asyncio.run(mcp.run_streamable_http_async())
+
+
+if __name__ == "__main__":
+    main()

--- a/src/md_generator/media/video/api/mcp_setup.py
+++ b/src/md_generator/media/video/api/mcp_setup.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import base64
+import os
+import re
+import tempfile
+from pathlib import Path
+
+from mcp.server.fastmcp import FastMCP
+
+from md_generator.media.video.api.settings import VideoApiSettings
+from md_generator.media.video.service import VideoToMarkdownService
+
+
+def _decode_base64(data: str) -> bytes:
+    s = data.strip()
+    if s.startswith("data:"):
+        parts = s.split(",", 1)
+        if len(parts) == 2:
+            s = parts[1]
+    return base64.b64decode(s, validate=False)
+
+
+def build_mcp_stack(*, mount_under_fastapi: bool = False) -> tuple[FastMCP, object]:
+    path = "/" if mount_under_fastapi else "/mcp"
+    mcp = FastMCP(
+        "video-to-md",
+        instructions="Extract audio from video, transcribe with Whisper, emit Markdown (paths or base64).",
+        streamable_http_path=path,
+    )
+    settings = VideoApiSettings()
+
+    @mcp.tool()
+    def transcribe_video_path(
+        video_path: str,
+        whisper_model: str = "base",
+        language: str | None = None,
+        title: str | None = None,
+    ) -> str:
+        """Transcribe a video file on disk; returns path to a temporary ``.md`` file on the server."""
+        src = Path(video_path).expanduser().resolve()
+        if not src.is_file():
+            raise ValueError("video_path must be an existing file")
+        svc = VideoToMarkdownService(whisper_model=whisper_model, language=language)
+        fd, name = tempfile.mkstemp(suffix=".md", prefix="video-mcp-")
+        os.close(fd)
+        out = Path(name)
+        try:
+            svc.write_markdown(src, out, title=title)
+        except Exception:
+            out.unlink(missing_ok=True)
+            raise
+        return str(out)
+
+    @mcp.tool()
+    def transcribe_video_base64(
+        video_base64: str,
+        filename: str = "upload.mp4",
+        whisper_model: str = "base",
+        language: str | None = None,
+        title: str | None = None,
+    ) -> str:
+        """Decode base64 video (optional ``data:*;base64,`` prefix), transcribe, return path to temporary ``.md``."""
+        raw = _decode_base64(video_base64)
+        max_b = settings.max_upload_mb * 1024 * 1024
+        if len(raw) > max_b:
+            raise ValueError(f"Decoded file exceeds MD_VIDEO_MAX_UPLOAD_MB ({settings.max_upload_mb})")
+        safe = re.sub(r"[^\w.\-]+", "_", filename) or "upload.mp4"
+        with tempfile.TemporaryDirectory() as td:
+            p = Path(td) / safe
+            p.write_bytes(raw)
+            svc = VideoToMarkdownService(whisper_model=whisper_model, language=language)
+            fd, name = tempfile.mkstemp(suffix=".md", prefix="video-mcp-b64-")
+            os.close(fd)
+            out = Path(name)
+            try:
+                svc.write_markdown(p, out, title=title)
+            except Exception:
+                out.unlink(missing_ok=True)
+                raise
+        return str(out)
+
+    sub = mcp.streamable_http_app()
+    return mcp, sub

--- a/src/md_generator/media/video/api/run.py
+++ b/src/md_generator/media/video/api/run.py
@@ -1,0 +1,30 @@
+"""Run the video REST + MCP FastAPI app with uvicorn."""
+
+from __future__ import annotations
+
+import argparse
+
+
+def main(argv: list[str] | None = None) -> int:
+    import uvicorn
+
+    from md_generator.media.video.api.settings import VideoApiSettings
+
+    p = argparse.ArgumentParser(description="video-to-md HTTP API (REST + MCP at /mcp)")
+    p.add_argument("--host", default=None)
+    p.add_argument("--port", type=int, default=None)
+    ns = p.parse_args(argv)
+    s = VideoApiSettings()
+    host = ns.host or s.api_host
+    port = ns.port if ns.port is not None else s.api_port
+    uvicorn.run(
+        "md_generator.media.video.api.main:create_app",
+        host=host,
+        port=port,
+        factory=True,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/md_generator/media/video/api/settings.py
+++ b/src/md_generator/media/video/api/settings.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class VideoApiSettings(BaseSettings):
+    model_config = SettingsConfigDict(
+        env_prefix="MD_VIDEO_",
+        env_file=".env",
+        extra="ignore",
+    )
+
+    max_upload_mb: int = 500
+    max_sync_upload_mb: int = 80
+    job_ttl_seconds: int = 3600
+    temp_dir: str | None = None
+    cors_origins: str = "*"
+    api_host: str = "127.0.0.1"
+    api_port: int = 8012
+
+
+def cors_list(settings: VideoApiSettings) -> list[str]:
+    raw = (settings.cors_origins or "*").strip()
+    if raw == "*":
+        return ["*"]
+    return [o.strip() for o in raw.split(",") if o.strip()]

--- a/src/md_generator/media/video/converter.py
+++ b/src/md_generator/media/video/converter.py
@@ -1,0 +1,104 @@
+"""Extract audio from video with ffmpeg; probe containers with ffprobe (``VideoConverter``)."""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+from md_generator.media.document_converter import (
+    DocumentConverter,
+    MediaToolsError,
+    VideoProbeResult,
+    require_ffmpeg_tools,
+    resolve_ffmpeg_executable,
+    video_probe_from_ffprobe,
+)
+
+
+class VideoConverter(DocumentConverter):
+    """ffprobe metadata + ffmpeg audio extraction (no transcription)."""
+
+    _DEFAULT_WAV_NAME = "extracted_audio.wav"
+    _FFMPEG_TIMEOUT = 3600
+
+    def convert(self, input_path: Path) -> VideoProbeResult:
+        """Return ffprobe-derived metadata only (no transcription)."""
+        path = Path(input_path).resolve()
+        if not path.is_file():
+            raise FileNotFoundError(path)
+        return video_probe_from_ffprobe(path)
+
+    def extract_audio(self, input_video: Path, tmp_dir: Path) -> Path:
+        """Extract a mono 16 kHz PCM WAV suitable for Whisper into ``tmp_dir``."""
+        require_ffmpeg_tools()
+        inp = Path(input_video).resolve()
+        if not inp.is_file():
+            raise FileNotFoundError(inp)
+        out_dir = Path(tmp_dir)
+        out_dir.mkdir(parents=True, exist_ok=True)
+        out_wav = out_dir / self._DEFAULT_WAV_NAME
+        ffmpeg = resolve_ffmpeg_executable()
+        cmd = [
+            ffmpeg,
+            "-hide_banner",
+            "-loglevel",
+            "error",
+            "-y",
+            "-i",
+            str(inp),
+            "-vn",
+            "-ac",
+            "1",
+            "-ar",
+            "16000",
+            "-acodec",
+            "pcm_s16le",
+            str(out_wav),
+        ]
+        try:
+            proc = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                timeout=self._FFMPEG_TIMEOUT,
+                check=False,
+            )
+        except FileNotFoundError as exc:
+            raise MediaToolsError("ffmpeg not found on PATH; install FFmpeg.") from exc
+        if proc.returncode != 0:
+            err = (proc.stderr or proc.stdout or "").strip()
+            raise MediaToolsError(err or f"ffmpeg failed with exit code {proc.returncode}")
+        if not out_wav.is_file():
+            raise MediaToolsError("ffmpeg did not produce the expected WAV output")
+        return out_wav
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(description="Transcribe video to Markdown (extract audio + Whisper).")
+    p.add_argument("input", type=Path, help="Input video file path")
+    p.add_argument("output", type=Path, help="Output .md file path")
+    p.add_argument("--model", default="base", help="Whisper model name (default: base)")
+    p.add_argument("--language", default=None, help="Force Whisper language code (optional)")
+    p.add_argument("--title", default=None, help="Override document title in Markdown")
+    p.add_argument("-v", "--verbose", action="store_true")
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    try:
+        from md_generator.media.video.service import VideoToMarkdownService
+
+        svc = VideoToMarkdownService(whisper_model=args.model, language=args.language)
+        out = svc.write_markdown(args.input, args.output, title=args.title)
+        if args.verbose:
+            print(f"Wrote {out}", file=sys.stderr)
+        return 0
+    except MediaToolsError as e:
+        print(str(e), file=sys.stderr)
+        return 2
+    except FileNotFoundError as e:
+        print(str(e), file=sys.stderr)
+        return 1

--- a/src/md_generator/media/video/converter.py
+++ b/src/md_generator/media/video/converter.py
@@ -80,7 +80,14 @@ def _build_parser() -> argparse.ArgumentParser:
     p.add_argument("input", type=Path, help="Input video file path")
     p.add_argument("output", type=Path, help="Output .md file path")
     p.add_argument("--model", default="base", help="Whisper model name (default: base)")
-    p.add_argument("--language", default=None, help="Force Whisper language code (optional)")
+    p.add_argument(
+        "--language",
+        default=None,
+        help=(
+            "Whisper language (default: auto-detect if omitted). Single code/name (e.g. en, hi) to force, "
+            "or hi,en / hinglish for Hindi+English mixed. Explicit auto / detect matches omitting the flag."
+        ),
+    )
     p.add_argument("--title", default=None, help="Override document title in Markdown")
     p.add_argument("-v", "--verbose", action="store_true")
     return p

--- a/src/md_generator/media/video/formatter.py
+++ b/src/md_generator/media/video/formatter.py
@@ -1,0 +1,81 @@
+"""Markdown for video: container/stream metadata plus reused timestamped transcript."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from md_generator.media.audio.converter import TranscriptionResult
+from md_generator.media.audio.formatter import format_timestamped_transcript
+from md_generator.media.document_converter import VideoProbeResult
+
+
+def _video_metadata_lines(video_path: Path, probe: VideoProbeResult) -> list[str]:
+    lines = [
+        f"- **Video file:** `{video_path.resolve()}`",
+    ]
+    if probe.duration_seconds is not None:
+        lines.append(f"- **Duration (seconds):** {probe.duration_seconds:.3f}")
+    if probe.format_name:
+        lines.append(f"- **Container / format:** {probe.format_name}")
+    if probe.size_bytes is not None:
+        lines.append(f"- **Size (bytes):** {probe.size_bytes}")
+    if probe.video_codec:
+        lines.append(f"- **Video codec:** {probe.video_codec}")
+    if probe.video_width and probe.video_height:
+        lines.append(f"- **Resolution:** {probe.video_width}×{probe.video_height}")
+    if probe.audio_codec:
+        lines.append(f"- **Muxed audio codec:** {probe.audio_codec}")
+    if probe.sample_rate is not None:
+        lines.append(f"- **Muxed audio sample rate (Hz):** {probe.sample_rate}")
+    return lines
+
+
+def _transcription_metadata_lines(tr: TranscriptionResult) -> list[str]:
+    meta = tr.metadata
+    lines = [
+        "- **Pipeline:** audio extracted to mono 16 kHz WAV, then transcribed with Whisper",
+        f"- **Whisper model:** {meta.whisper_model}",
+    ]
+    if meta.whisper_language:
+        lines.append(f"- **Detected / set language:** {meta.whisper_language}")
+    return lines
+
+
+class VideoMarkdownFormatter:
+    """Compose video probe metadata with transcript from ``TranscriptionResult``."""
+
+    def format(
+        self,
+        *,
+        video_path: Path,
+        probe: VideoProbeResult,
+        transcription: TranscriptionResult,
+        title_override: str | None = None,
+    ) -> str:
+        title = (
+            title_override
+            or probe.format_tags_title
+            or Path(video_path).stem
+            or transcription.metadata.title
+            or "Untitled"
+        ).strip()
+
+        parts = [
+            f"# {title}",
+            "",
+            "## Metadata",
+            "",
+            "### Video",
+            "",
+            *_video_metadata_lines(Path(video_path), probe),
+            "",
+            "### Transcription",
+            "",
+            *_transcription_metadata_lines(transcription),
+            "",
+            "## Transcript",
+            "",
+            format_timestamped_transcript(transcription.segments),
+            "",
+        ]
+        return "\n".join(parts).rstrip() + "\n"

--- a/src/md_generator/media/video/service.py
+++ b/src/md_generator/media/video/service.py
@@ -1,0 +1,79 @@
+"""Video → Markdown: ffmpeg extract + delegate transcription to ``AudioToMarkdownService``."""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+from md_generator.media.audio.converter import TranscriptionResult
+from md_generator.media.audio.service import AudioToMarkdownService
+from md_generator.media.document_converter import VideoProbeResult
+from md_generator.media.video.converter import VideoConverter
+from md_generator.media.video.formatter import VideoMarkdownFormatter
+
+
+class VideoToMarkdownService:
+    """Extract audio from video, transcribe via audio service only, then format."""
+
+    def __init__(
+        self,
+        *,
+        video_converter: VideoConverter | None = None,
+        audio_service: AudioToMarkdownService | None = None,
+        formatter: VideoMarkdownFormatter | None = None,
+        whisper_model: str = "base",
+        language: str | None = None,
+    ) -> None:
+        self._video = video_converter or VideoConverter()
+        self._audio = audio_service or AudioToMarkdownService(whisper_model=whisper_model, language=language)
+        self._formatter = formatter or VideoMarkdownFormatter()
+
+    @property
+    def video_converter(self) -> VideoConverter:
+        return self._video
+
+    @property
+    def audio_service(self) -> AudioToMarkdownService:
+        return self._audio
+
+    @property
+    def formatter(self) -> VideoMarkdownFormatter:
+        return self._formatter
+
+    def probe(self, input_video: Path) -> VideoProbeResult:
+        return self._video.convert(Path(input_video))
+
+    def transcribe_via_extracted_audio(
+        self,
+        input_video: Path,
+    ) -> tuple[VideoProbeResult, TranscriptionResult]:
+        """Extract audio to a temp WAV and return ``(probe, transcription)``."""
+        video_path = Path(input_video).resolve()
+        probe = self.probe(video_path)
+        with tempfile.TemporaryDirectory() as td:
+            wav_path = self._video.extract_audio(video_path, Path(td))
+            transcription = self._audio.transcribe(wav_path)
+        return probe, transcription
+
+    def to_markdown(self, input_video: Path, *, title: str | None = None) -> str:
+        probe, transcription = self.transcribe_via_extracted_audio(Path(input_video))
+        return self._formatter.format(
+            video_path=Path(input_video),
+            probe=probe,
+            transcription=transcription,
+            title_override=title,
+        )
+
+    def write_markdown(
+        self,
+        input_video: Path,
+        output_md: Path,
+        *,
+        title: str | None = None,
+        encoding: str = "utf-8",
+    ) -> Path:
+        output_md = Path(output_md)
+        output_md.parent.mkdir(parents=True, exist_ok=True)
+        body = self.to_markdown(input_video, title=title)
+        output_md.write_text(body, encoding=encoding)
+        return output_md

--- a/src/md_generator/media/whisper_language.py
+++ b/src/md_generator/media/whisper_language.py
@@ -1,0 +1,78 @@
+"""Map user-facing ``language`` strings to Whisper ``language`` / ``initial_prompt`` kwargs."""
+
+from __future__ import annotations
+
+import re
+from typing import Final
+
+# Whisper is single-language per ``language=``; for Hindi+English mixes we auto-detect and bias with a prompt.
+_BILINGUAL_HI_EN_PROMPT: Final[str] = (
+    "This audio may contain both Hindi and English (including code-switching). "
+    "Transcribe Hindi in Devanagari where appropriate and English in the Latin alphabet."
+)
+
+
+def _token_to_whisper_code(tok: str, *, languages: dict, to_code: dict) -> str | None:
+    t = tok.strip().lower()
+    if not t:
+        return None
+    if t in languages:
+        return t
+    return to_code.get(t)
+
+
+def resolve_whisper_language(language: str | None) -> tuple[str | None, str | None, str | None]:
+    """
+    Return ``(whisper_language, initial_prompt, language_profile)`` for ``model.transcribe``.
+
+    * ``whisper_language`` — passed as ``language=`` when a single supported code is chosen.
+    * ``initial_prompt`` — passed as ``initial_prompt=`` for mixed Hindi/English (or multi-code) hints.
+    * ``language_profile`` — short label for Markdown metadata (e.g. ``hi+en (mixed)``).
+
+    When ``language`` is omitted or blank, Whisper uses **automatic language detection** (same as
+    passing ``auto`` / ``detect`` / ``none`` / ``multilingual``). Pass a single code (e.g. ``en``)
+    to force that language.
+    """
+    if language is None:
+        return None, None, None
+    raw = str(language).strip()
+    if not raw:
+        return None, None, None
+
+    lower = raw.lower()
+    if lower in ("auto", "detect", "none", "multilingual"):
+        return None, None, None
+
+    if "hinglish" in lower.replace(" ", ""):
+        return None, _BILINGUAL_HI_EN_PROMPT, "Hindi+English (Hinglish)"
+
+    from whisper.tokenizer import LANGUAGES, TO_LANGUAGE_CODE
+
+    parts = [p for p in re.split(r"[,+/|;]+|\s+", raw) if p.strip()]
+    if not parts:
+        parts = [raw]
+
+    codes: list[str] = []
+    for p in parts:
+        code = _token_to_whisper_code(p, languages=LANGUAGES, to_code=TO_LANGUAGE_CODE)
+        if code and code not in codes:
+            codes.append(code)
+
+    if len(codes) >= 2:
+        if set(codes) == {"hi", "en"}:
+            return None, _BILINGUAL_HI_EN_PROMPT, "hi+en (mixed, auto-detect)"
+        langs = ", ".join(codes)
+        prompt = (
+            f"This audio may contain multiple spoken languages including: {langs}. "
+            "Use each language's usual writing system where appropriate."
+        )
+        return None, prompt, "+".join(codes) + " (mixed, auto-detect)"
+
+    if len(codes) == 1:
+        return codes[0], None, None
+
+    # One segment that did not map (e.g. typo): try whole string once, else auto-detect
+    fallback = _token_to_whisper_code(raw, languages=LANGUAGES, to_code=TO_LANGUAGE_CODE)
+    if fallback:
+        return fallback, None, fallback
+    return None, None, raw

--- a/video-to-md/converter.py
+++ b/video-to-md/converter.py
@@ -1,0 +1,8 @@
+"""Shim CLI: prefer `md-video` after `pip install mdengine[video]`."""
+
+from __future__ import annotations
+
+from md_generator.media.video.converter import main
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/video-to-md/pytest.ini
+++ b/video-to-md/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+pythonpath = ../src
+testpaths = tests

--- a/video-to-md/requirements.txt
+++ b/video-to-md/requirements.txt
@@ -1,0 +1,2 @@
+openai-whisper>=20231117
+pytest>=8.0.0

--- a/video-to-md/tests/test_video_api.py
+++ b/video-to-md/tests/test_video_api.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from md_generator.media.video.service import VideoToMarkdownService
+
+
+@pytest.fixture()
+def _patch_write(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_write_markdown(
+        self: VideoToMarkdownService,
+        input_video: Path,
+        output_md: Path,
+        *,
+        title: str | None = None,
+        encoding: str = "utf-8",
+    ) -> Path:
+        output_md = Path(output_md)
+        output_md.parent.mkdir(parents=True, exist_ok=True)
+        output_md.write_text("# video stub\n", encoding=encoding)
+        return output_md
+
+    monkeypatch.setattr(VideoToMarkdownService, "write_markdown", fake_write_markdown)
+
+
+def test_sync_rejects_bad_extension(_patch_write: None) -> None:
+    pytest.importorskip("fastapi")
+    from fastapi.testclient import TestClient
+
+    from md_generator.media.video.api.main import create_app
+
+    with TestClient(create_app()) as client:
+        r = client.post(
+            "/convert/sync",
+            files={"file": ("x.mp3", b"hi", "audio/mpeg")},
+        )
+        assert r.status_code == 400
+
+
+def test_sync_accepts_mp4(_patch_write: None) -> None:
+    pytest.importorskip("fastapi")
+    from fastapi.testclient import TestClient
+
+    from md_generator.media.video.api.main import create_app
+
+    with TestClient(create_app()) as client:
+        r = client.post(
+            "/convert/sync",
+            files={"file": ("a.mp4", b"fake", "video/mp4")},
+        )
+        assert r.status_code == 200, r.text
+        assert "video stub" in r.text
+
+
+def test_jobs_flow(_patch_write: None) -> None:
+    pytest.importorskip("fastapi")
+    import time
+
+    from fastapi.testclient import TestClient
+
+    from md_generator.media.video.api.main import create_app
+
+    with TestClient(create_app()) as client:
+        r = client.post(
+            "/convert/jobs",
+            files={"file": ("a.mp4", b"fake", "video/mp4")},
+        )
+        assert r.status_code == 200, r.text
+        jid = r.json()["job_id"]
+        for _ in range(50):
+            st = client.get(f"/convert/jobs/{jid}").json()
+            if st["status"] == "done":
+                break
+            if st["status"] == "failed":
+                pytest.fail(st.get("error"))
+            time.sleep(0.05)
+        dl = client.get(f"/convert/jobs/{jid}/download")
+        assert dl.status_code == 200
+        assert "video stub" in dl.text

--- a/video-to-md/tests/test_video_formatter.py
+++ b/video-to-md/tests/test_video_formatter.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from md_generator.media.audio.converter import MediaMetadata, TranscriptSegment, TranscriptionResult
+from md_generator.media.document_converter import VideoProbeResult
+from md_generator.media.video.formatter import VideoMarkdownFormatter
+
+
+def test_video_markdown_formatter_merges_sections() -> None:
+    probe = VideoProbeResult(
+        path=Path("in.mp4"),
+        duration_seconds=9.0,
+        format_name="mov,mp4",
+        format_tags_title="Tagged",
+        size_bytes=1000,
+        video_codec="h264",
+        video_width=640,
+        video_height=480,
+        audio_codec="aac",
+        sample_rate=44100,
+        raw_ffprobe={},
+    )
+    meta = MediaMetadata(
+        title="ignored-for-video-title",
+        duration_seconds=9.0,
+        container="wav",
+        audio_codec="pcm_s16le",
+        sample_rate=16000,
+        whisper_language="en",
+        whisper_model="base",
+        source_path="/tmp/extracted.wav",
+    )
+    tr = TranscriptionResult(
+        metadata=meta,
+        segments=(TranscriptSegment(1.0, 2.0, "line", 0),),
+        plain_text="line",
+    )
+    md = VideoMarkdownFormatter().format(
+        video_path=Path("clip.mp4"),
+        probe=probe,
+        transcription=tr,
+        title_override="Override",
+    )
+    assert md.startswith("# Override\n")
+    assert "### Video" in md
+    assert "### Transcription" in md
+    assert "## Transcript" in md
+    assert "640×480" in md
+    assert "[0:01.000 --> 0:02.000] line" in md

--- a/video-to-md/tests/test_video_service_flow.py
+++ b/video-to-md/tests/test_video_service_flow.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from md_generator.media.audio.converter import MediaMetadata, TranscriptSegment, TranscriptionResult
+from md_generator.media.audio.service import AudioToMarkdownService
+from md_generator.media.document_converter import VideoProbeResult
+from md_generator.media.video.converter import VideoConverter
+from md_generator.media.video.formatter import VideoMarkdownFormatter
+from md_generator.media.video.service import VideoToMarkdownService
+
+
+def test_video_service_delegates_transcription_to_audio_service(tmp_path: Path) -> None:
+    video = tmp_path / "v.mp4"
+    video.write_bytes(b"not-a-real-video")
+
+    probe = VideoProbeResult(
+        path=video,
+        duration_seconds=3.0,
+        format_name="mov,mp4",
+        format_tags_title=None,
+        size_bytes=10,
+        video_codec="h264",
+        video_width=10,
+        video_height=10,
+        audio_codec="aac",
+        sample_rate=48000,
+        raw_ffprobe={},
+    )
+    tr = TranscriptionResult(
+        metadata=MediaMetadata(
+            title="x",
+            duration_seconds=3.0,
+            container="wav",
+            audio_codec="pcm_s16le",
+            sample_rate=16000,
+            whisper_language="en",
+            whisper_model="base",
+            source_path=str(tmp_path / "extracted_audio.wav"),
+        ),
+        segments=(TranscriptSegment(0.0, 1.0, "delegated", 0),),
+        plain_text="delegated",
+    )
+
+    class VC(VideoConverter):
+        def convert(self, input_path: Path) -> VideoProbeResult:  # type: ignore[override]
+            return probe
+
+        def extract_audio(self, input_video: Path, tmp_dir: Path) -> Path:  # noqa: ARG002
+            out = Path(tmp_dir) / "extracted_audio.wav"
+            out.write_bytes(b"RIFF")
+            return out
+
+    mock_audio = MagicMock(spec=AudioToMarkdownService)
+    mock_audio.transcribe.return_value = tr
+
+    svc = VideoToMarkdownService(
+        video_converter=VC(),
+        audio_service=mock_audio,
+        formatter=VideoMarkdownFormatter(),
+    )
+    md = svc.to_markdown(video)
+    assert "delegated" in md
+    mock_audio.transcribe.assert_called_once()
+    called_path = mock_audio.transcribe.call_args[0][0]
+    assert called_path.name == "extracted_audio.wav"


### PR DESCRIPTION
## Summary

Adds **standalone audio → Markdown** conversion and **video → Markdown** by routing video through the same transcription pipeline as audio (extract audio / WAV, then Whisper). Includes **CLI entry points**, optional **HTTP API** and **MCP** commands for both media types, and aligns packaging/docs with the new **`audio`** / **`video`** optional extras.

Related issues (enhancement):

- feat(audio-to-md): Implement standalone audio to markdown conversion module  
- feat(video-to-md): Implement video to markdown module using audio-to-md pipeline  

## What’s included

- **Audio:** `md-audio` CLI; `audio` extra (`openai-whisper`, `imageio-ffmpeg` for bundled ffmpeg when needed).
- **Video:** `md-video` CLI; `video` extra (same ML stack; ffmpeg-based extraction to mono 16 kHz WAV before transcription).
- **Services:** `md-audio-api` / `md-video-api`, `md-audio-mcp` / `md-video-mcp` where implemented in-tree.
- **Docs / metadata:** README and `pyproject.toml` description mention **audio** and **video**; optional extras table updated.

## How to try it

```bash
pip install -e ".[audio]"
md-audio --help

pip install -e ".[video]"
md-video --help