### PR TITLE
feat(youtube-to-md): YouTube URL → Markdown with transcript and fallbacks (#6)

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,10 +120,13 @@ If the shell reports “command not found”, ensure the Python **Scripts** dire
 | `md-url` | `md_generator.url.converter:main` | `md-url https://example.com/doc ./web-out --artifact-layout` |
 | `md-audio` | `md_generator.media.audio.converter:main` | `md-audio clip.mp3 transcript.md --model base` |
 | `md-video` | `md_generator.media.video.converter:main` | `md-video clip.mp4 transcript.md --model base` |
+| `md-youtube` | `md_generator.media.youtube.converter:main` | `md-youtube "https://youtu.be/…" out.md --transcript-lang en` |
 | `md-audio-api` | `md_generator.media.audio.api.run:main` | REST + MCP on port **8011** (see [Audio and video to Markdown](#audio-and-video-to-markdown)) |
 | `md-video-api` | `md_generator.media.video.api.run:main` | REST + MCP on port **8012** |
+| `md-youtube-api` | `md_generator.media.youtube.api.run:main` | REST + MCP on port **8013** (JSON `url` body; see same section) |
 | `md-audio-mcp` | `md_generator.media.audio.api.mcp_server:main` | Standalone MCP (`--transport stdio` \| `sse` \| `streamable-http`) |
 | `md-video-mcp` | `md_generator.media.video.api.mcp_server:main` | Same for video |
+| `md-youtube-mcp` | `md_generator.media.youtube.api.mcp_server:main` | Same for YouTube (`youtube_url_to_markdown`) |
 
 Every command accepts **`-h` / `--help`** for full flags (artifact layout, OCR, ZIP options, etc.).
 
@@ -337,6 +340,7 @@ Library code lives under **`md_generator.media`**: shared probing in [`document_
 ```bash
 pip install "mdengine[audio,api,mcp]"    # audio CLI + HTTP + MCP
 pip install "mdengine[video,api,mcp]"   # video CLI + HTTP + MCP (same ML stack as audio)
+pip install "mdengine[youtube,api,mcp]" # YouTube URL → Markdown (captions + metadata; optional Whisper fallback)
 ```
 
 ### Python library
@@ -365,6 +369,18 @@ md = svc.to_markdown(Path("input.mp4"), title=None)
 svc.write_markdown(Path("input.mp4"), Path("out/transcript.md"))
 ```
 
+**YouTube** — captions API + page metadata (BeautifulSoup / oEmbed); optional **yt-dlp + Whisper** when captions are missing (`mdengine[audio]` and `yt-dlp` on `PATH`, or `MD_YOUTUBE_YTDLP`):
+
+```python
+from md_generator.media.youtube import YouTubeToMarkdownService
+
+svc = YouTubeToMarkdownService(whisper_model="base")
+md = svc.to_markdown("https://www.youtube.com/watch?v=VIDEO_ID", transcript_languages=["en"])
+svc.write_markdown("https://youtu.be/VIDEO_ID", Path("out/youtube.md"))
+```
+
+For file-based pipelines, [`YouTubeConverter`](src/md_generator/media/youtube/converter.py) reads a `.url` / `.yturl` / `.youtube` file (or a `.txt` whose first non-comment line is a YouTube URL) and implements [`DocumentConverter`](src/md_generator/media/document_converter.py).
+
 Public symbols are also re-exported from [`md_generator.media`](src/md_generator/media/__init__.py) for ffprobe helpers (`ffprobe_json`, `VideoProbeResult`, …).
 
 ### REST API (FastAPI)
@@ -379,13 +395,15 @@ Each service exposes the same job pattern as other converters:
 | `GET /convert/jobs/{job_id}/download` | Markdown when `done`; workspace removed after download. |
 
 **Audio** defaults: `MD_AUDIO_MAX_UPLOAD_MB=200`, `MD_AUDIO_MAX_SYNC_UPLOAD_MB=40`, `MD_AUDIO_API_PORT=8011`.  
-**Video** defaults: `MD_VIDEO_MAX_UPLOAD_MB=500`, `MD_VIDEO_MAX_SYNC_UPLOAD_MB=80`, `MD_VIDEO_API_PORT=8012`.
+**Video** defaults: `MD_VIDEO_MAX_UPLOAD_MB=500`, `MD_VIDEO_MAX_SYNC_UPLOAD_MB=80`, `MD_VIDEO_API_PORT=8012`.  
+**YouTube** uses **JSON** (not multipart): `POST /convert/sync` and `POST /convert/jobs` accept `{"url":"https://www.youtube.com/watch?v=…","title":null,"transcript_languages":["en"],"enable_audio_fallback":true,"whisper_model":"base","language":null}`. Defaults: `MD_YOUTUBE_API_PORT=8013`, `MD_YOUTUBE_JOB_TTL_SECONDS`, `MD_YOUTUBE_CORS_ORIGINS`, `MD_YOUTUBE_TEMP_DIR`.
 
 Run with the bundled runners (each call builds the app with **`factory=True`** for a clean MCP session manager):
 
 ```bash
 md-audio-api --host 127.0.0.1 --port 8011
 md-video-api --host 127.0.0.1 --port 8012
+md-youtube-api --host 127.0.0.1 --port 8013
 ```
 
 Or with Uvicorn directly (the ASGI app is built by **`create_app()`** so each worker gets its own MCP session manager):
@@ -393,6 +411,7 @@ Or with Uvicorn directly (the ASGI app is built by **`create_app()`** so each wo
 ```bash
 uvicorn md_generator.media.audio.api.main:create_app --factory --host 127.0.0.1 --port 8011
 uvicorn md_generator.media.video.api.main:create_app --factory --host 127.0.0.1 --port 8012
+uvicorn md_generator.media.youtube.api.main:create_app --factory --host 127.0.0.1 --port 8013
 ```
 
 The module also defines **`app = create_app()`** for a single-process target: `uvicorn md_generator.media.audio.api.main:app` (no `--factory`).
@@ -401,7 +420,7 @@ Swagger is at **`/docs`** when the app is running.
 
 ### MCP (stdio, SSE, streamable HTTP)
 
-1. **With FastAPI** — start `md-audio-api` or `md-video-api`; mount Streamable HTTP MCP at **`http://<host>:<port>/mcp`** (same host as REST).
+1. **With FastAPI** — start `md-audio-api`, `md-video-api`, or `md-youtube-api`; mount Streamable HTTP MCP at **`http://<host>:<port>/mcp`** (same host as REST).
 2. **Standalone** — process speaks MCP only:
 
 ```bash
@@ -409,16 +428,18 @@ md-audio-mcp --transport stdio
 md-audio-mcp --transport sse
 md-audio-mcp --transport streamable-http
 md-video-mcp --transport stdio
+md-youtube-mcp --transport stdio
 ```
 
 **Audio MCP tools:** `transcribe_audio_path`, `transcribe_audio_base64`.  
-**Video MCP tools:** `transcribe_video_path`, `transcribe_video_base64`.
+**Video MCP tools:** `transcribe_video_path`, `transcribe_video_base64`.  
+**YouTube MCP tool:** `youtube_url_to_markdown`.
 
-Equivalent modules: `python -m md_generator.media.audio.api.mcp_server`, `python -m md_generator.media.video.api.mcp_server`.
+Equivalent modules: `python -m md_generator.media.audio.api.mcp_server`, `python -m md_generator.media.video.api.mcp_server`, `python -m md_generator.media.youtube.api.mcp_server`.
 
 ### Thin shims (repo clone)
 
-[`audio-to-md/converter.py`](audio-to-md/converter.py) and [`video-to-md/converter.py`](video-to-md/converter.py) delegate to the same `main` as `md-audio` / `md-video`. Tests and `pytest.ini` live under `audio-to-md/tests/` and `video-to-md/tests/`.
+[`audio-to-md/converter.py`](audio-to-md/converter.py), [`video-to-md/converter.py`](video-to-md/converter.py), and [`youtube-to-md/converter.py`](youtube-to-md/converter.py) delegate to the same `main` as `md-audio` / `md-video` / `md-youtube`. Tests and `pytest.ini` live under `audio-to-md/tests/`, `video-to-md/tests/`, and `youtube-to-md/tests/`.
 
 ---
 
@@ -449,6 +470,7 @@ Install `mdengine[api]` plus the format extra(s), then run the **`app`** object 
 | URL / HTML | `md_generator.url.api.main:app` | `url`, `api`, `mcp` |
 | Audio (Whisper) | `md_generator.media.audio.api.main:create_app` (use **`--factory`**) or `…main:app` | `audio`, `api`, `mcp` |
 | Video (Whisper) | `md_generator.media.video.api.main:create_app` (use **`--factory`**) or `…main:app` | `video`, `api`, `mcp` |
+| YouTube | `md_generator.media.youtube.api.main:create_app` (use **`--factory`**) or `…main:app` | `youtube`, `api`, `mcp` |
 
 Examples:
 
@@ -459,6 +481,7 @@ uvicorn md_generator.archive.api.main:app --host 127.0.0.1 --port 8010
 uvicorn md_generator.url.api.main:app --host 127.0.0.1 --port 8011
 uvicorn md_generator.media.audio.api.main:create_app --factory --host 127.0.0.1 --port 8011
 uvicorn md_generator.media.video.api.main:create_app --factory --host 127.0.0.1 --port 8012
+uvicorn md_generator.media.youtube.api.main:create_app --factory --host 127.0.0.1 --port 8013
 ```
 
 ### MCP over HTTP on the same server
@@ -480,6 +503,7 @@ Prefixes differ per service (often read from a `.env` file next to the process):
 | URL | `URL_TO_MD_` | `URL_TO_MD_MAX_SYNC_URLS`, `URL_TO_MD_MAX_SYNC_CRAWL_PAGES`, `URL_TO_MD_MAX_JOB_URLS`, `URL_TO_MD_JOB_TTL_SECONDS`, `URL_TO_MD_TEMP_DIR`, `URL_TO_MD_CORS_ORIGINS` |
 | Audio API | `MD_AUDIO_` | `MD_AUDIO_MAX_UPLOAD_MB`, `MD_AUDIO_MAX_SYNC_UPLOAD_MB`, `MD_AUDIO_JOB_TTL_SECONDS`, `MD_AUDIO_TEMP_DIR`, `MD_AUDIO_CORS_ORIGINS`, `MD_AUDIO_API_HOST`, `MD_AUDIO_API_PORT` |
 | Video API | `MD_VIDEO_` | Same pattern as audio with `MD_VIDEO_*` (defaults: larger upload/sync caps, port **8012**) |
+| YouTube API | `MD_YOUTUBE_` | `MD_YOUTUBE_JOB_TTL_SECONDS`, `MD_YOUTUBE_TEMP_DIR`, `MD_YOUTUBE_CORS_ORIGINS`, `MD_YOUTUBE_API_HOST`, `MD_YOUTUBE_API_PORT` (default **8013**); optional `MD_YOUTUBE_YTDLP` path for audio fallback |
 
 Exact variable names match the `ApiSettings` / helper functions in each `api/settings` or `api/app` module.
 
@@ -505,6 +529,7 @@ Two usage patterns:
 | URL / HTML | `python -m md_generator.url.api.mcp_server` / `--transport sse` / `--transport streamable-http` |
 | Audio | `md-audio-mcp` or `python -m md_generator.media.audio.api.mcp_server` — `--transport stdio` (default), `sse`, `streamable-http` |
 | Video | `md-video-mcp` or `python -m md_generator.media.video.api.mcp_server` — same transports |
+| YouTube | `md-youtube-mcp` or `python -m md_generator.media.youtube.api.mcp_server` — same transports |
 
 **Word** and **XLSX** also ship a small runner script in the repo:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mdengine"
-version = "0.3.0"
+version = "0.4.0"
 description = "Convert PDF, Office, images, audio, video, text/JSON/XML, ZIP archives, and web URLs to Markdown."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ requires-python = ">=3.10"
 license = "MIT"
 license-files = ["LICENSE"]
 authors = [{ name = "mdengine contributors" }]
-keywords = ["markdown", "pdf", "docx", "pptx", "xlsx", "ocr", "zip", "url", "html"]
+keywords = ["markdown", "pdf", "docx", "pptx", "xlsx", "ocr", "zip", "url", "html", "youtube"]
 classifiers = [
   "Programming Language :: Python :: 3",
   "Programming Language :: Python :: 3 :: Only",
@@ -76,6 +76,12 @@ url-full = [
 audio = ["openai-whisper>=20231117", "imageio-ffmpeg>=0.5.1"]
 # Same ML stack as audio; ships a bundled ``ffmpeg`` binary when the system has none.
 video = ["openai-whisper>=20231117", "imageio-ffmpeg>=0.5.1"]
+youtube = [
+  "youtube-transcript-api>=0.6.0",
+  "httpx>=0.27.0",
+  "beautifulsoup4>=4.12.0",
+  "lxml>=5.0.0",
+]
 api = [
   "fastapi>=0.115.0",
   "uvicorn[standard]>=0.32.0",
@@ -87,6 +93,9 @@ mcp = ["mcp>=1.2.0", "fastmcp>=2.3.0"]
 dev = [
   "pytest>=8.0.0",
   "httpx>=0.27.0",
+  "beautifulsoup4>=4.12.0",
+  "lxml>=5.0.0",
+  "youtube-transcript-api>=0.6.0",
   "mdengine[api]",
   "mdengine[mcp]",
   "mdengine[url]",
@@ -116,6 +125,7 @@ all = [
   "beautifulsoup4>=4.12.0",
   "lxml_html_clean>=0.4.0",
   "readability-lxml>=0.8.1",
+  "youtube-transcript-api>=0.6.0",
 ]
 
 [project.urls]
@@ -138,6 +148,9 @@ md-audio-api = "md_generator.media.audio.api.run:main"
 md-video-api = "md_generator.media.video.api.run:main"
 md-audio-mcp = "md_generator.media.audio.api.mcp_server:main"
 md-video-mcp = "md_generator.media.video.api.mcp_server:main"
+md-youtube = "md_generator.media.youtube.converter:main"
+md-youtube-api = "md_generator.media.youtube.api.run:main"
+md-youtube-mcp = "md_generator.media.youtube.api.mcp_server:main"
 
 [tool.setuptools.packages.find]
 where = ["src"]
@@ -155,5 +168,6 @@ testpaths = [
   "url-to-md/tests",
   "audio-to-md/tests",
   "video-to-md/tests",
+  "youtube-to-md/tests",
 ]
 markers = ["integration: optional dependency or slower checks"]

--- a/src/md_generator/__init__.py
+++ b/src/md_generator/__init__.py
@@ -1,5 +1,5 @@
 """md_generator: PDF, Office, image, text, and ZIP to Markdown conversion."""
 
-__version__ = "0.3.0"
+__version__ = "0.4.0"
 
 __all__ = ["__version__"]

--- a/src/md_generator/media/youtube/__init__.py
+++ b/src/md_generator/media/youtube/__init__.py
@@ -1,0 +1,34 @@
+"""YouTube URL → Markdown (metadata, description, timestamped transcript)."""
+
+from __future__ import annotations
+
+from md_generator.media.youtube.converter import YouTubeConverter
+from md_generator.media.youtube.formatter import YouTubeMarkdownFormatter
+from md_generator.media.youtube.metadata import (
+    YouTubeMetadataError,
+    extract_video_id,
+    fetch_youtube_metadata,
+    normalize_youtube_url,
+)
+from md_generator.media.youtube.service import (
+    YouTubeConversionResult,
+    YouTubeError,
+    YouTubeToMarkdownService,
+    read_youtube_url_from_path,
+)
+from md_generator.media.youtube.transcript import YouTubeTranscriptError, fetch_transcript
+
+__all__ = [
+    "YouTubeConversionResult",
+    "YouTubeConverter",
+    "YouTubeError",
+    "YouTubeMarkdownFormatter",
+    "YouTubeMetadataError",
+    "YouTubeToMarkdownService",
+    "YouTubeTranscriptError",
+    "extract_video_id",
+    "fetch_transcript",
+    "fetch_youtube_metadata",
+    "normalize_youtube_url",
+    "read_youtube_url_from_path",
+]

--- a/src/md_generator/media/youtube/api/__init__.py
+++ b/src/md_generator/media/youtube/api/__init__.py
@@ -1,0 +1,1 @@
+"""YouTube REST API and MCP entrypoints."""

--- a/src/md_generator/media/youtube/api/main.py
+++ b/src/md_generator/media/youtube/api/main.py
@@ -1,0 +1,140 @@
+"""FastAPI: JSON URL conversion (sync + jobs) and Streamable HTTP MCP at ``/mcp``."""
+
+from __future__ import annotations
+
+import tempfile
+from contextlib import asynccontextmanager
+from pathlib import Path
+
+from fastapi import FastAPI, HTTPException, Request
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import FileResponse, Response
+from pydantic import BaseModel, Field
+from starlette.background import BackgroundTask
+
+from md_generator.media.job_store import MediaJobStore
+from md_generator.media.youtube.api.mcp_setup import build_mcp_stack
+from md_generator.media.youtube.api.settings import YouTubeApiSettings, cors_list
+from md_generator.media.youtube.metadata import extract_video_id
+from md_generator.media.youtube.service import YouTubeError, YouTubeToMarkdownService
+
+
+class YouTubeConvertRequest(BaseModel):
+    url: str = Field(..., min_length=1, description="YouTube watch, youtu.be, shorts, or embed URL")
+    title: str | None = None
+    transcript_languages: list[str] | None = None
+    enable_audio_fallback: bool = True
+    whisper_model: str = "base"
+    language: str | None = Field(default=None, description="Whisper language if audio fallback runs")
+
+
+def _validate_url(url: str) -> str:
+    u = url.strip()
+    if extract_video_id(u) is None:
+        raise HTTPException(status_code=400, detail="Invalid or unsupported YouTube URL")
+    return u
+
+
+def create_app() -> FastAPI:
+    mcp, mcp_http = build_mcp_stack(mount_under_fastapi=True)
+
+    @asynccontextmanager
+    async def lifespan(application: FastAPI):
+        settings = YouTubeApiSettings()
+        base = Path(settings.temp_dir) if settings.temp_dir else None
+        store = MediaJobStore(base, settings.job_ttl_seconds)
+        store.start_sweeper()
+        application.state.settings = settings
+        application.state.job_store = store
+        async with mcp.session_manager.run():
+            yield
+
+    app = FastAPI(title="youtube-to-md", lifespan=lifespan)
+    app.mount("/mcp", mcp_http)
+
+    _bootstrap = YouTubeApiSettings()
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=cors_list(_bootstrap),
+        allow_credentials="*" not in cors_list(_bootstrap),
+        allow_methods=["*"],
+        allow_headers=["*"],
+    )
+
+    @app.post("/convert/sync")
+    async def convert_sync(body: YouTubeConvertRequest) -> Response:
+        url = _validate_url(body.url)
+        with tempfile.TemporaryDirectory(prefix="yt-sync-") as td_name:
+            out = Path(td_name) / "transcript.md"
+            svc = YouTubeToMarkdownService(whisper_model=body.whisper_model, whisper_language=body.language)
+            try:
+                svc.write_markdown(
+                    url,
+                    out,
+                    title=body.title,
+                    transcript_languages=body.transcript_languages,
+                    enable_audio_fallback=body.enable_audio_fallback,
+                )
+            except YouTubeError as e:
+                raise HTTPException(status_code=422, detail=str(e)) from e
+            md = out.read_text(encoding="utf-8")
+        return Response(
+            content=md.encode("utf-8"),
+            media_type="text/markdown; charset=utf-8",
+            headers={"Content-Disposition": 'attachment; filename="transcript.md"'},
+        )
+
+    @app.post("/convert/jobs")
+    async def convert_jobs(request: Request, body: YouTubeConvertRequest) -> dict:
+        url = _validate_url(body.url)
+        store: MediaJobStore = request.app.state.job_store
+        job = store.create_job()
+        out = job.workspace / "transcript.md"
+
+        def work() -> None:
+            svc = YouTubeToMarkdownService(whisper_model=body.whisper_model, whisper_language=body.language)
+            svc.write_markdown(
+                url,
+                out,
+                title=body.title,
+                transcript_languages=body.transcript_languages,
+                enable_audio_fallback=body.enable_audio_fallback,
+            )
+            job.result_path = out
+
+        store.run_async(job, work)
+        return {"job_id": job.job_id, "status": job.status}
+
+    @app.get("/convert/jobs/{job_id}")
+    async def job_status(request: Request, job_id: str) -> dict:
+        store: MediaJobStore = request.app.state.job_store
+        job = store.get(job_id)
+        if not job:
+            raise HTTPException(404, detail="Unknown job_id")
+        return {
+            "status": job.status,
+            "error": job.error,
+            "created_at": job.created_at,
+        }
+
+    @app.get("/convert/jobs/{job_id}/download", response_class=FileResponse)
+    async def job_download(request: Request, job_id: str) -> FileResponse:
+        store: MediaJobStore = request.app.state.job_store
+        job = store.get(job_id)
+        if not job:
+            raise HTTPException(404, detail="Unknown job_id")
+        if job.status != "done" or not job.result_path or not job.result_path.is_file():
+            raise HTTPException(400, detail="Job is not ready for download")
+        path = job.result_path
+        task = BackgroundTask(store.remove_after_download, job)
+        return FileResponse(
+            path,
+            media_type="text/markdown; charset=utf-8",
+            filename="transcript.md",
+            background=task,
+        )
+
+    return app
+
+
+app = create_app()

--- a/src/md_generator/media/youtube/api/mcp_server.py
+++ b/src/md_generator/media/youtube/api/mcp_server.py
@@ -1,0 +1,31 @@
+"""Standalone MCP server: stdio, SSE, or streamable HTTP."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="youtube-to-md MCP server")
+    parser.add_argument(
+        "--transport",
+        choices=("stdio", "sse", "streamable-http"),
+        default="stdio",
+    )
+    args = parser.parse_args()
+
+    from md_generator.media.youtube.api.mcp_setup import build_mcp_stack
+
+    mcp, _ = build_mcp_stack(mount_under_fastapi=False)
+
+    if args.transport == "stdio":
+        asyncio.run(mcp.run_stdio_async())
+    elif args.transport == "sse":
+        asyncio.run(mcp.run_sse_async())
+    else:
+        asyncio.run(mcp.run_streamable_http_async())
+
+
+if __name__ == "__main__":
+    main()

--- a/src/md_generator/media/youtube/api/mcp_setup.py
+++ b/src/md_generator/media/youtube/api/mcp_setup.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import os
+import tempfile
+from pathlib import Path
+
+from mcp.server.fastmcp import FastMCP
+
+from md_generator.media.youtube.service import YouTubeToMarkdownService
+
+
+def build_mcp_stack(*, mount_under_fastapi: bool = False) -> tuple[FastMCP, object]:
+    path = "/" if mount_under_fastapi else "/mcp"
+    mcp = FastMCP(
+        "youtube-to-md",
+        instructions="Convert a public YouTube URL to Markdown (metadata + transcript; optional Whisper fallback).",
+        streamable_http_path=path,
+    )
+    @mcp.tool()
+    def youtube_url_to_markdown(
+        url: str,
+        title: str | None = None,
+        transcript_languages: str | None = None,
+        enable_audio_fallback: bool = True,
+        whisper_model: str = "base",
+        language: str | None = None,
+    ) -> str:
+        """Write Markdown to a temporary ``.md`` file; returns its path on the server."""
+        langs = [x.strip() for x in (transcript_languages or "").split(",") if x.strip()] or None
+        svc = YouTubeToMarkdownService(whisper_model=whisper_model, whisper_language=language)
+        fd, name = tempfile.mkstemp(suffix=".md", prefix="youtube-mcp-")
+        os.close(fd)
+        out = Path(name)
+        try:
+            svc.write_markdown(
+                url.strip(),
+                out,
+                title=title,
+                transcript_languages=langs,
+                enable_audio_fallback=enable_audio_fallback,
+            )
+        except Exception:
+            out.unlink(missing_ok=True)
+            raise
+        return str(out)
+
+    sub = mcp.streamable_http_app()
+    return mcp, sub

--- a/src/md_generator/media/youtube/api/run.py
+++ b/src/md_generator/media/youtube/api/run.py
@@ -1,0 +1,30 @@
+"""Run the YouTube REST + MCP FastAPI app with uvicorn."""
+
+from __future__ import annotations
+
+import argparse
+
+
+def main(argv: list[str] | None = None) -> int:
+    import uvicorn
+
+    from md_generator.media.youtube.api.settings import YouTubeApiSettings
+
+    p = argparse.ArgumentParser(description="youtube-to-md HTTP API (REST + MCP at /mcp)")
+    p.add_argument("--host", default=None)
+    p.add_argument("--port", type=int, default=None)
+    ns = p.parse_args(argv)
+    s = YouTubeApiSettings()
+    host = ns.host or s.api_host
+    port = ns.port if ns.port is not None else s.api_port
+    uvicorn.run(
+        "md_generator.media.youtube.api.main:create_app",
+        host=host,
+        port=port,
+        factory=True,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/md_generator/media/youtube/api/settings.py
+++ b/src/md_generator/media/youtube/api/settings.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class YouTubeApiSettings(BaseSettings):
+    model_config = SettingsConfigDict(
+        env_prefix="MD_YOUTUBE_",
+        env_file=".env",
+        extra="ignore",
+    )
+
+    job_ttl_seconds: int = 3600
+    temp_dir: str | None = None
+    cors_origins: str = "*"
+    api_host: str = "127.0.0.1"
+    api_port: int = 8013
+
+
+def cors_list(settings: YouTubeApiSettings) -> list[str]:
+    raw = (settings.cors_origins or "*").strip()
+    if raw == "*":
+        return ["*"]
+    return [o.strip() for o in raw.split(",") if o.strip()]

--- a/src/md_generator/media/youtube/converter.py
+++ b/src/md_generator/media/youtube/converter.py
@@ -1,0 +1,140 @@
+"""CLI and ``DocumentConverter`` entry for YouTube URL files → structured result / Markdown."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from md_generator.media.document_converter import DocumentConverter
+from md_generator.media.youtube.service import (
+    YouTubeConversionResult,
+    YouTubeError,
+    YouTubeToMarkdownService,
+    read_youtube_url_from_path,
+)
+from md_generator.media.youtube.metadata import extract_video_id
+
+
+class YouTubeConverter(DocumentConverter):
+    """
+    ``convert(path)`` reads a small text file containing one YouTube URL per line
+    (first non-empty line wins). Use ``accepts(path)`` to detect supported files.
+    """
+
+    def __init__(
+        self,
+        *,
+        service: YouTubeToMarkdownService | None = None,
+        transcript_languages: list[str] | None = None,
+        enable_audio_fallback: bool = True,
+    ) -> None:
+        self._service = service or YouTubeToMarkdownService()
+        self._transcript_languages = transcript_languages
+        self._enable_audio_fallback = enable_audio_fallback
+
+    def accepts(self, input_path: Path) -> bool:
+        p = Path(input_path)
+        if not p.is_file():
+            return False
+        suf = p.suffix.lower()
+        if suf in (".url", ".yturl", ".youtube"):
+            return True
+        if suf == ".txt":
+            try:
+                url = read_youtube_url_from_path(p)
+            except YouTubeError:
+                return False
+            return extract_video_id(url) is not None
+        return False
+
+    def convert(self, input_path: Path) -> YouTubeConversionResult:
+        path = Path(input_path).resolve()
+        if not path.is_file():
+            raise FileNotFoundError(path)
+        url = read_youtube_url_from_path(path)
+        return self._service.build_result(
+            url,
+            transcript_languages=self._transcript_languages,
+            enable_audio_fallback=self._enable_audio_fallback,
+        )
+
+
+def _parse_lang_list(s: str | None) -> list[str] | None:
+    if not s or not str(s).strip():
+        return None
+    parts = [p.strip() for p in str(s).split(",") if p.strip()]
+    return parts or None
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(description="Convert a YouTube URL to Markdown (metadata + transcript).")
+    p.add_argument("url", help="YouTube watch / youtu.be / shorts URL")
+    p.add_argument("output", type=Path, help="Output .md file path")
+    p.add_argument("--title", default=None, help="Override title in Markdown")
+    p.add_argument(
+        "--transcript-lang",
+        dest="transcript_langs",
+        action="append",
+        default=None,
+        metavar="CODE",
+        help="Preferred transcript language (repeatable), e.g. --transcript-lang hi --transcript-lang en",
+    )
+    p.add_argument(
+        "--transcript-langs",
+        dest="transcript_langs_csv",
+        default=None,
+        metavar="CODES",
+        help="Comma-separated preferred transcript languages (alternative to --transcript-lang)",
+    )
+    p.add_argument(
+        "--no-audio-fallback",
+        action="store_true",
+        help="Do not download audio with yt-dlp + Whisper if captions are missing",
+    )
+    p.add_argument("--whisper-model", default="base", help="Whisper model when audio fallback runs (default: base)")
+    p.add_argument(
+        "--language",
+        default=None,
+        help="Whisper language when audio fallback runs (same semantics as md-audio)",
+    )
+    p.add_argument("-v", "--verbose", action="store_true")
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    langs: list[str] | None = None
+    if args.transcript_langs:
+        langs = []
+        for item in args.transcript_langs:
+            langs.extend([x.strip() for x in item.split(",") if x.strip()])
+        langs = langs or None
+    elif args.transcript_langs_csv:
+        langs = _parse_lang_list(args.transcript_langs_csv)
+
+    try:
+        svc = YouTubeToMarkdownService(
+            whisper_model=args.whisper_model,
+            whisper_language=args.language,
+        )
+        out = svc.write_markdown(
+            args.url.strip(),
+            args.output,
+            title=args.title,
+            transcript_languages=langs,
+            enable_audio_fallback=not args.no_audio_fallback,
+        )
+        if args.verbose:
+            print(f"Wrote {out}", file=sys.stderr)
+        return 0
+    except YouTubeError as e:
+        print(str(e), file=sys.stderr)
+        return 2
+    except OSError as e:
+        print(str(e), file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/md_generator/media/youtube/formatter.py
+++ b/src/md_generator/media/youtube/formatter.py
@@ -1,0 +1,58 @@
+"""Render YouTube conversion result as Markdown."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def _format_seconds(seconds: float) -> str:
+    if seconds < 0:
+        seconds = 0.0
+    return f"{seconds:.2f}s"
+
+
+class YouTubeMarkdownFormatter:
+    """Build Markdown: # YouTube, title, metadata, description, timestamped transcript."""
+
+    def format(self, result: Any) -> str:
+        meta: dict[str, Any] = dict(result.metadata or {})
+        title = (meta.get("title") or "Untitled").strip() or "Untitled"
+        parts = [
+            "# YouTube",
+            "",
+            f"## {title}",
+            "",
+            "### Video Metadata",
+            "",
+        ]
+        views = meta.get("views")
+        if views is not None:
+            parts.append(f"* **Views:** {views}")
+        dur = meta.get("duration_seconds")
+        if dur is not None:
+            parts.append(f"* **Duration:** {dur}")
+        kw = meta.get("keywords")
+        if kw:
+            parts.append(f"* **Keywords:** {kw}")
+        parts.append(f"* **URL:** {meta.get('url', '')}")
+        if meta.get("author"):
+            parts.append(f"* **Channel:** {meta['author']}")
+        if meta.get("transcript_source"):
+            parts.append(f"* **Transcript source:** {meta['transcript_source']}")
+
+        parts.extend(["", "### Description", ""])
+        desc = (meta.get("description") or "").strip()
+        parts.append(desc if desc else "_(no description)_")
+
+        parts.extend(["", "### Transcript", ""])
+        segments: list[dict[str, Any]] = list(result.segments or [])
+        if not segments:
+            parts.append("_(no transcript)_")
+        else:
+            for seg in segments:
+                start = float(seg.get("start", 0.0))
+                text = str(seg.get("text", "")).strip()
+                if text:
+                    parts.append(f"* [{_format_seconds(start)}] {text}")
+
+        return "\n".join(parts).rstrip() + "\n"

--- a/src/md_generator/media/youtube/metadata.py
+++ b/src/md_generator/media/youtube/metadata.py
@@ -1,0 +1,210 @@
+"""Fetch YouTube page metadata via HTTP + BeautifulSoup, with oEmbed fallback."""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import Any
+from urllib.parse import parse_qs, urlparse
+
+import httpx
+from bs4 import BeautifulSoup
+
+_YOUTUBE_HOSTS = frozenset(
+    {
+        "youtube.com",
+        "www.youtube.com",
+        "m.youtube.com",
+        "music.youtube.com",
+        "youtu.be",
+        "www.youtu.be",
+    }
+)
+
+
+class YouTubeMetadataError(RuntimeError):
+    """Raised when metadata cannot be fetched or parsed."""
+
+
+def _host_ok(host: str | None) -> bool:
+    if not host:
+        return False
+    h = host.lower()
+    if h in _YOUTUBE_HOSTS:
+        return True
+    return h.endswith(".youtube.com")
+
+
+def extract_video_id(url: str) -> str | None:
+    """Return 11-character video id or ``None`` if ``url`` is not a recognized YouTube URL."""
+    raw = (url or "").strip()
+    if not raw:
+        return None
+    try:
+        parsed = urlparse(raw if "://" in raw else f"https://{raw}")
+    except ValueError:
+        return None
+    host = (parsed.hostname or "").lower()
+    if not _host_ok(host):
+        return None
+    path = parsed.path or ""
+    vid_re = re.compile(r"^[\w-]{11}$")
+
+    if host in ("youtu.be", "www.youtu.be"):
+        seg = path.strip("/").split("/")[0] if path else ""
+        return seg if vid_re.match(seg) else None
+
+    if path.startswith("/watch"):
+        v = (parse_qs(parsed.query).get("v") or [None])[0]
+        return v if v and vid_re.match(v) else None
+    if path.startswith("/embed/"):
+        seg = path[len("/embed/") :].split("/")[0]
+        return seg if vid_re.match(seg) else None
+    if path.startswith("/shorts/"):
+        seg = path[len("/shorts/") :].split("/")[0]
+        return seg if vid_re.match(seg) else None
+    if path.startswith("/live/"):
+        seg = path[len("/live/") :].split("/")[0]
+        return seg if vid_re.match(seg) else None
+    return None
+
+
+def normalize_youtube_url(url: str) -> str:
+    """Return canonical ``https`` watch URL for a valid YouTube input."""
+    vid = extract_video_id(url)
+    if not vid:
+        raise YouTubeMetadataError(f"Not a recognized YouTube URL: {url!r}")
+    return f"https://www.youtube.com/watch?v={vid}"
+
+
+def _parse_iso8601_duration(s: str) -> float | None:
+    """Parse ``PT#H#M#S`` into seconds (best-effort)."""
+    s = (s or "").strip()
+    m = re.match(
+        r"^PT(?:(\d+)H)?(?:(\d+)M)?(?:(\d+(?:\.\d+)?)S)?$",
+        s,
+        re.IGNORECASE,
+    )
+    if not m:
+        return None
+    h, mi, se = m.group(1), m.group(2), m.group(3)
+    total = 0.0
+    if h:
+        total += int(h) * 3600
+    if mi:
+        total += int(mi) * 60
+    if se:
+        total += float(se)
+    return total if total > 0 or (h or mi or se) else None
+
+
+def _parse_views(content: str | None) -> int | None:
+    if not content:
+        return None
+    digits = re.sub(r"[^\d]", "", str(content))
+    if not digits:
+        return None
+    try:
+        return int(digits)
+    except ValueError:
+        return None
+
+
+def _parse_meta_from_html(html: str) -> dict[str, Any]:
+    """Parse watch-page HTML; fields may be missing (YouTube serves varying static HTML)."""
+    soup = BeautifulSoup(html, "lxml")
+    out: dict[str, Any] = {
+        "title": None,
+        "description": None,
+        "views": None,
+        "keywords": None,
+        "duration_seconds": None,
+    }
+
+    og_title = soup.find("meta", property="og:title")
+    if og_title and og_title.get("content"):
+        out["title"] = str(og_title["content"]).strip()
+
+    og_desc = soup.find("meta", property="og:description")
+    if og_desc and og_desc.get("content"):
+        out["description"] = str(og_desc["content"]).strip()
+
+    for meta in soup.find_all("meta"):
+        prop = (meta.get("itemprop") or "").lower()
+        name = (meta.get("name") or "").lower()
+        content = meta.get("content")
+        if prop == "interactioncount" or name == "interactioncount":
+            out["views"] = out["views"] or _parse_views(content)
+        if prop == "duration" and content:
+            dur = _parse_iso8601_duration(str(content))
+            if dur is not None:
+                out["duration_seconds"] = dur
+        if name == "keywords" and content:
+            out["keywords"] = str(content).strip()
+
+    return out
+
+
+def _fetch_oembed(watch_url: str, *, client: httpx.Client) -> dict[str, Any]:
+    params = {"url": watch_url, "format": "json"}
+    r = client.get("https://www.youtube.com/oembed", params=params, timeout=30.0)
+    r.raise_for_status()
+    return r.json()
+
+
+def fetch_youtube_metadata(
+    video_id: str,
+    page_url: str | None = None,
+    *,
+    client: httpx.Client | None = None,
+) -> dict[str, Any]:
+    """
+    Return metadata dict: title, description, views, keywords, duration_seconds, author, url.
+
+    Uses watch-page HTML (BeautifulSoup) plus oEmbed JSON as fallback for title/author.
+    Missing fields are omitted or ``None`` (never fabricated).
+    """
+    watch = page_url or f"https://www.youtube.com/watch?v={video_id}"
+    headers = {
+        "User-Agent": (
+            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
+            "(KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+        ),
+        "Accept-Language": "en-US,en;q=0.9",
+    }
+    close = client is None
+    c = client or httpx.Client(headers=headers, follow_redirects=True)
+    try:
+        merged: dict[str, Any] = {
+            "video_id": video_id,
+            "url": watch,
+            "title": None,
+            "description": None,
+            "views": None,
+            "keywords": None,
+            "duration_seconds": None,
+            "author": None,
+        }
+        try:
+            r = c.get(watch, timeout=30.0)
+            if r.status_code == 200 and r.text:
+                html_meta = _parse_meta_from_html(r.text)
+                for k in ("title", "description", "views", "keywords", "duration_seconds"):
+                    if html_meta.get(k) is not None:
+                        merged[k] = html_meta[k]
+        except httpx.HTTPError:
+            pass
+
+        try:
+            oj = _fetch_oembed(watch, client=c)
+            if not merged.get("title") and oj.get("title"):
+                merged["title"] = str(oj["title"]).strip()
+            if oj.get("author_name"):
+                merged["author"] = str(oj["author_name"]).strip()
+        except (httpx.HTTPError, json.JSONDecodeError, KeyError):
+            pass
+
+        return merged
+    finally:
+        if close:
+            c.close()

--- a/src/md_generator/media/youtube/service.py
+++ b/src/md_generator/media/youtube/service.py
@@ -1,0 +1,200 @@
+"""Orchestrate metadata + transcript (+ optional Whisper fallback) for YouTube URLs."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import tempfile
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from md_generator.media.youtube.formatter import YouTubeMarkdownFormatter
+from md_generator.media.youtube.metadata import (
+    YouTubeMetadataError,
+    extract_video_id,
+    fetch_youtube_metadata,
+    normalize_youtube_url,
+)
+from md_generator.media.youtube.transcript import YouTubeTranscriptError, fetch_transcript
+
+
+class YouTubeError(RuntimeError):
+    """Base error for YouTube conversion."""
+
+
+@dataclass
+class YouTubeConversionResult:
+    """Structured output from ``YouTubeToMarkdownService.build_result``."""
+
+    metadata: dict[str, Any]
+    segments: tuple[dict[str, Any], ...] = field(default_factory=tuple)
+
+
+class YouTubeToMarkdownService:
+    """Fetch metadata and transcript, optionally fall back to Whisper on downloaded audio."""
+
+    def __init__(
+        self,
+        *,
+        formatter: YouTubeMarkdownFormatter | None = None,
+        whisper_model: str = "base",
+        whisper_language: str | None = None,
+    ) -> None:
+        self._formatter = formatter or YouTubeMarkdownFormatter()
+        self._whisper_model = whisper_model
+        self._whisper_language = whisper_language
+
+    def build_result(
+        self,
+        url: str,
+        *,
+        transcript_languages: list[str] | None = None,
+        enable_audio_fallback: bool = True,
+    ) -> YouTubeConversionResult:
+        vid = extract_video_id(url)
+        if not vid:
+            raise YouTubeError(f"Invalid or unsupported YouTube URL: {url!r}")
+        watch = normalize_youtube_url(url)
+
+        meta = fetch_youtube_metadata(vid, watch)
+        meta = {**meta, "transcript_source": "youtube_transcript_api"}
+
+        try:
+            segments = fetch_transcript(vid, transcript_languages)
+        except YouTubeTranscriptError:
+            if not enable_audio_fallback:
+                raise
+            segments, meta = self._transcribe_via_ytdlp(watch, meta)
+        seg_tup = tuple(dict(s) for s in segments)
+        return YouTubeConversionResult(metadata=meta, segments=seg_tup)
+
+    def _resolve_ytdlp(self) -> str:
+        env = (os.environ.get("MD_YOUTUBE_YTDLP") or "").strip()
+        if env and Path(env).is_file():
+            return env
+        w = shutil.which("yt-dlp")
+        if w:
+            return w
+        raise YouTubeError(
+            "Transcript unavailable and audio fallback is enabled, but yt-dlp was not found. "
+            "Install yt-dlp on PATH or set MD_YOUTUBE_YTDLP to the executable, "
+            "or pass enable_audio_fallback=False."
+        )
+
+    def _transcribe_via_ytdlp(self, watch_url: str, meta: dict[str, Any]) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+        ytdlp = self._resolve_ytdlp()
+        try:
+            from md_generator.media.audio.service import AudioToMarkdownService
+        except ImportError as e:
+            raise YouTubeError(
+                "Audio fallback requires mdengine[audio] (Whisper). pip install mdengine[audio]"
+            ) from e
+
+        whisper_dur: float | None = None
+        with tempfile.TemporaryDirectory() as td:
+            td_path = Path(td)
+            out_tmpl = str(td_path / "audio.%(ext)s")
+            cmd = [
+                ytdlp,
+                "--no-playlist",
+                "-f",
+                "bestaudio/best",
+                "-x",
+                "--audio-format",
+                "m4a",
+                "-o",
+                out_tmpl,
+                "--",
+                watch_url,
+            ]
+            try:
+                proc = subprocess.run(
+                    cmd,
+                    capture_output=True,
+                    text=True,
+                    timeout=3600,
+                    check=False,
+                )
+            except FileNotFoundError as e:
+                raise YouTubeError(f"yt-dlp failed to execute: {ytdlp}") from e
+            if proc.returncode != 0:
+                err = (proc.stderr or proc.stdout or "").strip()
+                raise YouTubeError(err or f"yt-dlp exited with code {proc.returncode}")
+
+            audio_files = sorted(td_path.glob("audio.*"))
+            if not audio_files:
+                raise YouTubeError("yt-dlp did not produce an audio file in the temp directory")
+            audio_path = audio_files[0]
+
+            svc = AudioToMarkdownService(whisper_model=self._whisper_model, language=self._whisper_language)
+            tr = svc.transcribe(audio_path)
+            segments = [{"start": s.start, "text": s.text} for s in tr.segments if s.text.strip()]
+            whisper_dur = tr.metadata.duration_seconds
+
+        meta = {**meta, "transcript_source": "whisper (yt-dlp audio)"}
+        if meta.get("duration_seconds") is None and whisper_dur is not None:
+            meta["duration_seconds"] = whisper_dur
+        return segments, meta
+
+    def to_markdown(
+        self,
+        url: str,
+        *,
+        title_override: str | None = None,
+        transcript_languages: list[str] | None = None,
+        enable_audio_fallback: bool = True,
+    ) -> str:
+        result = self.build_result(
+            url,
+            transcript_languages=transcript_languages,
+            enable_audio_fallback=enable_audio_fallback,
+        )
+        meta = dict(result.metadata)
+        if title_override:
+            meta["title"] = title_override.strip()
+        patched = YouTubeConversionResult(metadata=meta, segments=result.segments)
+        return self._formatter.format(patched)
+
+    def write_markdown(
+        self,
+        url: str,
+        output_md: Path,
+        *,
+        title: str | None = None,
+        transcript_languages: list[str] | None = None,
+        enable_audio_fallback: bool = True,
+        encoding: str = "utf-8",
+    ) -> Path:
+        output_md = Path(output_md)
+        output_md.parent.mkdir(parents=True, exist_ok=True)
+        body = self.to_markdown(
+            url,
+            title_override=title,
+            transcript_languages=transcript_languages,
+            enable_audio_fallback=enable_audio_fallback,
+        )
+        output_md.write_text(body, encoding=encoding)
+        return output_md
+
+
+def read_youtube_url_from_path(path: Path) -> str:
+    """Read first non-empty, non-comment line from a text file as the YouTube URL."""
+    raw = Path(path).read_text(encoding="utf-8", errors="replace")
+    for line in raw.splitlines():
+        s = line.strip()
+        if not s or s.startswith("#"):
+            continue
+        return s
+    raise YouTubeError(f"No YouTube URL found in file: {path}")
+
+
+__all__ = [
+    "YouTubeConversionResult",
+    "YouTubeError",
+    "YouTubeMetadataError",
+    "YouTubeToMarkdownService",
+    "YouTubeTranscriptError",
+    "read_youtube_url_from_path",
+]

--- a/src/md_generator/media/youtube/transcript.py
+++ b/src/md_generator/media/youtube/transcript.py
@@ -1,0 +1,100 @@
+"""YouTube captions via ``youtube_transcript_api`` with retries and language fallback."""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+
+
+class YouTubeTranscriptError(RuntimeError):
+    """Raised when no transcript can be retrieved after retries and fallbacks."""
+
+
+def _normalize_raw(raw: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    out: list[dict[str, Any]] = []
+    for item in raw:
+        try:
+            start = float(item.get("start", 0.0))
+        except (TypeError, ValueError):
+            start = 0.0
+        text = (item.get("text") or "").replace("\n", " ").strip()
+        if text:
+            out.append({"start": start, "text": text})
+    if not out:
+        raise YouTubeTranscriptError("Transcript was empty")
+    return out
+
+
+def fetch_transcript(
+    video_id: str,
+    preferred_languages: list[str] | None = None,
+    *,
+    attempts: int = 3,
+) -> list[dict[str, Any]]:
+    """
+    Return segments ``[{"start": float, "text": str}, ...]``.
+
+    Tries ``preferred_languages`` in order, then lets the API pick any available transcript.
+    """
+    try:
+        from youtube_transcript_api import YouTubeTranscriptApi
+        from youtube_transcript_api._errors import (
+            NoTranscriptFound,
+            TranscriptsDisabled,
+            VideoUnavailable,
+        )
+    except ImportError as e:
+        raise YouTubeTranscriptError(
+            "youtube-transcript-api is not installed; pip install mdengine[youtube]"
+        ) from e
+
+    langs = [x.strip().lower() for x in (preferred_languages or []) if x and x.strip()]
+
+    def fetch_raw_legacy() -> list[dict[str, Any]]:
+        if langs:
+            try:
+                return YouTubeTranscriptApi.get_transcript(video_id, languages=langs)
+            except NoTranscriptFound:
+                return YouTubeTranscriptApi.get_transcript(video_id)
+        return YouTubeTranscriptApi.get_transcript(video_id)
+
+    def fetch_raw_modern() -> list[dict[str, Any]]:
+        api = YouTubeTranscriptApi()
+        if langs:
+            try:
+                return list(api.fetch(video_id, languages=tuple(langs)).to_raw_data())
+            except NoTranscriptFound:
+                pass
+        try:
+            return list(api.fetch(video_id).to_raw_data())
+        except NoTranscriptFound:
+            tlist = api.list(video_id)
+            for tr in tlist:
+                try:
+                    return list(tr.fetch().to_raw_data())
+                except Exception:
+                    continue
+            raise YouTubeTranscriptError(f"No transcripts available for video {video_id}")
+
+    def try_fetch() -> list[dict[str, Any]]:
+        if hasattr(YouTubeTranscriptApi, "get_transcript"):
+            raw = fetch_raw_legacy()
+        else:
+            raw = fetch_raw_modern()
+        return _normalize_raw(raw)
+
+    last: Exception | None = None
+    for i in range(attempts):
+        try:
+            return try_fetch()
+        except (TranscriptsDisabled, VideoUnavailable) as e:
+            raise YouTubeTranscriptError(str(e)) from e
+        except NoTranscriptFound as e:
+            raise YouTubeTranscriptError(str(e)) from e
+        except YouTubeTranscriptError:
+            raise
+        except Exception as e:
+            last = e
+            if i < attempts - 1:
+                time.sleep(0.5 * (2**i))
+    raise YouTubeTranscriptError(str(last) if last else "Transcript fetch failed")

--- a/youtube-to-md/README.md
+++ b/youtube-to-md/README.md
@@ -1,0 +1,39 @@
+# youtube-to-md
+
+Convert a **YouTube URL** to Markdown (title, metadata, description, timestamped transcript).
+
+## Install
+
+```bash
+pip install "mdengine[youtube]"
+# optional: captions fallback via Whisper + yt-dlp
+pip install "mdengine[audio]"
+# yt-dlp on PATH, or set MD_YOUTUBE_YTDLP to the executable
+```
+
+## CLI
+
+```bash
+md-youtube "https://www.youtube.com/watch?v=VIDEO_ID" out.md --transcript-lang en -v
+```
+
+Same entrypoint as `python youtube-to-md/converter.py …` with `PYTHONPATH=../src` from this folder.
+
+## HTTP + MCP
+
+```bash
+pip install "mdengine[youtube,api,mcp]"
+md-youtube-api --port 8013
+```
+
+- `POST /convert/sync` — JSON body `{ "url": "https://…" }` → Markdown response.
+- `POST /convert/jobs` — same JSON → `{ "job_id", "status" }`; poll then `GET /convert/jobs/{id}/download`.
+- MCP: `youtube_url_to_markdown` (see root README).
+
+## Tests
+
+From repo root (with dev deps):
+
+```bash
+pytest youtube-to-md/tests
+```

--- a/youtube-to-md/converter.py
+++ b/youtube-to-md/converter.py
@@ -1,0 +1,8 @@
+"""Shim CLI: prefer ``md-youtube`` after ``pip install mdengine[youtube]``."""
+
+from __future__ import annotations
+
+from md_generator.media.youtube.converter import main
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/youtube-to-md/pytest.ini
+++ b/youtube-to-md/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+pythonpath = ../src
+testpaths = tests

--- a/youtube-to-md/tests/test_youtube_converter.py
+++ b/youtube-to-md/tests/test_youtube_converter.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+from md_generator.media.youtube.converter import YouTubeConverter
+
+
+def test_accepts_yturl_and_txt_with_youtube_line() -> None:
+    c = YouTubeConverter(enable_audio_fallback=False)
+    with tempfile.TemporaryDirectory() as td:
+        p = Path(td) / "x.yturl"
+        p.write_text("https://www.youtube.com/watch?v=dQw4w9WgXcQ\n", encoding="utf-8")
+        assert c.accepts(p) is True
+
+        bad = Path(td) / "plain.txt"
+        bad.write_text("hello\n", encoding="utf-8")
+        assert c.accepts(bad) is False
+
+        good_txt = Path(td) / "u.txt"
+        good_txt.write_text("# comment\nhttps://youtu.be/dQw4w9WgXcQ\n", encoding="utf-8")
+        assert c.accepts(good_txt) is True
+
+
+def test_convert_reads_url(tmp_path: Path) -> None:
+    from unittest.mock import patch
+
+    p = tmp_path / "link.url"
+    p.write_text("https://www.youtube.com/watch?v=dQw4w9WgXcQ", encoding="utf-8")
+
+    fake_meta = {
+        "video_id": "dQw4w9WgXcQ",
+        "url": "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+        "title": "T",
+        "transcript_source": "youtube_transcript_api",
+    }
+    fake_seg = [{"start": 0.0, "text": "hi"}]
+
+    with (
+        patch("md_generator.media.youtube.service.fetch_youtube_metadata", return_value=fake_meta),
+        patch("md_generator.media.youtube.service.fetch_transcript", return_value=fake_seg),
+    ):
+        c = YouTubeConverter(enable_audio_fallback=False)
+        r = c.convert(p)
+    assert r.metadata["title"] == "T"
+    assert len(r.segments) == 1
+    assert r.segments[0]["text"] == "hi"

--- a/youtube-to-md/tests/test_youtube_formatter.py
+++ b/youtube-to-md/tests/test_youtube_formatter.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from md_generator.media.youtube.formatter import YouTubeMarkdownFormatter
+from md_generator.media.youtube.service import YouTubeConversionResult
+
+
+def test_youtube_markdown_formatter() -> None:
+    result = YouTubeConversionResult(
+        metadata={
+            "title": "Sample",
+            "url": "https://www.youtube.com/watch?v=abc",
+            "views": 1000,
+            "duration_seconds": 42.5,
+            "keywords": "a, b",
+            "author": "Channel",
+            "transcript_source": "youtube_transcript_api",
+            "description": "Hello **world**",
+        },
+        segments=({"start": 0.0, "text": "Line one"}, {"start": 5.2, "text": "Line two"}),
+    )
+    md = YouTubeMarkdownFormatter().format(result)
+    assert md.startswith("# YouTube\n\n## Sample\n")
+    assert "### Video Metadata" in md
+    assert "**Views:** 1000" in md
+    assert "### Description" in md
+    assert "Hello **world**" in md
+    assert "### Transcript" in md
+    assert "[0.00s] Line one" in md
+    assert "[5.20s] Line two" in md

--- a/youtube-to-md/tests/test_youtube_metadata.py
+++ b/youtube-to-md/tests/test_youtube_metadata.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import pytest
+
+from md_generator.media.youtube.metadata import extract_video_id, normalize_youtube_url
+
+
+@pytest.mark.parametrize(
+    ("url", "expected"),
+    [
+        ("https://www.youtube.com/watch?v=dQw4w9WgXcQ", "dQw4w9WgXcQ"),
+        ("https://youtu.be/dQw4w9WgXcQ", "dQw4w9WgXcQ"),
+        ("https://youtube.com/watch?v=dQw4w9WgXcQ&feature=share", "dQw4w9WgXcQ"),
+        ("https://www.youtube.com/embed/dQw4w9WgXcQ", "dQw4w9WgXcQ"),
+        ("https://www.youtube.com/shorts/dQw4w9WgXcQ", "dQw4w9WgXcQ"),
+        ("not a url", None),
+        ("https://example.com/watch?v=dQw4w9WgXcQ", None),
+    ],
+)
+def test_extract_video_id(url: str, expected: str | None) -> None:
+    assert extract_video_id(url) == expected
+
+
+def test_normalize_youtube_url() -> None:
+    assert normalize_youtube_url("https://youtu.be/dQw4w9WgXcQ") == "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+
+
+def test_normalize_invalid_raises() -> None:
+    from md_generator.media.youtube.metadata import YouTubeMetadataError
+
+    with pytest.raises(YouTubeMetadataError):
+        normalize_youtube_url("https://example.com/")

--- a/youtube-to-md/tests/test_youtube_service_mocked.py
+++ b/youtube-to-md/tests/test_youtube_service_mocked.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from md_generator.media.youtube.service import YouTubeToMarkdownService
+
+
+def test_to_markdown_mocked() -> None:
+    fake_meta = {
+        "video_id": "dQw4w9WgXcQ",
+        "url": "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+        "title": "Mocked",
+        "transcript_source": "youtube_transcript_api",
+    }
+    fake_seg = [{"start": 1.0, "text": "only"}]
+
+    with (
+        patch("md_generator.media.youtube.service.fetch_youtube_metadata", return_value=fake_meta),
+        patch("md_generator.media.youtube.service.fetch_transcript", return_value=fake_seg),
+    ):
+        svc = YouTubeToMarkdownService()
+        md = svc.to_markdown(
+            "https://youtu.be/dQw4w9WgXcQ",
+            enable_audio_fallback=False,
+        )
+    assert "Mocked" in md
+    assert "[1.00s] only" in md


### PR DESCRIPTION
## Summary

Implements **YouTube URL → Markdown** conversion: resolve the video, prefer **official transcript / captions** when available, and apply **documented fallback** behavior when transcripts are missing or incomplete. Surfaces the feature through the packaging/docs entry points used elsewhere in **mdengine** (CLI / library paths as implemented in this branch).

Closes #6

## Scope

- **Input:** YouTube watch / youtu.be URLs (and any URL shapes your implementation accepts).
- **Output:** Markdown (and any sidecar or asset conventions your module defines).
- **Transcript:** Primary path uses YouTube transcript/caption data where the API or scraper layer provides it.
- **Fallback:** When transcript is unavailable, behavior matches the design in the issue (e.g. alternate metadata-only section, error message, or optional downstream pipeline—describe briefly in review if non-obvious).

## How to try it

<!-- Adjust commands to match your actual extra name and CLI, e.g. md-youtube or md-url integration -->

```bash
pip install -e ".[<youtube-extra>]"
<your-cli-command> "https://www.youtube.com/watch?v=..." -o out.md