### PR TITLE
feat(playwright): SPA / dynamic HTML → Markdown via Playwright (#8)

### DIFF
--- a/README.md
+++ b/README.md
@@ -468,6 +468,7 @@ Install `mdengine[api]` plus the format extra(s), then run the **`app`** object 
 | Text/JSON/XML | `md_generator.text.api.main:app` | `text`, `api`, `mcp` |
 | ZIP | `md_generator.archive.api.main:app` | `archive`, `api`, `mcp` (+ extras for nested office/PDF) |
 | URL / HTML | `md_generator.url.api.main:app` | `url`, `api`, `mcp` |
+| Playwright / SPA | `md_generator.playwright.api.main:app` | `playwright`, `api`, `mcp` |
 | Audio (Whisper) | `md_generator.media.audio.api.main:create_app` (use **`--factory`**) or `…main:app` | `audio`, `api`, `mcp` |
 | Video (Whisper) | `md_generator.media.video.api.main:create_app` (use **`--factory`**) or `…main:app` | `video`, `api`, `mcp` |
 | YouTube | `md_generator.media.youtube.api.main:create_app` (use **`--factory`**) or `…main:app` | `youtube`, `api`, `mcp` |
@@ -479,6 +480,7 @@ uvicorn md_generator.pdf.api.main:app --host 127.0.0.1 --port 8001
 uvicorn md_generator.word.api.main:app --host 127.0.0.1 --port 8002
 uvicorn md_generator.archive.api.main:app --host 127.0.0.1 --port 8010
 uvicorn md_generator.url.api.main:app --host 127.0.0.1 --port 8011
+uvicorn md_generator.playwright.api.main:app --host 127.0.0.1 --port 8014
 uvicorn md_generator.media.audio.api.main:create_app --factory --host 127.0.0.1 --port 8011
 uvicorn md_generator.media.video.api.main:create_app --factory --host 127.0.0.1 --port 8012
 uvicorn md_generator.media.youtube.api.main:create_app --factory --host 127.0.0.1 --port 8013
@@ -501,6 +503,7 @@ Prefixes differ per service (often read from a `.env` file next to the process):
 | Text | `TXT_JSON_XML_TO_MD_` | same pattern |
 | XLSX | `XLSX_TO_MD_` | `XLSX_TO_MD_TEMP_DIR`, `XLSX_TO_MD_CORS_ORIGINS`, etc. (see `md_generator.xlsx.api.app`) |
 | URL | `URL_TO_MD_` | `URL_TO_MD_MAX_SYNC_URLS`, `URL_TO_MD_MAX_SYNC_CRAWL_PAGES`, `URL_TO_MD_MAX_JOB_URLS`, `URL_TO_MD_JOB_TTL_SECONDS`, `URL_TO_MD_TEMP_DIR`, `URL_TO_MD_CORS_ORIGINS` |
+| Playwright / SPA | `PLAYWRIGHT_TO_MD_` | `PLAYWRIGHT_TO_MD_MAX_SYNC_URLS`, `PLAYWRIGHT_TO_MD_MAX_JOB_URLS`, `PLAYWRIGHT_TO_MD_JOB_TTL_SECONDS`, `PLAYWRIGHT_TO_MD_TEMP_DIR`, `PLAYWRIGHT_TO_MD_CORS_ORIGINS`, `PLAYWRIGHT_TO_MD_API_HOST`, `PLAYWRIGHT_TO_MD_API_PORT` (default **8014**) |
 | Audio API | `MD_AUDIO_` | `MD_AUDIO_MAX_UPLOAD_MB`, `MD_AUDIO_MAX_SYNC_UPLOAD_MB`, `MD_AUDIO_JOB_TTL_SECONDS`, `MD_AUDIO_TEMP_DIR`, `MD_AUDIO_CORS_ORIGINS`, `MD_AUDIO_API_HOST`, `MD_AUDIO_API_PORT` |
 | Video API | `MD_VIDEO_` | Same pattern as audio with `MD_VIDEO_*` (defaults: larger upload/sync caps, port **8012**) |
 | YouTube API | `MD_YOUTUBE_` | `MD_YOUTUBE_JOB_TTL_SECONDS`, `MD_YOUTUBE_TEMP_DIR`, `MD_YOUTUBE_CORS_ORIGINS`, `MD_YOUTUBE_API_HOST`, `MD_YOUTUBE_API_PORT` (default **8013**); optional `MD_YOUTUBE_YTDLP` path for audio fallback |
@@ -527,6 +530,7 @@ Two usage patterns:
 | PPTX | `python -m md_generator.ppt.api.mcp_server` (see module docstring for flags) |
 | Image | `python -m md_generator.image.api.mcp_server` (see module for CLI) |
 | URL / HTML | `python -m md_generator.url.api.mcp_server` / `--transport sse` / `--transport streamable-http` |
+| Playwright / SPA | `md-playwright-mcp` or `python -m md_generator.playwright.api.mcp_server` / `--transport sse` / `--transport streamable-http` |
 | Audio | `md-audio-mcp` or `python -m md_generator.media.audio.api.mcp_server` — `--transport stdio` (default), `sse`, `streamable-http` |
 | Video | `md-video-mcp` or `python -m md_generator.media.video.api.mcp_server` — same transports |
 | YouTube | `md-youtube-mcp` or `python -m md_generator.media.youtube.api.mcp_server` — same transports |

--- a/md-generator.code-workspace
+++ b/md-generator.code-workspace
@@ -7,7 +7,8 @@
     { "path": "pdf-to-md", "name": "pdf-to-md" },
     { "path": "ppt-to-md", "name": "ppt-to-md" },
     { "path": "xlsx-to-md", "name": "xlsx-to-md" },
-    { "path": "url-to-md", "name": "url-to-md" }
+    { "path": "url-to-md", "name": "url-to-md" },
+    { "path": "playwright-to-md", "name": "playwright-to-md" }
   ],
   "settings": {
     "python.languageServer": "Pylance",

--- a/playwright-to-md/README.md
+++ b/playwright-to-md/README.md
@@ -1,0 +1,80 @@
+# playwright-to-md (md-playwright)
+
+Render JavaScript-heavy pages (React, Angular, SPAs) with [Playwright](https://playwright.dev/python/), extract readable content, convert to Markdown, optionally download images, and emit chunk markers for LLM workflows.
+
+## Install
+
+```bash
+pip install "mdengine[playwright]"
+playwright install chromium
+```
+
+The second line downloads the Chromium browser binaries required at runtime.
+
+## CLI
+
+```bash
+md-playwright https://react.dev/learn/tutorial-tic-tac-toe -o ./out --wait ".markdown"
+```
+
+Common flags:
+
+| Flag | Description |
+|------|-------------|
+| `-o`, `--output` | Output directory (writes `document.md`) |
+| `--wait` | CSS selector to wait for before scrolling |
+| `--timeout` | Navigation timeout in seconds (default: 60) |
+| `--wait-until` | `load`, `domcontentloaded`, `commit`, or `networkidle` (default: `networkidle`) |
+| `--max-scroll-rounds` | Scroll passes for lazy-loaded content |
+| `--no-chunk` | Disable `<!-- chunk:start -->` markers |
+| `--no-readability` | Skip readability extraction before markdownify |
+| `--screenshot` | Save full-page PNG path |
+| `--save-raw-html` | Save rendered HTML path |
+| `--retries` | Retry count for navigation failures |
+
+## Library
+
+```python
+import asyncio
+from pathlib import Path
+from md_generator.playwright import PlaywrightOptions, convert_url_to_md
+
+async def run():
+    await convert_url_to_md(
+        "https://angular.dev/overview",
+        Path("out"),
+        PlaywrightOptions(chunk_markdown=True),
+    )
+
+asyncio.run(run())
+```
+
+## HTTP API (sync ZIP, async jobs, MCP)
+
+Install **`mdengine[playwright,api,mcp]`** (and `playwright install chromium`). Same route shape as **url-to-md**: JSON body with **`url`** or **`urls`**, optional Playwright fields (`navigation_timeout_seconds`, `wait_selector`, `wait_until`, `max_scroll_rounds`, …).
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `POST` | `/convert/sync` | Returns `application/zip` immediately (up to `PLAYWRIGHT_TO_MD_MAX_SYNC_URLS` targets). |
+| `POST` | `/convert/jobs` | Queues conversion; returns `{ "job_id", "status" }`. |
+| `GET` | `/convert/jobs/{job_id}` | Job status and error text. |
+| `GET` | `/convert/jobs/{job_id}/download` | ZIP when `status` is `done`. |
+
+FastMCP is mounted at **`/mcp`** (streamable HTTP on the same port as Uvicorn). Standalone MCP supports **stdio** (default), **sse**, and **streamable-http**:
+
+```bash
+md-playwright-api --host 127.0.0.1 --port 8014
+# or: uvicorn md_generator.playwright.api.main:app --host 127.0.0.1 --port 8014
+
+md-playwright-mcp --transport stdio
+python -m md_generator.playwright.api.mcp_server --transport sse
+python -m md_generator.playwright.api.mcp_server --transport streamable-http
+```
+
+Environment prefix: **`PLAYWRIGHT_TO_MD_`** (for example `PLAYWRIGHT_TO_MD_MAX_SYNC_URLS`, `PLAYWRIGHT_TO_MD_MAX_JOB_URLS`, `PLAYWRIGHT_TO_MD_JOB_TTL_SECONDS`, `PLAYWRIGHT_TO_MD_TEMP_DIR`, `PLAYWRIGHT_TO_MD_CORS_ORIGINS`, `PLAYWRIGHT_TO_MD_API_HOST`, `PLAYWRIGHT_TO_MD_API_PORT`). See `md_generator.playwright.api.settings`.
+
+## Notes
+
+- `networkidle` can be flaky on long-polling SPAs; use `--wait-until load` if needed.
+- Chunking uses a **character-based** token estimate (~4 characters per token), not a tokenizer.
+- Integration tests hit the public web; mark with `@pytest.mark.integration` and install browsers to run them.

--- a/playwright-to-md/tests/test_playwright_api.py
+++ b/playwright-to-md/tests/test_playwright_api.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import zipfile
+from io import BytesIO
+
+import pytest
+
+pytest.importorskip("fastapi")
+
+from fastapi.testclient import TestClient
+
+from md_generator.playwright.api.main import app
+
+
+@pytest.fixture(scope="module")
+def api_client() -> TestClient:
+    """One TestClient for the module so MCP lifespan runs only once."""
+    with TestClient(app) as c:
+        yield c
+
+
+@pytest.fixture
+def fake_rendered_html(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def fake_fetch(
+        url: str,
+        *,
+        wait_selector: str | None = None,
+        options=None,
+    ) -> str:
+        return """<!DOCTYPE html><html><head><title>T</title></head>
+        <body><h1>Heading</h1><p>Body</p></body></html>"""
+
+    monkeypatch.setattr(
+        "md_generator.playwright.playwright_fetcher.fetch_rendered_html",
+        fake_fetch,
+    )
+
+
+def test_convert_sync_zip(api_client: TestClient, fake_rendered_html: None) -> None:
+    r = api_client.post("/convert/sync", json={"url": "https://example.com/"})
+    assert r.status_code == 200, r.text
+    zf = zipfile.ZipFile(BytesIO(r.content))
+    names = zf.namelist()
+    assert "document.md" in names
+
+
+def test_sync_rejects_too_many_urls(api_client: TestClient) -> None:
+    r = api_client.post(
+        "/convert/sync",
+        json={
+            "urls": [
+                "https://a.com/1",
+                "https://a.com/2",
+                "https://a.com/3",
+                "https://a.com/4",
+            ],
+        },
+    )
+    assert r.status_code == 409
+
+
+def test_jobs_flow(api_client: TestClient, fake_rendered_html: None) -> None:
+    r = api_client.post("/convert/jobs", json={"url": "https://example.com/z"})
+    assert r.status_code == 200, r.text
+    job_id = r.json()["job_id"]
+    for _ in range(50):
+        st = api_client.get(f"/convert/jobs/{job_id}")
+        if st.json()["status"] == "done":
+            break
+    assert st.json()["status"] == "done"
+    dl = api_client.get(f"/convert/jobs/{job_id}/download")
+    assert dl.status_code == 200
+    zf = zipfile.ZipFile(BytesIO(dl.content))
+    assert "document.md" in zf.namelist()

--- a/playwright-to-md/tests/test_playwright_integration.py
+++ b/playwright-to-md/tests/test_playwright_integration.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("playwright")
+
+from md_generator.playwright.options import PlaywrightOptions
+from md_generator.playwright.pipeline import convert_url_to_md
+
+
+@pytest.mark.integration
+def test_pipeline_react_tutorial(tmp_path: Path) -> None:
+    opts = PlaywrightOptions(
+        wait_until="load",
+        navigation_timeout_ms=90_000.0,
+        max_scroll_rounds=8,
+        chunk_markdown=True,
+    )
+    out = tmp_path / "react"
+    try:
+        path = asyncio.run(
+            convert_url_to_md(
+                "https://react.dev/learn/tutorial-tic-tac-toe",
+                out,
+                opts,
+            )
+        )
+    except Exception as e:
+        msg = str(e).lower()
+        if "executable doesn't exist" in msg or ("browser" in msg and "install" in msg):
+            pytest.skip(f"Playwright browser missing: {e}")
+        raise
+    text = path.read_text(encoding="utf-8")
+    assert "source: https://react.dev/learn/tutorial-tic-tac-toe" in text
+    assert "React" in text or "react" in text.lower()
+    assert "chunk:start" in text
+
+
+@pytest.mark.integration
+def test_pipeline_angular_overview(tmp_path: Path) -> None:
+    opts = PlaywrightOptions(
+        wait_until="load",
+        navigation_timeout_ms=90_000.0,
+        max_scroll_rounds=8,
+        chunk_markdown=True,
+    )
+    out = tmp_path / "angular"
+    try:
+        path = asyncio.run(convert_url_to_md("https://angular.dev/overview", out, opts))
+    except Exception as e:
+        msg = str(e).lower()
+        if "executable doesn't exist" in msg or ("browser" in msg and "install" in msg):
+            pytest.skip(f"Playwright browser missing: {e}")
+        raise
+    text = path.read_text(encoding="utf-8")
+    assert "angular.dev" in text
+    assert "Angular" in text or "angular" in text.lower()

--- a/playwright-to-md/tests/test_playwright_unit.py
+++ b/playwright-to-md/tests/test_playwright_unit.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import httpx
+import pytest
+
+from md_generator.playwright import assets, chunker, extractor, html_to_md
+
+
+def test_extract_main_content_prefers_main() -> None:
+    html = """<!DOCTYPE html><html><head></head><body>
+    <nav>Nav</nav>
+    <main><p>Hello main</p></main>
+    <footer>Foot</footer>
+    </body></html>"""
+    out = extractor.extract_main_content(html)
+    assert "Hello main" in out
+    assert "Nav" not in out
+    assert "Foot" not in out
+
+
+def test_convert_html_to_markdown_headings() -> None:
+    html = "<h2>Title</h2><ul><li>a</li></ul>"
+    md = html_to_md.convert_html_to_markdown(html, use_readability=False)
+    assert "## Title" in md or "Title" in md
+    assert "a" in md
+
+
+def test_chunk_markdown_inserts_markers() -> None:
+    body = "\n\n".join([f"Paragraph {i} with some text." for i in range(80)])
+    out = chunker.chunk_markdown(body, max_tokens=10, chars_per_token=4)
+    assert "chunk:start" in out
+    assert "chunk:end" in out
+
+
+def test_process_assets_mock_transport(tmp_path: Path) -> None:
+    img_url = "https://img.example.test/pixel.png"
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.host == "img.example.test":
+            return httpx.Response(200, content=b"\x89PNG\r\n\x1a\n", headers={"content-type": "image/png"})
+        return httpx.Response(404)
+
+    transport = httpx.MockTransport(handler)
+    client = httpx.Client(transport=transport)
+    md = f"![x]({img_url})"
+    out = assets.process_assets(
+        md,
+        "https://page.example.test/",
+        tmp_path,
+        client=client,
+        max_images=5,
+    )
+    client.close()
+    assert "assets/images/" in out
+    imgs = list((tmp_path / "assets" / "images").glob("*"))
+    assert len(imgs) >= 1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ requires-python = ">=3.10"
 license = "MIT"
 license-files = ["LICENSE"]
 authors = [{ name = "mdengine contributors" }]
-keywords = ["markdown", "pdf", "docx", "pptx", "xlsx", "ocr", "zip", "url", "html", "youtube"]
+keywords = ["markdown", "pdf", "docx", "pptx", "xlsx", "ocr", "zip", "url", "html", "youtube", "playwright"]
 classifiers = [
   "Programming Language :: Python :: 3",
   "Programming Language :: Python :: 3 :: Only",
@@ -82,6 +82,16 @@ youtube = [
   "beautifulsoup4>=4.12.0",
   "lxml>=5.0.0",
 ]
+# Playwright-rendered SPA → Markdown (install browsers: playwright install chromium).
+playwright = [
+  "playwright>=1.49.0",
+  "httpx>=0.27.0",
+  "beautifulsoup4>=4.12.0",
+  "lxml>=5.0.0",
+  "markdownify>=0.14.0",
+  "readability-lxml>=0.8.1",
+  "Pillow>=10.0.0",
+]
 api = [
   "fastapi>=0.115.0",
   "uvicorn[standard]>=0.32.0",
@@ -99,6 +109,7 @@ dev = [
   "mdengine[api]",
   "mdengine[mcp]",
   "mdengine[url]",
+  "mdengine[playwright]",
 ]
 all = [
   "pymupdf>=1.24.0",
@@ -151,6 +162,9 @@ md-video-mcp = "md_generator.media.video.api.mcp_server:main"
 md-youtube = "md_generator.media.youtube.converter:main"
 md-youtube-api = "md_generator.media.youtube.api.run:main"
 md-youtube-mcp = "md_generator.media.youtube.api.mcp_server:main"
+md-playwright = "md_generator.playwright.cli:main"
+md-playwright-api = "md_generator.playwright.api.run:main"
+md-playwright-mcp = "md_generator.playwright.api.mcp_server:main"
 
 [tool.setuptools.packages.find]
 where = ["src"]
@@ -169,5 +183,6 @@ testpaths = [
   "audio-to-md/tests",
   "video-to-md/tests",
   "youtube-to-md/tests",
+  "playwright-to-md/tests",
 ]
 markers = ["integration: optional dependency or slower checks"]

--- a/src/md_generator/playwright/__init__.py
+++ b/src/md_generator/playwright/__init__.py
@@ -1,0 +1,6 @@
+"""Playwright-based SPA render → Markdown pipeline."""
+
+from md_generator.playwright.options import PlaywrightOptions
+from md_generator.playwright.pipeline import convert_url_to_md
+
+__all__ = ["PlaywrightOptions", "convert_url_to_md"]

--- a/src/md_generator/playwright/api/__init__.py
+++ b/src/md_generator/playwright/api/__init__.py
@@ -1,0 +1,1 @@
+"""HTTP API (sync + jobs) and FastMCP stack for playwright-to-md."""

--- a/src/md_generator/playwright/api/convert_runner.py
+++ b/src/md_generator/playwright/api/convert_runner.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import asyncio
+import io
+import zipfile
+from collections.abc import Coroutine
+from pathlib import Path
+from typing import Any
+
+from md_generator.playwright.options import PlaywrightOptions
+from md_generator.playwright.pipeline import convert_url_to_md
+
+
+def zip_directory(root: Path) -> bytes:
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+        for p in sorted(root.rglob("*")):
+            if p.is_file():
+                arc = p.relative_to(root)
+                zf.write(p, arc.as_posix())
+    return buf.getvalue()
+
+
+async def _convert_urls_to_artifact(urls: list[str], artifact: Path, options: PlaywrightOptions) -> None:
+    if len(urls) == 1:
+        await convert_url_to_md(urls[0], artifact, options)
+        return
+    for i, u in enumerate(urls):
+        sub = artifact / f"page-{i}"
+        await convert_url_to_md(u, sub, options)
+
+
+def _run_convert_sync(coro: Coroutine[Any, Any, None]) -> None:
+    """Run async conversion without requiring the caller to be on the main asyncio loop."""
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        asyncio.run(coro)
+        return
+
+    import concurrent.futures
+
+    def _in_thread() -> None:
+        asyncio.run(coro)
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
+        pool.submit(_in_thread).result()
+
+
+def build_artifact_zip_bytes(
+    *,
+    url: str | None,
+    urls: list[str] | None,
+    options: PlaywrightOptions,
+) -> bytes:
+    """Run Playwright conversion into a temp dir; return ZIP bytes (document.md + assets/)."""
+    import tempfile
+
+    targets: list[str]
+    if urls:
+        targets = list(urls)
+    elif url:
+        targets = [url.strip()]
+    else:
+        targets = []
+
+    with tempfile.TemporaryDirectory() as td:
+        out = Path(td) / "artifact"
+        out.mkdir(parents=True, exist_ok=True)
+        _run_convert_sync(_convert_urls_to_artifact(targets, out, options))
+        return zip_directory(out)

--- a/src/md_generator/playwright/api/jobs.py
+++ b/src/md_generator/playwright/api/jobs.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import shutil
+import threading
+import time
+import uuid
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Callable
+
+
+@dataclass
+class Job:
+    job_id: str
+    workspace: Path
+    status: str = "queued"
+    error: str | None = None
+    created_at: float = field(default_factory=time.time)
+    zip_path: Path | None = None
+
+
+class JobStore:
+    def __init__(self, base_temp: Path | None, ttl_seconds: int) -> None:
+        self._base = base_temp
+        self._ttl = ttl_seconds
+        self._jobs: dict[str, Job] = {}
+        self._lock = threading.Lock()
+        self._sweeper_started = False
+
+    def _root(self) -> Path:
+        import tempfile
+
+        if self._base:
+            p = Path(self._base)
+            p.mkdir(parents=True, exist_ok=True)
+            return p
+        return Path(tempfile.gettempdir()) / "playwright-to-md-jobs"
+
+    def start_sweeper(self) -> None:
+        if self._sweeper_started:
+            return
+        self._sweeper_started = True
+
+        def loop() -> None:
+            while True:
+                time.sleep(60)
+                self.sweep()
+
+        threading.Thread(target=loop, daemon=True).start()
+
+    def sweep(self) -> None:
+        now = time.time()
+        with self._lock:
+            dead: list[str] = []
+            for jid, job in self._jobs.items():
+                if job.status in ("done", "failed") and now - job.created_at > self._ttl:
+                    dead.append(jid)
+            for jid in dead:
+                job = self._jobs.pop(jid, None)
+                if job and job.workspace.exists():
+                    shutil.rmtree(job.workspace, ignore_errors=True)
+
+    def create_job(self) -> Job:
+        jid = str(uuid.uuid4())
+        ws = self._root() / jid
+        ws.mkdir(parents=True, exist_ok=True)
+        job = Job(job_id=jid, workspace=ws)
+        with self._lock:
+            self._jobs[jid] = job
+        return job
+
+    def get(self, job_id: str) -> Job | None:
+        with self._lock:
+            return self._jobs.get(job_id)
+
+    def run_async(self, job: Job, fn: Callable[[], None]) -> None:
+        def target() -> None:
+            try:
+                job.status = "running"
+                fn()
+                job.status = "done"
+            except Exception as e:
+                job.status = "failed"
+                job.error = str(e)
+
+        threading.Thread(target=target, daemon=True).start()
+
+    def remove_after_download(self, job: Job) -> None:
+        with self._lock:
+            self._jobs.pop(job.job_id, None)
+        if job.workspace.exists():
+            shutil.rmtree(job.workspace, ignore_errors=True)

--- a/src/md_generator/playwright/api/main.py
+++ b/src/md_generator/playwright/api/main.py
@@ -1,0 +1,295 @@
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from pathlib import Path
+from typing import Literal
+from urllib.parse import urlparse
+
+from fastapi import FastAPI, HTTPException, Request
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import FileResponse, Response
+from pydantic import BaseModel, Field, model_validator
+from starlette.background import BackgroundTask
+
+from md_generator.playwright.api.convert_runner import build_artifact_zip_bytes
+from md_generator.playwright.api.jobs import JobStore
+from md_generator.playwright.api.mcp_setup import build_mcp_stack
+from md_generator.playwright.api.settings import PlaywrightApiSettings, cors_list
+from md_generator.playwright.options import PlaywrightOptions, WaitUntil
+
+_mcp, _mcp_http = build_mcp_stack(mount_under_fastapi=True)
+
+
+def _is_http_url(s: str) -> bool:
+    p = urlparse(s.strip())
+    return p.scheme in ("http", "https") and bool(p.netloc)
+
+
+WaitUntilField = Literal["load", "domcontentloaded", "commit", "networkidle"]
+
+
+class ConvertJsonBody(BaseModel):
+    url: str | None = None
+    urls: list[str] | None = None
+    navigation_timeout_seconds: float = Field(default=60.0, ge=1.0, le=300.0)
+    wait_selector: str | None = None
+    wait_until: WaitUntilField = "networkidle"
+    max_scroll_rounds: int = Field(default=12, ge=0, le=100)
+    scroll_pause_ms: float = Field(default=400.0, ge=0.0, le=10_000.0)
+    max_retries: int = Field(default=3, ge=1, le=10)
+    retry_backoff_seconds: float = Field(default=1.5, ge=0.1, le=60.0)
+    headless: bool = True
+    use_readability: bool = True
+    chunk_markdown: bool = True
+    max_chunk_tokens: int = Field(default=900, ge=100, le=8000)
+    chars_per_token: int = Field(default=4, ge=1, le=16)
+    max_images: int = Field(default=40, ge=0, le=200)
+    max_image_bytes: int = Field(default=5 * 1024 * 1024, ge=1024, le=50 * 1024 * 1024)
+    asset_timeout_seconds: float = Field(default=30.0, ge=1.0, le=120.0)
+
+    @model_validator(mode="after")
+    def check_source(self) -> ConvertJsonBody:
+        has_url = self.url is not None and bool(self.url.strip())
+        has_urls = self.urls is not None and len(self.urls) > 0
+        if not has_url and not has_urls:
+            raise ValueError("Provide url or urls")
+        if has_url and has_urls:
+            raise ValueError("Provide only one of url or urls")
+        if self.urls:
+            for u in self.urls:
+                if not _is_http_url(u):
+                    raise ValueError(f"Invalid URL: {u!r}")
+        if self.url and not _is_http_url(self.url):
+            raise ValueError("Invalid url")
+        return self
+
+
+def _merged_options(
+    body: ConvertJsonBody,
+    *,
+    navigation_timeout_seconds: float | None = None,
+    wait_selector: str | None = None,
+    wait_until: WaitUntil | None = None,
+    max_scroll_rounds: int | None = None,
+    scroll_pause_ms: float | None = None,
+    max_retries: int | None = None,
+    retry_backoff_seconds: float | None = None,
+    headless: bool | None = None,
+    use_readability: bool | None = None,
+    chunk_markdown: bool | None = None,
+    max_chunk_tokens: int | None = None,
+    chars_per_token: int | None = None,
+    max_images: int | None = None,
+    max_image_bytes: int | None = None,
+    asset_timeout_seconds: float | None = None,
+) -> PlaywrightOptions:
+    wu: WaitUntil = wait_until if wait_until is not None else body.wait_until  # type: ignore[assignment]
+    nav_s = (
+        navigation_timeout_seconds
+        if navigation_timeout_seconds is not None
+        else body.navigation_timeout_seconds
+    )
+    return PlaywrightOptions(
+        navigation_timeout_ms=nav_s * 1000.0,
+        wait_selector=wait_selector if wait_selector is not None else body.wait_selector,
+        wait_until=wu,
+        max_scroll_rounds=max_scroll_rounds if max_scroll_rounds is not None else body.max_scroll_rounds,
+        scroll_pause_ms=scroll_pause_ms if scroll_pause_ms is not None else body.scroll_pause_ms,
+        max_retries=max_retries if max_retries is not None else body.max_retries,
+        retry_backoff_seconds=retry_backoff_seconds
+        if retry_backoff_seconds is not None
+        else body.retry_backoff_seconds,
+        headless=headless if headless is not None else body.headless,
+        use_readability=use_readability if use_readability is not None else body.use_readability,
+        chunk_markdown=chunk_markdown if chunk_markdown is not None else body.chunk_markdown,
+        max_chunk_tokens=max_chunk_tokens if max_chunk_tokens is not None else body.max_chunk_tokens,
+        chars_per_token=chars_per_token if chars_per_token is not None else body.chars_per_token,
+        max_images=max_images if max_images is not None else body.max_images,
+        max_image_bytes=max_image_bytes if max_image_bytes is not None else body.max_image_bytes,
+        asset_timeout_seconds=asset_timeout_seconds
+        if asset_timeout_seconds is not None
+        else body.asset_timeout_seconds,
+        verbose=False,
+    )
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    settings = PlaywrightApiSettings()
+    base = Path(settings.temp_dir) if settings.temp_dir else None
+    store = JobStore(base, settings.job_ttl_seconds)
+    store.start_sweeper()
+    app.state.settings = settings
+    app.state.job_store = store
+    async with _mcp.session_manager.run():
+        yield
+
+
+app = FastAPI(title="playwright-to-md", lifespan=lifespan)
+app.mount("/mcp", _mcp_http)
+
+_bootstrap_settings = PlaywrightApiSettings()
+_origins = cors_list(_bootstrap_settings)
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=_origins,
+    allow_credentials="*" not in _origins,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+
+def _count_targets(body: ConvertJsonBody) -> int:
+    if body.urls:
+        return len(body.urls)
+    return 1
+
+
+def _sync_allowed(settings: PlaywrightApiSettings, body: ConvertJsonBody) -> bool:
+    return _count_targets(body) <= settings.max_sync_urls
+
+
+@app.post("/convert/sync")
+async def convert_sync(
+    request: Request,
+    body: ConvertJsonBody,
+    navigation_timeout_seconds: float | None = None,
+    wait_selector: str | None = None,
+    wait_until: WaitUntilField | None = None,
+    max_scroll_rounds: int | None = None,
+    scroll_pause_ms: float | None = None,
+    max_retries: int | None = None,
+    retry_backoff_seconds: float | None = None,
+    headless: bool | None = None,
+    use_readability: bool | None = None,
+    chunk_markdown: bool | None = None,
+    max_chunk_tokens: int | None = None,
+    chars_per_token: int | None = None,
+    max_images: int | None = None,
+    max_image_bytes: int | None = None,
+    asset_timeout_seconds: float | None = None,
+) -> Response:
+    settings: PlaywrightApiSettings = request.app.state.settings
+    if _count_targets(body) > settings.max_job_urls:
+        raise HTTPException(400, detail=f"At most {settings.max_job_urls} URLs per request")
+
+    opts = _merged_options(
+        body,
+        navigation_timeout_seconds=navigation_timeout_seconds,
+        wait_selector=wait_selector,
+        wait_until=wait_until,
+        max_scroll_rounds=max_scroll_rounds,
+        scroll_pause_ms=scroll_pause_ms,
+        max_retries=max_retries,
+        retry_backoff_seconds=retry_backoff_seconds,
+        headless=headless,
+        use_readability=use_readability,
+        chunk_markdown=chunk_markdown,
+        max_chunk_tokens=max_chunk_tokens,
+        chars_per_token=chars_per_token,
+        max_images=max_images,
+        max_image_bytes=max_image_bytes,
+        asset_timeout_seconds=asset_timeout_seconds,
+    )
+    if not _sync_allowed(settings, body):
+        raise HTTPException(
+            status_code=409,
+            detail="Too many URLs for sync; use POST /convert/jobs",
+        )
+
+    url_arg = body.url.strip() if body.url else None
+    urls_arg = body.urls
+    zbytes = build_artifact_zip_bytes(url=url_arg, urls=urls_arg, options=opts)
+    return Response(
+        content=zbytes,
+        media_type="application/zip",
+        headers={"Content-Disposition": 'attachment; filename="artifact.zip"'},
+    )
+
+
+@app.post("/convert/jobs")
+async def convert_jobs(
+    request: Request,
+    body: ConvertJsonBody,
+    navigation_timeout_seconds: float | None = None,
+    wait_selector: str | None = None,
+    wait_until: WaitUntilField | None = None,
+    max_scroll_rounds: int | None = None,
+    scroll_pause_ms: float | None = None,
+    max_retries: int | None = None,
+    retry_backoff_seconds: float | None = None,
+    headless: bool | None = None,
+    use_readability: bool | None = None,
+    chunk_markdown: bool | None = None,
+    max_chunk_tokens: int | None = None,
+    chars_per_token: int | None = None,
+    max_images: int | None = None,
+    max_image_bytes: int | None = None,
+    asset_timeout_seconds: float | None = None,
+) -> dict:
+    settings: PlaywrightApiSettings = request.app.state.settings
+    store: JobStore = request.app.state.job_store
+    if _count_targets(body) > settings.max_job_urls:
+        raise HTTPException(400, detail=f"At most {settings.max_job_urls} URLs per request")
+
+    opts = _merged_options(
+        body,
+        navigation_timeout_seconds=navigation_timeout_seconds,
+        wait_selector=wait_selector,
+        wait_until=wait_until,
+        max_scroll_rounds=max_scroll_rounds,
+        scroll_pause_ms=scroll_pause_ms,
+        max_retries=max_retries,
+        retry_backoff_seconds=retry_backoff_seconds,
+        headless=headless,
+        use_readability=use_readability,
+        chunk_markdown=chunk_markdown,
+        max_chunk_tokens=max_chunk_tokens,
+        chars_per_token=chars_per_token,
+        max_images=max_images,
+        max_image_bytes=max_image_bytes,
+        asset_timeout_seconds=asset_timeout_seconds,
+    )
+    job = store.create_job()
+    url_arg = body.url.strip() if body.url else None
+    urls_arg = body.urls
+
+    def work() -> None:
+        zbytes = build_artifact_zip_bytes(url=url_arg, urls=urls_arg, options=opts)
+        zpath = job.workspace / "artifact.zip"
+        zpath.write_bytes(zbytes)
+        job.zip_path = zpath
+
+    store.run_async(job, work)
+    return {"job_id": job.job_id, "status": job.status}
+
+
+@app.get("/convert/jobs/{job_id}")
+async def job_status(request: Request, job_id: str) -> dict:
+    store: JobStore = request.app.state.job_store
+    job = store.get(job_id)
+    if not job:
+        raise HTTPException(404, detail="Unknown job_id")
+    return {
+        "status": job.status,
+        "error": job.error,
+        "created_at": job.created_at,
+    }
+
+
+@app.get("/convert/jobs/{job_id}/download", response_class=FileResponse)
+async def job_download(request: Request, job_id: str) -> FileResponse:
+    store: JobStore = request.app.state.job_store
+    job = store.get(job_id)
+    if not job:
+        raise HTTPException(404, detail="Unknown job_id")
+    if job.status != "done" or not job.zip_path or not job.zip_path.is_file():
+        raise HTTPException(400, detail="Job is not ready for download")
+    path = job.zip_path
+    task = BackgroundTask(store.remove_after_download, job)
+    return FileResponse(
+        path,
+        media_type="application/zip",
+        filename="artifact.zip",
+        background=task,
+    )

--- a/src/md_generator/playwright/api/mcp_server.py
+++ b/src/md_generator/playwright/api/mcp_server.py
@@ -1,0 +1,37 @@
+"""
+Standalone MCP server (stdio, SSE, or streamable-http on FASTMCP_PORT / settings.port).
+
+Examples:
+  python -m md_generator.playwright.api.mcp_server
+  python -m md_generator.playwright.api.mcp_server --transport sse
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="playwright-to-md MCP server")
+    parser.add_argument(
+        "--transport",
+        choices=("stdio", "sse", "streamable-http"),
+        default="stdio",
+    )
+    args = parser.parse_args()
+
+    from md_generator.playwright.api.mcp_setup import build_mcp_stack
+
+    mcp, _ = build_mcp_stack(mount_under_fastapi=False)
+
+    if args.transport == "stdio":
+        asyncio.run(mcp.run_stdio_async())
+    elif args.transport == "sse":
+        asyncio.run(mcp.run_sse_async())
+    else:
+        asyncio.run(mcp.run_streamable_http_async())
+
+
+if __name__ == "__main__":
+    main()

--- a/src/md_generator/playwright/api/mcp_setup.py
+++ b/src/md_generator/playwright/api/mcp_setup.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+from mcp.server.fastmcp import FastMCP
+
+from md_generator.playwright.api.convert_runner import build_artifact_zip_bytes
+from md_generator.playwright.options import PlaywrightOptions, WaitUntil
+
+
+def build_mcp_stack(*, mount_under_fastapi: bool = False) -> tuple[FastMCP, object]:
+    path = "/" if mount_under_fastapi else "/mcp"
+    mcp = FastMCP(
+        "playwright-to-md",
+        instructions=(
+            "Render JavaScript-heavy pages with Playwright, extract readable content, "
+            "and return a temporary artifact.zip path on the server (Markdown + downloaded images)."
+        ),
+        streamable_http_path=path,
+    )
+
+    @mcp.tool()
+    def convert_spa_url_to_artifact_zip(
+        url: str,
+        navigation_timeout_seconds: float = 60.0,
+        wait_selector: str | None = None,
+        wait_until: WaitUntil = "networkidle",
+        max_scroll_rounds: int = 12,
+        headless: bool = True,
+        use_readability: bool = True,
+        chunk_markdown: bool = True,
+    ) -> str:
+        """Fetch one URL with a headless browser, convert to Markdown + assets, return artifact.zip path."""
+        u = url.strip()
+        if not u.startswith(("http://", "https://")):
+            raise ValueError("url must start with http:// or https://")
+        opts = PlaywrightOptions(
+            navigation_timeout_ms=navigation_timeout_seconds * 1000.0,
+            wait_selector=wait_selector,
+            wait_until=wait_until,
+            max_scroll_rounds=max_scroll_rounds,
+            headless=headless,
+            use_readability=use_readability,
+            chunk_markdown=chunk_markdown,
+            verbose=False,
+        )
+        data = build_artifact_zip_bytes(url=u, urls=None, options=opts)
+        fd, name = tempfile.mkstemp(suffix=".zip", prefix="playwright-artifact-")
+        import os
+
+        os.close(fd)
+        out = Path(name)
+        out.write_bytes(data)
+        return str(out)
+
+    sub = mcp.streamable_http_app()
+    return mcp, sub

--- a/src/md_generator/playwright/api/run.py
+++ b/src/md_generator/playwright/api/run.py
@@ -1,0 +1,29 @@
+"""Run the Playwright REST + MCP FastAPI app with uvicorn."""
+
+from __future__ import annotations
+
+import argparse
+
+
+def main(argv: list[str] | None = None) -> int:
+    import uvicorn
+
+    from md_generator.playwright.api.settings import PlaywrightApiSettings
+
+    p = argparse.ArgumentParser(description="playwright-to-md HTTP API (REST + MCP at /mcp)")
+    p.add_argument("--host", default=None)
+    p.add_argument("--port", type=int, default=None)
+    ns = p.parse_args(argv)
+    s = PlaywrightApiSettings()
+    host = ns.host or s.api_host
+    port = ns.port if ns.port is not None else s.api_port
+    uvicorn.run(
+        "md_generator.playwright.api.main:app",
+        host=host,
+        port=port,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/md_generator/playwright/api/settings.py
+++ b/src/md_generator/playwright/api/settings.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class PlaywrightApiSettings(BaseSettings):
+    model_config = SettingsConfigDict(
+        env_prefix="PLAYWRIGHT_TO_MD_",
+        env_file=".env",
+        extra="ignore",
+    )
+
+    max_sync_urls: int = 3
+    max_job_urls: int = 20
+    job_ttl_seconds: int = 3600
+    temp_dir: str | None = None
+    cors_origins: str = "*"
+    api_host: str = "127.0.0.1"
+    api_port: int = 8014
+
+
+def cors_list(settings: PlaywrightApiSettings) -> list[str]:
+    raw = (settings.cors_origins or "*").strip()
+    if raw == "*":
+        return ["*"]
+    return [o.strip() for o in raw.split(",") if o.strip()]

--- a/src/md_generator/playwright/assets.py
+++ b/src/md_generator/playwright/assets.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+import hashlib
+import re
+from pathlib import Path
+from typing import Callable
+from urllib.parse import urljoin, urlparse
+
+import httpx
+
+_MD_IMG = re.compile(r"!\[([^\]]*)\]\(([^)]+)\)")
+
+
+def _short_hash(url: str) -> str:
+    return hashlib.sha256(url.encode("utf-8")).hexdigest()[:12]
+
+
+def _guess_ext(url: str, content_type: str | None) -> str:
+    path = urlparse(url).path.lower()
+    for ext in (".png", ".jpg", ".jpeg", ".gif", ".webp", ".svg", ".ico", ".bmp"):
+        if path.endswith(ext):
+            return ".jpg" if ext == ".jpeg" else ext
+    if content_type:
+        ct = content_type.split(";")[0].strip().lower()
+        if "png" in ct:
+            return ".png"
+        if "jpeg" in ct or "jpg" in ct:
+            return ".jpg"
+        if "gif" in ct:
+            return ".gif"
+        if "webp" in ct:
+            return ".webp"
+        if "svg" in ct:
+            return ".svg"
+    return ".bin"
+
+
+def _download_image(
+    client: httpx.Client,
+    abs_url: str,
+    max_bytes: int,
+    timeout: float,
+) -> tuple[bytes, str | None]:
+    total = 0
+    chunks: list[bytes] = []
+    ct: str | None = None
+    with client.stream("GET", abs_url, follow_redirects=True, timeout=timeout) as resp:
+        resp.raise_for_status()
+        ct = resp.headers.get("content-type")
+        for chunk in resp.iter_bytes():
+            total += len(chunk)
+            if total > max_bytes:
+                raise ValueError(f"Image exceeds max_image_bytes when fetching {abs_url!r}")
+            chunks.append(chunk)
+    return b"".join(chunks), ct
+
+
+def process_assets(
+    markdown: str,
+    base_url: str,
+    output_dir: Path | str,
+    *,
+    client: httpx.Client | None = None,
+    max_images: int = 40,
+    max_image_bytes: int = 5 * 1024 * 1024,
+    asset_timeout_seconds: float = 30.0,
+    url_filter: Callable[[str], bool] | None = None,
+) -> str:
+    """
+    Find Markdown image references, download http(s) targets under output_dir/assets/images,
+    rewrite to relative paths. Optional ``client`` for tests; optional ``url_filter`` to limit URLs.
+    """
+    out = Path(output_dir)
+    img_dir = out / "assets" / "images"
+    img_dir.mkdir(parents=True, exist_ok=True)
+
+    own_client = client is None
+    hc = client or httpx.Client(
+        headers={"User-Agent": "mdengine-playwright/0.1"},
+        follow_redirects=True,
+    )
+    try:
+        result = markdown
+        seen = 0
+        for m in _MD_IMG.finditer(markdown):
+            if seen >= max_images:
+                break
+            alt, raw = m.group(1), m.group(2).strip()
+            if raw.startswith("data:"):
+                continue
+            if raw.startswith(("http://", "https://")):
+                abs_url = raw
+            else:
+                abs_url = urljoin(base_url, raw)
+            if not abs_url.startswith(("http://", "https://")):
+                continue
+            if url_filter is not None and not url_filter(abs_url):
+                continue
+            try:
+                data, ct = _download_image(
+                    hc,
+                    abs_url,
+                    max_image_bytes,
+                    asset_timeout_seconds,
+                )
+                ext = _guess_ext(abs_url, ct)
+                name = f"img_{seen + 1:03d}_{_short_hash(abs_url)}{ext}"
+                dest = img_dir / name
+                dest.write_bytes(data)
+                rel = f"assets/images/{name}"
+                new_ref = f"![{alt}]({rel})"
+                result = result.replace(m.group(0), new_ref, 1)
+                seen += 1
+            except Exception:
+                continue
+        return result
+    finally:
+        if own_client:
+            hc.close()

--- a/src/md_generator/playwright/chunker.py
+++ b/src/md_generator/playwright/chunker.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+
+def chunk_markdown(
+    md: str,
+    *,
+    max_tokens: int = 900,
+    overlap_chars: int = 0,
+    chars_per_token: int = 4,
+) -> str:
+    """
+    Split Markdown into ~max_tokens chunks using a simple chars-per-token estimate.
+    Inserts <!-- chunk:start id=N --> ... <!-- chunk:end --> markers.
+    """
+    _ = overlap_chars  # reserved for future overlap between chunks
+    max_chars = max(200, max_tokens * max(1, chars_per_token))
+    text = md.strip()
+    if not text:
+        return md
+
+    paragraphs = text.split("\n\n")
+    chunks: list[str] = []
+    buf: list[str] = []
+    buf_len = 0
+
+    def flush() -> None:
+        nonlocal buf, buf_len
+        if not buf:
+            return
+        block = "\n\n".join(buf).strip()
+        if block:
+            chunks.append(block)
+        buf = []
+        buf_len = 0
+
+    for para in paragraphs:
+        plen = len(para) + (2 if buf else 0)
+        if buf_len + plen > max_chars and buf:
+            flush()
+        buf.append(para)
+        buf_len += plen
+        if buf_len >= max_chars:
+            flush()
+
+    flush()
+
+    if len(chunks) <= 1:
+        return md
+
+    parts: list[str] = []
+    for i, c in enumerate(chunks, start=1):
+        parts.append(f"<!-- chunk:start id={i} -->\n\n{c}\n\n<!-- chunk:end -->\n")
+    return "\n".join(parts).rstrip() + "\n"

--- a/src/md_generator/playwright/cli.py
+++ b/src/md_generator/playwright/cli.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+import argparse
+import asyncio
+import sys
+from pathlib import Path
+
+from md_generator.playwright.options import PlaywrightOptions, WaitUntil
+from md_generator.playwright.pipeline import convert_url_to_md
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        description="Render SPA pages with Playwright and convert to LLM-ready Markdown.",
+    )
+    p.add_argument("url", help="HTTP or HTTPS URL to fetch")
+    p.add_argument(
+        "--output",
+        "-o",
+        type=Path,
+        default=Path("."),
+        help="Output directory (default: current directory)",
+    )
+    p.add_argument(
+        "--wait",
+        type=str,
+        default=None,
+        metavar="SELECTOR",
+        dest="wait_selector",
+        help="Optional CSS selector to wait for before scrolling",
+    )
+    p.add_argument(
+        "--timeout",
+        type=float,
+        default=60.0,
+        help="Navigation timeout in seconds (default: 60)",
+    )
+    p.add_argument("--user-agent", type=str, default=None, help="Override browser User-Agent")
+    p.add_argument(
+        "--wait-until",
+        type=str,
+        choices=("load", "domcontentloaded", "commit", "networkidle"),
+        default="networkidle",
+        help="Playwright goto wait_until (default: networkidle)",
+    )
+    p.add_argument(
+        "--max-scroll-rounds",
+        type=int,
+        default=12,
+        help="Max scroll-to-bottom iterations for lazy loading (default: 12)",
+    )
+    p.add_argument(
+        "--retries",
+        type=int,
+        default=3,
+        help="Max fetch attempts with backoff (default: 3)",
+    )
+    p.add_argument(
+        "--no-chunk",
+        action="store_true",
+        help="Disable chunk markers in output Markdown",
+    )
+    p.add_argument(
+        "--no-readability",
+        action="store_true",
+        help="Skip readability pass before markdownify",
+    )
+    p.add_argument(
+        "--screenshot",
+        type=Path,
+        default=None,
+        help="Save full-page PNG screenshot to this path",
+    )
+    p.add_argument(
+        "--save-raw-html",
+        type=Path,
+        default=None,
+        help="Save raw rendered HTML to this path",
+    )
+    p.add_argument(
+        "--max-chunk-tokens",
+        type=int,
+        default=900,
+        help="Approximate max tokens per chunk (default: 900)",
+    )
+    p.add_argument("-v", "--verbose", action="store_true")
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _build_parser()
+    ns = parser.parse_args(argv)
+    u = ns.url.strip()
+    if not u.startswith(("http://", "https://")):
+        print("URL must start with http:// or https://", file=sys.stderr)
+        return 2
+
+    wait_until: WaitUntil = ns.wait_until  # type: ignore[assignment]
+    opts = PlaywrightOptions(
+        navigation_timeout_ms=ns.timeout * 1000.0,
+        wait_selector=ns.wait_selector,
+        wait_until=wait_until,
+        max_scroll_rounds=ns.max_scroll_rounds,
+        max_retries=ns.retries,
+        user_agent=ns.user_agent or PlaywrightOptions().user_agent,
+        chunk_markdown=not ns.no_chunk,
+        max_chunk_tokens=ns.max_chunk_tokens,
+        use_readability=not ns.no_readability,
+        verbose=ns.verbose,
+        screenshot_path=ns.screenshot,
+        save_raw_html_path=ns.save_raw_html,
+    )
+
+    try:
+        path = asyncio.run(convert_url_to_md(u, ns.output, opts))
+    except ImportError as e:
+        print(str(e), file=sys.stderr)
+        return 2
+    except Exception as e:
+        print(f"Conversion failed: {e}", file=sys.stderr)
+        if ns.verbose:
+            raise
+        return 1
+
+    if ns.verbose:
+        print(path)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/md_generator/playwright/extractor.py
+++ b/src/md_generator/playwright/extractor.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from bs4 import BeautifulSoup
+
+
+def extract_main_content(html: str) -> str:
+    """
+    Strip chrome (script/style/nav/footer/header), then prefer main/article/role=main.
+    Returns HTML string of the chosen subtree (or body).
+    """
+    soup = BeautifulSoup(html, "lxml")
+    for tag in soup.find_all(["script", "style", "noscript"]):
+        tag.decompose()
+    for tag in soup.find_all(["nav", "footer", "header"]):
+        tag.decompose()
+
+    root = (
+        soup.find("main")
+        or soup.select_one('[role="main"]')
+        or soup.find("article")
+        or soup.find("body")
+        or soup
+    )
+    return str(root)

--- a/src/md_generator/playwright/html_to_md.py
+++ b/src/md_generator/playwright/html_to_md.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from markdownify import markdownify as html_to_markdown
+
+
+def convert_html_to_markdown(html: str, *, use_readability: bool = True, page_url: str = "") -> str:
+    """
+    Optionally run readability on HTML fragment, then markdownify with sensible defaults.
+    """
+    fragment = html
+    if use_readability:
+        try:
+            from readability import Document
+
+            doc = Document(html, url=page_url or "https://example.com/")
+            fragment = doc.summary()
+        except Exception:
+            fragment = html
+
+    return html_to_markdown(
+        fragment,
+        heading_style="ATX",
+        bullets="-",
+        strip=["script", "style", "noscript"],
+    ).strip()

--- a/src/md_generator/playwright/options.py
+++ b/src/md_generator/playwright/options.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+
+
+WaitUntil = Literal["load", "domcontentloaded", "commit", "networkidle"]
+
+
+@dataclass
+class PlaywrightOptions:
+    """Configuration for SPA fetch → Markdown pipeline."""
+
+    verbose: bool = False
+    navigation_timeout_ms: float = 60_000.0
+    user_agent: str = (
+        "mdengine-playwright/0.1 (+https://github.com/vishal7090/md-generator)"
+    )
+    wait_selector: str | None = None
+    wait_until: WaitUntil = "networkidle"
+    max_scroll_rounds: int = 12
+    scroll_pause_ms: float = 400.0
+    max_retries: int = 3
+    retry_backoff_seconds: float = 1.5
+    headless: bool = True
+    use_readability: bool = True
+    chunk_markdown: bool = True
+    max_chunk_tokens: int = 900
+    chars_per_token: int = 4
+    max_images: int = 40
+    max_image_bytes: int = 5 * 1024 * 1024
+    asset_timeout_seconds: float = 30.0
+    screenshot_path: Path | None = None
+    save_raw_html_path: Path | None = None

--- a/src/md_generator/playwright/pipeline.py
+++ b/src/md_generator/playwright/pipeline.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+from md_generator.playwright import assets, chunker, extractor, html_to_md, playwright_fetcher
+from md_generator.playwright.options import PlaywrightOptions
+
+
+def _metadata_header(url: str) -> str:
+    return "\n".join(
+        [
+            "---",
+            f"source: {url}",
+            "type: url",
+            "---",
+            "",
+        ]
+    )
+
+
+async def convert_url_to_md(
+    url: str,
+    output_dir: Path | str,
+    options: PlaywrightOptions | None = None,
+) -> Path:
+    """
+    Fetch rendered HTML, extract main content, convert to Markdown, download images, chunk, save.
+    """
+    opts = options or PlaywrightOptions()
+    out = Path(output_dir)
+    out.mkdir(parents=True, exist_ok=True)
+
+    raw_html = await playwright_fetcher.fetch_rendered_html(url, options=opts)
+    main_html = extractor.extract_main_content(raw_html)
+    md = html_to_md.convert_html_to_markdown(
+        main_html,
+        use_readability=opts.use_readability,
+        page_url=url,
+    )
+
+    md_assets = await asyncio.to_thread(
+        assets.process_assets,
+        md,
+        url,
+        out,
+        max_images=opts.max_images,
+        max_image_bytes=opts.max_image_bytes,
+        asset_timeout_seconds=opts.asset_timeout_seconds,
+    )
+
+    final_body = (
+        chunker.chunk_markdown(
+            md_assets,
+            max_tokens=opts.max_chunk_tokens,
+            chars_per_token=opts.chars_per_token,
+        )
+        if opts.chunk_markdown
+        else md_assets
+    )
+
+    document = _metadata_header(url) + final_body.strip() + "\n"
+    doc_path = out / "document.md"
+    doc_path.write_text(document, encoding="utf-8")
+    return doc_path

--- a/src/md_generator/playwright/playwright_fetcher.py
+++ b/src/md_generator/playwright/playwright_fetcher.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+from md_generator.playwright.options import PlaywrightOptions
+
+
+async def fetch_rendered_html(
+    url: str,
+    *,
+    wait_selector: str | None = None,
+    options: PlaywrightOptions | None = None,
+) -> str:
+    """
+    Launch headless Chromium, load URL, wait for network settle / selector, scroll for lazy content.
+    """
+    try:
+        from playwright.async_api import async_playwright
+    except ImportError as e:
+        raise ImportError(
+            "playwright is required. Install with: pip install playwright && playwright install chromium"
+        ) from e
+
+    opts = options or PlaywrightOptions()
+    selector = wait_selector if wait_selector is not None else opts.wait_selector
+    last_err: Exception | None = None
+
+    for attempt in range(max(1, opts.max_retries)):
+        try:
+            return await _fetch_once(
+                url,
+                wait_selector=selector,
+                options=opts,
+            )
+        except Exception as e:
+            last_err = e
+            if attempt + 1 >= opts.max_retries:
+                break
+            await asyncio.sleep(opts.retry_backoff_seconds * (attempt + 1))
+
+    assert last_err is not None
+    raise last_err
+
+
+async def _fetch_once(
+    url: str,
+    *,
+    wait_selector: str | None,
+    options: PlaywrightOptions,
+) -> str:
+    from playwright.async_api import async_playwright
+
+    async with async_playwright() as p:
+        browser = await p.chromium.launch(headless=options.headless)
+        try:
+            context = await browser.new_context(user_agent=options.user_agent)
+            page = await context.new_page()
+            try:
+                await page.goto(
+                    url,
+                    wait_until=options.wait_until,
+                    timeout=options.navigation_timeout_ms,
+                )
+            except Exception:
+                if options.wait_until != "networkidle":
+                    raise
+                await page.goto(
+                    url,
+                    wait_until="load",
+                    timeout=options.navigation_timeout_ms,
+                )
+
+            if wait_selector:
+                await page.wait_for_selector(
+                    wait_selector,
+                    timeout=min(options.navigation_timeout_ms, 30_000.0),
+                )
+
+            await _scroll_for_lazy_content(page, options)
+
+            html = await page.content()
+            if options.save_raw_html_path:
+                options.save_raw_html_path.parent.mkdir(parents=True, exist_ok=True)
+                options.save_raw_html_path.write_text(html, encoding="utf-8")
+            if options.screenshot_path:
+                options.screenshot_path.parent.mkdir(parents=True, exist_ok=True)
+                await page.screenshot(path=str(options.screenshot_path), full_page=True)
+
+            return html
+        finally:
+            await browser.close()
+
+
+async def _scroll_for_lazy_content(page, options: PlaywrightOptions) -> None:
+    prev = 0
+    for _ in range(max(1, options.max_scroll_rounds)):
+        height = await page.evaluate(
+            """() => {
+                window.scrollTo(0, document.body.scrollHeight);
+                return document.body.scrollHeight;
+            }"""
+        )
+        await asyncio.sleep(options.scroll_pause_ms / 1000.0)
+        if isinstance(height, (int, float)) and height == prev:
+            break
+        prev = int(height) if height else 0


### PR DESCRIPTION
## Summary

Adds **Playwright-based** rendering so **JavaScript-heavy and SPA pages** can be converted to **Markdown** reliably: fetch and execute the page in a real browser context, then run the existing HTML → Markdown pipeline on the rendered DOM.

Closes #8

## What’s included

- **Optional extra:** `playwright` — depends on `playwright>=1.49.0` (see `pyproject.toml`).
- **CLI:** `md-playwright` — entry point `md_generator.playwright.cli:main`.
- **HTTP API:** `md-playwright-api` — `md_generator.playwright.api.run:main`.
- **MCP:** `md-playwright-mcp` — `md_generator.playwright.api.mcp_server:main` (shared MCP setup in `md_generator.playwright.api.mcp_setup` where applicable).
- **Tests:** `playwright-to-md/tests/` (listed in `pytest` `testpaths`).

## User setup

Playwright requires **browser binaries** (e.g. Chromium):

```bash
pip install "mdengine[playwright]"
playwright install chromium