### PR TITLE
feat(graph-to-md): graph data → Markdown (CLI, API, MCP) (#11)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # mdengine
 
-Single Python distribution for converting **PDF**, **Word (.docx)**, **PowerPoint (.pptx)**, **Excel (.xlsx/.xlsm)**, **images** (OCR), **plain text / JSON / XML**, **ZIP archives**, and **audio / video** (Whisper transcription → Markdown) into **Markdown** (and related assets). Install only the extras you need; everything imports under the **`md_generator`** package.
+Single Python distribution for converting **PDF**, **Word (.docx)**, **PowerPoint (.pptx)**, **Excel (.xlsx/.xlsm)**, **images** (OCR), **plain text / JSON / XML**, **ZIP archives**, **audio / video** (Whisper transcription → Markdown), **database metadata** (SQL + Mongo), and **graphs** (Neo4j / NetworkX → Markdown) into **Markdown** (and related assets). Install only the extras you need; everything imports under the **`md_generator`** package.
 
 - **PyPI name:** `mdengine` (import package: `md_generator`)
 - **Source:** [github.com/vishal7090/md-generator](https://github.com/vishal7090/md-generator)
@@ -78,6 +78,7 @@ pip install "mdengine[all]"
 | `video` | **Video → Markdown** (ffmpeg extracts mono 16 kHz WAV, then same Whisper stack as `audio`) |
 | `api` | FastAPI, uvicorn, httpx, pydantic-settings |
 | `mcp` | MCP servers (`mcp`, `fastmcp` where used) |
+| `graph` | **Graph → Markdown** (Neo4j Bolt + NetworkX GraphML/GML): `networkx`, `neo4j`, `pyyaml` |
 | `dev` | pytest + API/MCP test helpers |
 | `all` | Large superset of dependencies (use only if you need everything) |
 
@@ -92,7 +93,7 @@ All converters can be run from a terminal after you install the package (with th
 ### 1. Install (once)
 
 ```bash
-pip install "mdengine[pdf,word]"          # adjust extras: ppt, xlsx, image, archive, text, db, …
+pip install "mdengine[pdf,word]"          # adjust extras: ppt, xlsx, image, archive, text, db, graph, …
 # or from a clone:
 pip install -e ".[pdf,word,archive]"
 ```
@@ -130,11 +131,16 @@ If the shell reports “command not found”, ensure the Python **Scripts** dire
 | `md-db` | `md_generator.db.cli.main:main` | `pip install "mdengine[db]"` then `md-db --config db.yaml` (or `mdengine db-to-md …`) |
 | `md-db-api` | `md_generator.db.api.run:main` | FastAPI on port **8010** (`DB_TO_MD_PORT`): `POST /db-to-md/run`, `/db-to-md/job`, SSE `/db-to-md/job/{id}/events` |
 | `md-db-mcp` | `md_generator.db.api.mcp_server:main` | Standalone MCP for metadata export tools |
-| `mdengine` | `md_generator.engine_cli:main` | `mdengine db-to-md --uri …` (delegates to `md-db`) |
+| `md-graph` | `md_generator.graph.cli.main:main` | `pip install "mdengine[graph]"` then `md-graph --source neo4j --uri bolt://…` (or `mdengine graph-to-md …`) |
+| `md-graph-api` | `md_generator.graph.api.run:main` | FastAPI on port **8012** (`GRAPH_TO_MD_PORT`): `POST /graph-to-md/run`, `/graph-to-md/job`, SSE `/graph-to-md/job/{id}/events` |
+| `md-graph-mcp` | `md_generator.graph.api.mcp_server:main` | Standalone MCP for graph export tools |
+| `mdengine` | `md_generator.engine_cli:main` | `mdengine db-to-md …` / `mdengine graph-to-md …` (delegates to `md-db` / `md-graph`) |
 
 **db-to-md ER diagrams:** add **`erd`** to the export feature list (YAML `features.include`, API body, or CLI `--include …,erd`). **Preferred:** **Graphviz** (`dot` on `PATH`, or **`GRAPHVIZ_DOT`**) produces `erd/*.dot`, `erd/*.png`, and `erd/*.svg`. **If Graphviz is missing,** the exporter falls back to **Mermaid** (`erDiagram`): it writes `erd/*.mermaid` plus a fenced **`erd/*.md`** for GitHub-style preview. With **`mermaid-py`** (included in `mdengine[db]`), it also requests **PNG/SVG** via mermaid.ink (requires network unless you self-host mermaid.ink and set **`MERMAID_INK_SERVER`** per [mermaid-py](https://pypi.org/project/mermaid-py/)). Tune **`erd.max_tables`** (default 100) and **`erd.scope`** (`full` \| `per_schema` \| `per_table`) under `erd:` in YAML; CLI: `--erd-max-tables`, `--erd-scope`. Async job SSE uses `progress_update` with `current` starting with `erd:`.
 
 **db-to-md split exports and README merge:** with **`output.split_files: true`**, set **`output.write_combined_feature_markdown: true`** to also write root-level combined Markdown (for example `tables.md`, `functions.md`, `indexes.md`, and feature-specific paths such as `oracle/packages.md` or `mongodb/collections.md` when those features run). Set **`output.readme_feature_merge`** to **`inline`** (append full bundle bodies into `README.md`) or **`toc`** (append a linked list to those files). If merge is not **`none`** and split files are on, combined bundle writes are turned on automatically when loading config. CLI: `--write-combined-feature-markdown`, `--readme-feature-merge none|inline|toc`.
+
+**graph-to-md (Neo4j + NetworkX):** library lives under [`md_generator/graph/`](src/md_generator/graph/). **Sources:** **`networkx`** (GraphML/GML via `graph.graph_file` or `--graph-file`) or **`neo4j`** (`graph.uri`, `graph.user`, `graph.password`, optional `graph.database` for `session(database=…)`). **Output layout:** by default **`output.combine_markdown: true`** writes **`nodes.md`**, **`relationship.md`**, and **`graph_summary.md`** (summary plus embedded nodes and relationships). Set **`combine_markdown: false`** or CLI **`--individual` / `--markdown-layout individual`** for per-entity files under **`nodes/`** and **`relationships/`**. **Diagrams:** **`viz.mermaid: true`** (default) writes **`graph/graph.mmd`** and embeds a fenced Mermaid block in the export **`README.md`** (no Graphviz required). **`viz.enabled: true`** or CLI **`--viz`** also writes **`graph/graph.dot`** and runs **`dot`** for PNG/SVG/PDF when Graphviz is on `PATH` (or **`GRAPHVIZ_DOT`**). CLI **`--no-mermaid`** disables Mermaid; **`--depth`**, **`--start-node`**, **`--max-nodes`**, **`--max-edges`** bound traversal. Packaged defaults: [`src/md_generator/graph/config/default.yaml`](src/md_generator/graph/config/default.yaml). Tests: **`graph-to-md/tests/`**; API image: [`graph-to-md/Dockerfile.api`](graph-to-md/Dockerfile.api).
 
 Every command accepts **`-h` / `--help`** for full flags (artifact layout, OCR, ZIP options, etc.).
 
@@ -154,6 +160,7 @@ md-zip archive.zip ./unzipped-md
 md-url https://example.com/page ./page-bundle --artifact-layout
 md-audio ./voice.mp3 ./voice.md --model tiny
 md-video ./screen.mp4 ./screen.md --model base
+pip install "mdengine[graph]" && md-graph --source neo4j --uri neo4j://localhost:7687 --user neo4j --password secret --database neo4j --output ./graph-out --viz
 ```
 
 **Windows PowerShell** (same commands; use backslashes for paths if you prefer)
@@ -164,6 +171,8 @@ md-zip .\archive.zip .\zip-out
 md-url https://example.com/page .\page-bundle --artifact-layout
 md-audio .\voice.mp3 .\voice.md --model tiny
 md-video .\screen.mp4 .\screen.md --model base
+pip install "mdengine[graph]"
+md-graph --source neo4j --uri neo4j://localhost:7687 --user neo4j --password secret --database neo4j --output .\graph-out --viz
 ```
 
 **Windows CMD**
@@ -447,7 +456,7 @@ Equivalent modules: `python -m md_generator.media.audio.api.mcp_server`, `python
 
 ### Thin shims (repo clone)
 
-[`audio-to-md/converter.py`](audio-to-md/converter.py), [`video-to-md/converter.py`](video-to-md/converter.py), and [`youtube-to-md/converter.py`](youtube-to-md/converter.py) delegate to the same `main` as `md-audio` / `md-video` / `md-youtube`. Tests and `pytest.ini` live under `audio-to-md/tests/`, `video-to-md/tests/`, and `youtube-to-md/tests/`. [`db-to-md/converter.py`](db-to-md/converter.py) delegates to `md-db`; tests live under `db-to-md/tests/`.
+[`audio-to-md/converter.py`](audio-to-md/converter.py), [`video-to-md/converter.py`](video-to-md/converter.py), and [`youtube-to-md/converter.py`](youtube-to-md/converter.py) delegate to the same `main` as `md-audio` / `md-video` / `md-youtube`. Tests and `pytest.ini` live under `audio-to-md/tests/`, `video-to-md/tests/`, and `youtube-to-md/tests/`. [`db-to-md/converter.py`](db-to-md/converter.py) delegates to `md-db`; tests live under `db-to-md/tests/`. **graph-to-md** uses `md-graph` / `mdengine graph-to-md` directly (no thin `converter.py` shim); tests live under [`graph-to-md/tests/`](graph-to-md/tests/).
 
 ---
 
@@ -478,6 +487,7 @@ Install `mdengine[api]` plus the format extra(s), then run the **`app`** object 
 | URL / HTML | `md_generator.url.api.main:app` | `url`, `api`, `mcp` |
 | Playwright / SPA | `md_generator.playwright.api.main:app` | `playwright`, `api`, `mcp` |
 | Database metadata | `md_generator.db.api.main:app` | `db`, `api`, `mcp` |
+| Graph metadata (Neo4j / NetworkX) | `md_generator.graph.api.main:app` | `graph`, `api`, `mcp` |
 | Audio (Whisper) | `md_generator.media.audio.api.main:create_app` (use **`--factory`**) or `…main:app` | `audio`, `api`, `mcp` |
 | Video (Whisper) | `md_generator.media.video.api.main:create_app` (use **`--factory`**) or `…main:app` | `video`, `api`, `mcp` |
 | YouTube | `md_generator.media.youtube.api.main:create_app` (use **`--factory`**) or `…main:app` | `youtube`, `api`, `mcp` |
@@ -490,10 +500,13 @@ uvicorn md_generator.word.api.main:app --host 127.0.0.1 --port 8002
 uvicorn md_generator.archive.api.main:app --host 127.0.0.1 --port 8010
 uvicorn md_generator.url.api.main:app --host 127.0.0.1 --port 8011
 uvicorn md_generator.playwright.api.main:app --host 127.0.0.1 --port 8014
+uvicorn md_generator.graph.api.main:app --host 127.0.0.1 --port 8012
 uvicorn md_generator.media.audio.api.main:create_app --factory --host 127.0.0.1 --port 8011
 uvicorn md_generator.media.video.api.main:create_app --factory --host 127.0.0.1 --port 8012
 uvicorn md_generator.media.youtube.api.main:create_app --factory --host 127.0.0.1 --port 8013
 ```
+
+**Port note:** **`md-graph-api`** and **`md-video-api`** both default to **8012**; set **`GRAPH_TO_MD_PORT`** or **`MD_VIDEO_API_PORT`** when you need both on one machine.
 
 ### MCP over HTTP on the same server
 
@@ -514,6 +527,7 @@ Prefixes differ per service (often read from a `.env` file next to the process):
 | URL | `URL_TO_MD_` | `URL_TO_MD_MAX_SYNC_URLS`, `URL_TO_MD_MAX_SYNC_CRAWL_PAGES`, `URL_TO_MD_MAX_JOB_URLS`, `URL_TO_MD_JOB_TTL_SECONDS`, `URL_TO_MD_TEMP_DIR`, `URL_TO_MD_CORS_ORIGINS` |
 | Playwright / SPA | `PLAYWRIGHT_TO_MD_` | `PLAYWRIGHT_TO_MD_MAX_SYNC_URLS`, `PLAYWRIGHT_TO_MD_MAX_JOB_URLS`, `PLAYWRIGHT_TO_MD_JOB_TTL_SECONDS`, `PLAYWRIGHT_TO_MD_TEMP_DIR`, `PLAYWRIGHT_TO_MD_CORS_ORIGINS`, `PLAYWRIGHT_TO_MD_API_HOST`, `PLAYWRIGHT_TO_MD_API_PORT` (default **8014**) |
 | Database metadata | `DB_TO_MD_` | `DB_TO_MD_JOB_SQLITE_PATH`, `DB_TO_MD_JOB_WORKSPACE_ROOT`, `DB_TO_MD_CORS_ORIGINS`, `DB_TO_MD_MAX_SYNC_ZIP_MB`, `DB_TO_MD_HOST`, `DB_TO_MD_PORT` (default **8010**) |
+| Graph metadata | `GRAPH_TO_MD_` | `GRAPH_TO_MD_JOB_SQLITE_PATH`, `GRAPH_TO_MD_JOB_WORKSPACE_ROOT`, `GRAPH_TO_MD_CORS_ORIGINS`, `GRAPH_TO_MD_MAX_SYNC_ZIP_MB`, `GRAPH_TO_MD_HOST`, `GRAPH_TO_MD_PORT` (default **8012**) |
 | Audio API | `MD_AUDIO_` | `MD_AUDIO_MAX_UPLOAD_MB`, `MD_AUDIO_MAX_SYNC_UPLOAD_MB`, `MD_AUDIO_JOB_TTL_SECONDS`, `MD_AUDIO_TEMP_DIR`, `MD_AUDIO_CORS_ORIGINS`, `MD_AUDIO_API_HOST`, `MD_AUDIO_API_PORT` |
 | Video API | `MD_VIDEO_` | Same pattern as audio with `MD_VIDEO_*` (defaults: larger upload/sync caps, port **8012**) |
 | YouTube API | `MD_YOUTUBE_` | `MD_YOUTUBE_JOB_TTL_SECONDS`, `MD_YOUTUBE_TEMP_DIR`, `MD_YOUTUBE_CORS_ORIGINS`, `MD_YOUTUBE_API_HOST`, `MD_YOUTUBE_API_PORT` (default **8013**); optional `MD_YOUTUBE_YTDLP` path for audio fallback |
@@ -545,6 +559,7 @@ Two usage patterns:
 | Video | `md-video-mcp` or `python -m md_generator.media.video.api.mcp_server` — same transports |
 | YouTube | `md-youtube-mcp` or `python -m md_generator.media.youtube.api.mcp_server` — same transports |
 | Database metadata | `md-db-mcp` or `python -m md_generator.db.api.mcp_server` — `--transport stdio` (default), `sse`, `streamable-http` |
+| Graph (Neo4j / NetworkX) | `md-graph-mcp` or `python -m md_generator.graph.api.mcp_server` — `--transport stdio` (default), `sse`, `streamable-http` |
 
 **Word** and **XLSX** also ship a small runner script in the repo:
 
@@ -569,7 +584,7 @@ pip install -e ".[dev,all]"   # or a smaller subset of extras
 python -m pytest
 ```
 
-Tests live under each legacy folder’s `tests/` directory (e.g. `pdf-to-md/tests/`); `pyproject.toml` configures `pythonpath = ["src"]` so `md_generator` resolves without a separate `PYTHONPATH`.
+Tests live under each legacy folder’s `tests/` directory (e.g. `pdf-to-md/tests/`) and **`graph-to-md/tests/`**; `pyproject.toml` configures `pythonpath = ["src"]` so `md_generator` resolves without a separate `PYTHONPATH`.
 
 ---
 
@@ -579,7 +594,7 @@ Tests live under each legacy folder’s `tests/` directory (e.g. `pdf-to-md/test
 |------|------|
 | `LICENSE` | MIT license text |
 | `CODE_OF_CONDUCT.md` | [Contributor Covenant](https://www.contributor-covenant.org/) 2.1 |
-| `src/md_generator/` | **Library source** (all formats + `api` subpackages); **audio/video** under [`media/audio/`](src/md_generator/media/audio/) and [`media/video/`](src/md_generator/media/video/) |
+| `src/md_generator/` | **Library source** (all formats + `api` subpackages); **audio/video** under [`media/audio/`](src/md_generator/media/audio/) and [`media/video/`](src/md_generator/media/video/); **graph-to-md** under [`graph/`](src/md_generator/graph/) |
 | `pyproject.toml` | Packaging, extras, CLI entry points, pytest |
 | `*-to-md/` | **Docs, tests, fixtures**, thin `converter.py` shims, some `run.py` helpers |
 | `README.md` | This document |

--- a/graph-to-md/Dockerfile.api
+++ b/graph-to-md/Dockerfile.api
@@ -1,0 +1,16 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+RUN useradd -m -u 1000 appuser
+
+COPY pyproject.toml README.md LICENSE ./
+COPY src ./src
+
+RUN pip install --no-cache-dir ".[graph,api,mcp]"
+
+USER appuser
+
+EXPOSE 8012
+
+CMD ["python", "-m", "uvicorn", "md_generator.graph.api.main:app", "--host", "0.0.0.0", "--port", "8012"]

--- a/graph-to-md/tests/test_extractor_graphml.py
+++ b/graph-to-md/tests/test_extractor_graphml.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import networkx as nx
+
+from md_generator.graph.core.extractor import extract_to_markdown
+from md_generator.graph.core.run_config import GraphRunConfig
+
+
+def test_extract_graphml_writes_readme(tmp_path: Path) -> None:
+    g = nx.DiGraph()
+    g.add_node("a", label="User", name="Ann")
+    g.add_node("b", label="Order")
+    g.add_edge("a", "b", type="PLACED")
+    graph_path = tmp_path / "sample.graphml"
+    nx.write_graphml(g, graph_path)
+    out = tmp_path / "out"
+    cfg = GraphRunConfig(
+        source="networkx",
+        graph_file=graph_path,
+        output_path=out,
+        max_nodes=100,
+        max_edges=100,
+    ).normalized()
+    extract_to_markdown(cfg)
+    assert (out / "README.md").is_file()
+    assert (out / "graph_summary.md").is_file()
+    assert "## All nodes" in (out / "graph_summary.md").read_text(encoding="utf-8")
+    assert (out / "nodes.md").is_file()
+    assert (out / "relationship.md").is_file()
+
+
+def test_extract_graphml_individual_layout(tmp_path: Path) -> None:
+    g = nx.Graph()
+    g.add_node("x", label="N")
+    g.add_node("y", label="N")
+    g.add_edge("x", "y", type="R")
+    graph_path = tmp_path / "t.graphml"
+    nx.write_graphml(g, graph_path)
+    out = tmp_path / "out_ind"
+    cfg = GraphRunConfig(
+        source="networkx",
+        graph_file=graph_path,
+        output_path=out,
+        combine_markdown=False,
+        max_nodes=100,
+        max_edges=100,
+    ).normalized()
+    extract_to_markdown(cfg)
+    assert (out / "nodes" / "node_x.md").is_file()
+    assert (out / "relationships").is_dir()
+    summary = (out / "graph_summary.md").read_text(encoding="utf-8")
+    assert "## All nodes" not in summary

--- a/graph-to-md/tests/test_graph_builder.py
+++ b/graph-to-md/tests/test_graph_builder.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from md_generator.graph.core.graph_builder import apply_caps_sorted, bfs_subgraph, normalize_metadata
+from md_generator.graph.core.models import GraphMetadata, Node, Relationship
+
+
+def _triangle() -> GraphMetadata:
+    nodes = (
+        Node("a", ("N",), {}),
+        Node("b", ("N",), {}),
+        Node("c", ("N",), {}),
+    )
+    rels = (
+        Relationship("r1", "R", "a", "b", {}),
+        Relationship("r2", "R", "b", "c", {}),
+        Relationship("r3", "R", "a", "c", {}),
+    )
+    return GraphMetadata(nodes=nodes, relationships=rels)
+
+
+def test_bfs_subgraph_depth() -> None:
+    m = _triangle()
+    out = bfs_subgraph(m, "a", 1, max_nodes=100, max_edges=100)
+    ids = {n.id for n in out.nodes}
+    assert ids == {"a", "b", "c"}  # triangle: all neighbors of a are b,c at dist 1
+
+
+def test_apply_caps_sorted() -> None:
+    m = GraphMetadata(
+        nodes=tuple(Node(str(i), ("X",), {}) for i in range(5)),
+        relationships=tuple(),
+    )
+    out = apply_caps_sorted(m, max_nodes=3, max_edges=10)
+    assert len(out.nodes) == 3
+
+
+def test_normalize_metadata_no_start() -> None:
+    m = GraphMetadata(
+        nodes=tuple(Node(str(i), (), {}) for i in range(10)),
+        relationships=tuple(),
+    )
+    out = normalize_metadata(m, start_node=None, depth=0, max_nodes=3, max_edges=5)
+    assert len(out.nodes) == 3

--- a/graph-to-md/tests/test_job_manager.py
+++ b/graph-to-md/tests/test_job_manager.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from md_generator.graph.core.job_manager import GraphJobManager
+from md_generator.graph.core.run_config import GraphRunConfig
+
+
+def test_graph_job_create_and_load_config(tmp_path: Path) -> None:
+    cfg = GraphRunConfig(
+        source="neo4j",
+        uri="bolt://localhost:7687",
+        user="neo4j",
+        password="x",
+        graph_file=None,
+        max_nodes=10,
+        max_edges=10,
+    ).normalized()
+    jm = GraphJobManager(in_memory=True, workspace_root=tmp_path / "ws")
+    rec = jm.create_job(cfg)
+    loaded = jm.load_config(rec.job_id)
+    assert loaded is not None
+    assert loaded.source == "neo4j"
+    assert loaded.uri == "bolt://localhost:7687"
+    jm.close()

--- a/graph-to-md/tests/test_markdown_writer.py
+++ b/graph-to-md/tests/test_markdown_writer.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from md_generator.graph.core.markdown_writer import (
+    format_graph_summary,
+    format_graph_summary_with_embedded_documents,
+    format_node_markdown,
+    format_relationship_markdown,
+    slugify_segment,
+)
+from md_generator.graph.core.models import GraphMetadata, Node, Relationship
+
+
+def test_slugify_segment() -> None:
+    assert slugify_segment("a:b/c") == "a_b_c"
+
+
+def test_format_node_markdown() -> None:
+    n1 = Node("1", ("User",), {"name": "Ann"})
+    n2 = Node("22", ("Order",), {})
+    r = Relationship("r1", "PLACED", "1", "22", {})
+    meta = GraphMetadata(nodes=(n1, n2), relationships=(r,))
+    md = format_node_markdown(n1, meta)
+    assert "# Node: 1" in md
+    assert "* User" in md
+    assert "| name | Ann |" in md
+    assert "[:PLACED]->" in md
+
+
+def test_format_relationship_markdown() -> None:
+    n1 = Node("1", ("User",), {})
+    n2 = Node("22", ("Order",), {})
+    r = Relationship("r1", "PLACED", "1", "22", {"when": "2024"})
+    meta = GraphMetadata(nodes=(n1, n2), relationships=(r,))
+    md = format_relationship_markdown(r, meta)
+    assert "# Relationship: PLACED" in md
+    assert "User (id: 1)" in md
+    assert "Order (id: 22)" in md
+    assert "| when | 2024 |" in md
+
+
+def test_format_graph_summary_with_embedded() -> None:
+    n1 = Node("1", ("User",), {})
+    n2 = Node("22", ("Order",), {})
+    r = Relationship("r1", "PLACED", "1", "22", {})
+    meta = GraphMetadata(nodes=(n1, n2), relationships=(r,))
+    md = format_graph_summary_with_embedded_documents(meta)
+    assert "## All nodes" in md
+    assert "## All relationships" in md
+    assert "# Node: 1" in md
+    assert "# Relationship: PLACED" in md
+
+
+def test_format_graph_summary() -> None:
+    meta = GraphMetadata(
+        nodes=(Node("a", ("L",), {}), Node("b", ("L",), {})),
+        relationships=(Relationship("1", "KNOWS", "a", "b", {}),),
+    )
+    md = format_graph_summary(meta)
+    assert "## Nodes Count" in md
+    assert "2" in md
+    assert "* KNOWS" in md
+    assert "## Labels" in md

--- a/graph-to-md/tests/test_mermaid.py
+++ b/graph-to-md/tests/test_mermaid.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import networkx as nx
+
+from md_generator.graph.core.extractor import extract_to_markdown
+from md_generator.graph.core.run_config import GraphRunConfig, VizConfig
+from md_generator.graph.core.viz import metadata_to_mermaid_body, write_graph_mermaid
+
+
+def test_metadata_to_mermaid_body() -> None:
+    from md_generator.graph.core.models import GraphMetadata, Node, Relationship
+
+    meta = GraphMetadata(
+        nodes=(Node("a", ("User",), {}), Node("b", ("Order",), {})),
+        relationships=(Relationship("r1", "PLACED", "a", "b", {}),),
+    )
+    body = metadata_to_mermaid_body(meta)
+    assert "flowchart LR" in body
+    assert "-->|" in body or "-->" in body
+    assert "PLACED" in body
+
+
+def test_extract_writes_graph_mmd(tmp_path: Path) -> None:
+    g = nx.DiGraph()
+    g.add_node("a", label="U")
+    g.add_node("b", label="O")
+    g.add_edge("a", "b", type="R")
+    gf = tmp_path / "g.graphml"
+    nx.write_graphml(g, gf)
+    out = tmp_path / "out"
+    cfg = GraphRunConfig(
+        source="networkx",
+        graph_file=gf,
+        output_path=out,
+        viz=VizConfig(enabled=False, mermaid=True),
+        max_nodes=50,
+        max_edges=50,
+    ).normalized()
+    extract_to_markdown(cfg)
+    assert (out / "graph" / "graph.mmd").is_file()
+    readme = (out / "README.md").read_text(encoding="utf-8")
+    assert "```mermaid" in readme
+    assert "flowchart LR" in readme
+
+
+def test_write_graph_mermaid_returns_body(tmp_path: Path) -> None:
+    from md_generator.graph.core.models import GraphMetadata, Node
+
+    meta = GraphMetadata(nodes=(Node("x", ("N",), {}),), relationships=tuple())
+    body = write_graph_mermaid(meta, tmp_path)
+    assert "flowchart LR" in body
+    assert (tmp_path / "graph" / "graph.mmd").read_text(encoding="utf-8").strip().startswith("flowchart")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,6 +101,11 @@ db = [
   "pymongo>=4.6.0",
   "mermaid-py>=0.8.0",
 ]
+graph = [
+  "networkx>=3.2.0",
+  "neo4j>=5.14.0",
+  "pyyaml>=6.0.0",
+]
 api = [
   "fastapi>=0.115.0",
   "uvicorn[standard]>=0.32.0",
@@ -120,6 +125,7 @@ dev = [
   "mdengine[url]",
   "mdengine[playwright]",
   "mdengine[db]",
+  "mdengine[graph]",
 ]
 all = [
   "pymupdf>=1.24.0",
@@ -178,6 +184,9 @@ md-playwright-mcp = "md_generator.playwright.api.mcp_server:main"
 md-db = "md_generator.db.cli.main:main"
 md-db-api = "md_generator.db.api.run:main"
 md-db-mcp = "md_generator.db.api.mcp_server:main"
+md-graph = "md_generator.graph.cli.main:main"
+md-graph-api = "md_generator.graph.api.run:main"
+md-graph-mcp = "md_generator.graph.api.mcp_server:main"
 mdengine = "md_generator.engine_cli:main"
 
 [tool.setuptools.packages.find]
@@ -185,6 +194,7 @@ where = ["src"]
 
 [tool.setuptools.package-data]
 "md_generator.db.config" = ["*.yaml"]
+"md_generator.graph.config" = ["*.yaml"]
 
 [tool.pytest.ini_options]
 pythonpath = ["src"]
@@ -202,5 +212,6 @@ testpaths = [
   "youtube-to-md/tests",
   "playwright-to-md/tests",
   "db-to-md/tests",
+  "graph-to-md/tests",
 ]
 markers = ["integration: optional dependency or slower checks"]

--- a/src/md_generator/engine_cli.py
+++ b/src/md_generator/engine_cli.py
@@ -5,12 +5,25 @@ import sys
 
 def main(argv: list[str] | None = None) -> int:
     argv = list(sys.argv[1:] if argv is None else argv)
-    if len(argv) < 1 or argv[0] != "db-to-md":
-        print("Usage: mdengine db-to-md [--config path] [--type postgres|...] ...", file=sys.stderr)
+    if len(argv) < 1:
+        print(
+            "Usage: mdengine db-to-md ... | mdengine graph-to-md [--config path] [--source networkx|neo4j] ...",
+            file=sys.stderr,
+        )
         return 2
-    from md_generator.db.cli.main import main as db_main
+    if argv[0] == "db-to-md":
+        from md_generator.db.cli.main import main as db_main
 
-    return db_main(argv[1:])
+        return db_main(argv[1:])
+    if argv[0] == "graph-to-md":
+        from md_generator.graph.cli.main import main as graph_main
+
+        return graph_main(argv[1:])
+    print(
+        "Usage: mdengine db-to-md ... | mdengine graph-to-md [--config path] [--source networkx|neo4j] ...",
+        file=sys.stderr,
+    )
+    return 2
 
 
 if __name__ == "__main__":

--- a/src/md_generator/graph/__init__.py
+++ b/src/md_generator/graph/__init__.py
@@ -1,0 +1,3 @@
+"""Graph metadata to deterministic Markdown (graph-to-md)."""
+
+__all__: list[str] = []

--- a/src/md_generator/graph/adapters/__init__.py
+++ b/src/md_generator/graph/adapters/__init__.py
@@ -1,0 +1,3 @@
+from md_generator.graph.adapters.networkx_adapter import NetworkXAdapter
+
+__all__ = ["NetworkXAdapter"]

--- a/src/md_generator/graph/adapters/factory.py
+++ b/src/md_generator/graph/adapters/factory.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from md_generator.graph.adapters.networkx_adapter import NetworkXAdapter
+from md_generator.graph.core.base_adapter import BaseAdapter
+from md_generator.graph.core.run_config import GraphRunConfig
+
+
+def create_adapter(cfg: GraphRunConfig) -> BaseAdapter:
+    src = cfg.source
+    if src == "networkx":
+        return NetworkXAdapter(graph=None, graph_file=cfg.graph_file)
+    if src == "neo4j":
+        from md_generator.graph.adapters.neo4j_adapter import Neo4jAdapter
+
+        return Neo4jAdapter(cfg)
+    raise ValueError(f"Unknown graph source: {src}")

--- a/src/md_generator/graph/adapters/neo4j_adapter.py
+++ b/src/md_generator/graph/adapters/neo4j_adapter.py
@@ -1,0 +1,310 @@
+from __future__ import annotations
+
+from typing import Any
+
+from neo4j import GraphDatabase
+from neo4j.exceptions import Neo4jError
+
+from md_generator.graph.core.base_adapter import BaseAdapter
+from md_generator.graph.core.graph_builder import apply_caps_sorted
+from md_generator.graph.core.models import GraphMetadata, Node, Relationship
+from md_generator.graph.core.run_config import GraphRunConfig
+
+
+def _id_of(expr: str, use_element_id: bool) -> str:
+    return f"elementId({expr})" if use_element_id else f"toString(id({expr}))"
+
+
+class Neo4jAdapter(BaseAdapter):
+    def __init__(self, cfg: GraphRunConfig) -> None:
+        self._cfg = cfg.normalized()
+        self._driver: Any = None
+        self._use_element_id = self._cfg.neo4j_id_mode == "element_id"
+
+    def connect(self) -> None:
+        auth = (self._cfg.user, self._cfg.password) if self._cfg.user else None
+        self._driver = GraphDatabase.driver(
+            self._cfg.uri,
+            auth=auth,
+            connection_acquisition_timeout=self._cfg.connection_timeout_s,
+        )
+
+    def close(self) -> None:
+        if self._driver is not None:
+            self._driver.close()
+            self._driver = None
+
+    def validate_connection(self) -> None:
+        self.connect()
+        assert self._driver is not None
+        self._driver.verify_connectivity()
+
+    def _session(self) -> Any:
+        assert self._driver is not None
+        db = self._cfg.neo4j_database
+        if db:
+            return self._driver.session(database=db)
+        return self._driver.session()
+
+    def _run_read(self, query: str, **params: Any) -> list[dict[str, Any]]:
+        assert self._driver is not None
+        with self._session() as session:
+            result = session.run(query, **params)
+            return [r.data() for r in result]
+
+    def _run_read_try_id_mode(self, query_el: str, query_int: str, **params: Any) -> list[dict[str, Any]]:
+        use_el = self._use_element_id
+        q = query_el if use_el else query_int
+        try:
+            return self._run_read(q, **params)
+        except Neo4jError:
+            if not use_el:
+                raise
+            self._use_element_id = False
+            return self._run_read(query_int, **params)
+
+    def get_nodes(self) -> list[Node]:
+        return self._paginate_nodes(self._cfg.max_nodes)
+
+    def get_relationships(self) -> list[Relationship]:
+        nodes = {n.id for n in self._paginate_nodes(self._cfg.max_nodes)}
+        return self._paginate_rels_scan(nodes, self._cfg.max_edges)
+
+    def _paginate_nodes(self, cap: int) -> list[Node]:
+        q_el = f"""
+            MATCH (n)
+            RETURN {_id_of('n', True)} AS id, labels(n) AS labels, properties(n) AS properties
+            ORDER BY id
+            SKIP $skip LIMIT $limit
+            """
+        q_int = f"""
+            MATCH (n)
+            RETURN {_id_of('n', False)} AS id, labels(n) AS labels, properties(n) AS properties
+            ORDER BY id
+            SKIP $skip LIMIT $limit
+            """
+        out: list[Node] = []
+        skip = 0
+        page = self._cfg.neo4j_page_size
+        while len(out) < cap:
+            lim = min(page, cap - len(out))
+            rows = self._run_read_try_id_mode(q_el, q_int, skip=skip, limit=lim)
+            if not rows:
+                break
+            for row in rows:
+                labels = tuple(str(x) for x in (row.get("labels") or ()))
+                props = {str(k): v for k, v in dict(row.get("properties") or {}).items()}
+                out.append(Node(id=str(row["id"]), labels=labels or ("Node",), properties=props))
+            skip += len(rows)
+        return out
+
+    def _paginate_rels_scan(self, allowed: set[str], cap: int) -> list[Relationship]:
+        q_el = f"""
+            MATCH (a)-[r]->(b)
+            RETURN {_id_of('r', True)} AS id, type(r) AS typ,
+                   {_id_of('a', True)} AS start_id,
+                   {_id_of('b', True)} AS end_id,
+                   properties(r) AS properties
+            ORDER BY id
+            SKIP $skip LIMIT $limit
+            """
+        q_int = f"""
+            MATCH (a)-[r]->(b)
+            RETURN {_id_of('r', False)} AS id, type(r) AS typ,
+                   {_id_of('a', False)} AS start_id,
+                   {_id_of('b', False)} AS end_id,
+                   properties(r) AS properties
+            ORDER BY id
+            SKIP $skip LIMIT $limit
+            """
+        out: list[Relationship] = []
+        skip = 0
+        page = self._cfg.neo4j_page_size
+        while len(out) < cap:
+            lim = min(page, cap - len(out))
+            rows = self._run_read_try_id_mode(q_el, q_int, skip=skip, limit=lim)
+            if not rows:
+                break
+            for row in rows:
+                sid = str(row["start_id"])
+                eid = str(row["end_id"])
+                if sid not in allowed or eid not in allowed:
+                    continue
+                props = {str(k): v for k, v in dict(row.get("properties") or {}).items()}
+                out.append(
+                    Relationship(
+                        id=str(row["id"]),
+                        type=str(row["typ"]),
+                        start_node=sid,
+                        end_node=eid,
+                        properties=props,
+                    )
+                )
+                if len(out) >= cap:
+                    break
+            skip += len(rows)
+        return out
+
+    def get_subgraph(self, depth: int, start_node: str | None = None) -> GraphMetadata:
+        return self.extract_bounded(self._cfg)
+
+    def extract_bounded(self, cfg: GraphRunConfig | None = None) -> GraphMetadata:
+        cfg = (cfg or self._cfg).normalized()
+        if cfg.start_node:
+            nodes, rels = self._bfs_collect(cfg)
+            meta = GraphMetadata(nodes=tuple(sorted(nodes, key=lambda n: n.id)), relationships=tuple(rels))
+            return apply_caps_sorted(meta, max_nodes=cfg.max_nodes, max_edges=cfg.max_edges)
+        nodes = self._paginate_nodes(cfg.max_nodes)
+        nid_set = {n.id for n in nodes}
+        rels = self._rels_between_ids(nid_set, cfg.max_edges)
+        meta = GraphMetadata(nodes=tuple(sorted(nodes, key=lambda n: n.id)), relationships=tuple(rels))
+        return apply_caps_sorted(meta, max_nodes=cfg.max_nodes, max_edges=cfg.max_edges)
+
+    def _rels_between_ids(self, allowed: set[str], cap: int) -> list[Relationship]:
+        ids = sorted(allowed)
+        q_el = f"""
+            MATCH (a)-[r]->(b)
+            WHERE {_id_of('a', True)} IN $ids AND {_id_of('b', True)} IN $ids
+            RETURN {_id_of('r', True)} AS id, type(r) AS typ,
+                   {_id_of('a', True)} AS start_id,
+                   {_id_of('b', True)} AS end_id,
+                   properties(r) AS properties
+            ORDER BY id
+            SKIP $skip LIMIT $limit
+            """
+        q_int = f"""
+            MATCH (a)-[r]->(b)
+            WHERE {_id_of('a', False)} IN $ids AND {_id_of('b', False)} IN $ids
+            RETURN {_id_of('r', False)} AS id, type(r) AS typ,
+                   {_id_of('a', False)} AS start_id,
+                   {_id_of('b', False)} AS end_id,
+                   properties(r) AS properties
+            ORDER BY id
+            SKIP $skip LIMIT $limit
+            """
+        out: list[Relationship] = []
+        skip = 0
+        page = self._cfg.neo4j_page_size
+        while len(out) < cap:
+            lim = min(page, cap - len(out))
+            rows = self._run_read_try_id_mode(q_el, q_int, ids=ids, skip=skip, limit=lim)
+            if not rows:
+                break
+            for row in rows:
+                props = {str(k): v for k, v in dict(row.get("properties") or {}).items()}
+                out.append(
+                    Relationship(
+                        id=str(row["id"]),
+                        type=str(row["typ"]),
+                        start_node=str(row["start_id"]),
+                        end_node=str(row["end_id"]),
+                        properties=props,
+                    )
+                )
+                if len(out) >= cap:
+                    break
+            skip += len(rows)
+        return out
+
+    def _bfs_collect(self, cfg: GraphRunConfig) -> tuple[list[Node], list[Relationship]]:
+        assert cfg.start_node is not None
+        start = cfg.start_node
+        max_depth = cfg.depth if cfg.depth > 0 else 10**9
+        max_nodes = cfg.max_nodes
+        max_edges = cfg.max_edges
+
+        visited: set[str] = set()
+        node_by_id: dict[str, Node] = {}
+        rel_by_id: dict[str, Relationship] = {}
+
+        def fetch_node(nid: str) -> Node | None:
+            q_el = f"""
+                MATCH (n)
+                WHERE {_id_of('n', True)} = $nid
+                RETURN {_id_of('n', True)} AS id, labels(n) AS labels, properties(n) AS properties
+                LIMIT 1
+                """
+            q_int = f"""
+                MATCH (n)
+                WHERE {_id_of('n', False)} = $nid
+                RETURN {_id_of('n', False)} AS id, labels(n) AS labels, properties(n) AS properties
+                LIMIT 1
+                """
+            rows = self._run_read_try_id_mode(q_el, q_int, nid=nid)
+            if not rows:
+                return None
+            row = rows[0]
+            labels = tuple(str(x) for x in (row.get("labels") or ()))
+            props = {str(k): v for k, v in dict(row.get("properties") or {}).items()}
+            return Node(id=str(row["id"]), labels=labels or ("Node",), properties=props)
+
+        sn = fetch_node(start)
+        if sn is None:
+            return [], []
+        visited.add(sn.id)
+        node_by_id[sn.id] = sn
+
+        q_el = f"""
+            UNWIND $frontier AS fid
+            MATCH (n)
+            WHERE {_id_of('n', True)} = fid
+            MATCH (n)-[r]-(m)
+            RETURN DISTINCT {_id_of('m', True)} AS mid,
+                   {_id_of('r', True)} AS rid,
+                   type(r) AS typ,
+                   {_id_of('startNode(r)', True)} AS start_id,
+                   {_id_of('endNode(r)', True)} AS end_id,
+                   properties(r) AS rprops,
+                   labels(m) AS mlabels,
+                   properties(m) AS mprops
+            """
+        q_int = f"""
+            UNWIND $frontier AS fid
+            MATCH (n)
+            WHERE {_id_of('n', False)} = fid
+            MATCH (n)-[r]-(m)
+            RETURN DISTINCT {_id_of('m', False)} AS mid,
+                   {_id_of('r', False)} AS rid,
+                   type(r) AS typ,
+                   {_id_of('startNode(r)', False)} AS start_id,
+                   {_id_of('endNode(r)', False)} AS end_id,
+                   properties(r) AS rprops,
+                   labels(m) AS mlabels,
+                   properties(m) AS mprops
+            """
+
+        layer: set[str] = {start}
+        depth = 0
+        while layer and depth < max_depth and len(visited) < max_nodes:
+            frontier = sorted(layer)
+            layer = set()
+            for i in range(0, len(frontier), self._cfg.neo4j_page_size):
+                batch = frontier[i : i + self._cfg.neo4j_page_size]
+                rows = self._run_read_try_id_mode(q_el, q_int, frontier=batch)
+                for row in rows:
+                    rid = str(row["rid"])
+                    if rid not in rel_by_id and len(rel_by_id) < max_edges:
+                        rel_by_id[rid] = Relationship(
+                            id=rid,
+                            type=str(row["typ"]),
+                            start_node=str(row["start_id"]),
+                            end_node=str(row["end_id"]),
+                            properties={str(k): v for k, v in dict(row.get("rprops") or {}).items()},
+                        )
+                    mid = str(row["mid"])
+                    if mid in visited:
+                        continue
+                    if len(visited) >= max_nodes:
+                        break
+                    visited.add(mid)
+                    labels = tuple(str(x) for x in (row.get("mlabels") or ()))
+                    props = {str(k): v for k, v in dict(row.get("mprops") or {}).items()}
+                    node_by_id[mid] = Node(id=mid, labels=labels or ("Node",), properties=props)
+                    layer.add(mid)
+                if len(visited) >= max_nodes:
+                    break
+            depth += 1
+
+        nodes = [node_by_id[i] for i in sorted(node_by_id)]
+        rels = [rel_by_id[i] for i in sorted(rel_by_id)]
+        return nodes, rels

--- a/src/md_generator/graph/adapters/networkx_adapter.py
+++ b/src/md_generator/graph/adapters/networkx_adapter.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import networkx as nx
+
+from md_generator.graph.core.base_adapter import BaseAdapter
+from md_generator.graph.core.models import Node, Relationship
+
+
+def _labels_for_node(data: dict[str, Any] | None) -> tuple[str, ...]:
+    if not data:
+        return ("Node",)
+    if "_labels" in data and isinstance(data["_labels"], (list, tuple)):
+        return tuple(str(x) for x in data["_labels"])
+    if "labels" in data and isinstance(data["labels"], (list, tuple)):
+        return tuple(str(x) for x in data["labels"])
+    if "labels" in data and isinstance(data["labels"], str) and data["labels"].strip():
+        return (str(data["labels"]).strip(),)
+    if "label" in data and data["label"] is not None and str(data["label"]).strip():
+        return (str(data["label"]).strip(),)
+    return ("Node",)
+
+
+def _node_id_str(n: Any) -> str:
+    return str(n)
+
+
+def _rel_id_str(u: Any, v: Any, key: Any | None, idx: int, directed: bool) -> str:
+    if key is None:
+        return f"{u}->{v}::{idx}" if directed else f"{u}-{v}::{idx}"
+    return f"{u}->{v}#{key}"
+
+
+class NetworkXAdapter(BaseAdapter):
+    """Adapter for in-memory NetworkX graphs or GraphML/GML files."""
+
+    def __init__(self, graph: nx.Graph | nx.DiGraph | nx.MultiDiGraph | None = None, graph_file: Path | None = None) -> None:
+        self._graph_file = Path(graph_file).expanduser() if graph_file else None
+        self._graph = graph
+        self._loaded: nx.Graph | nx.DiGraph | nx.MultiDiGraph | None = None
+
+    def connect(self) -> None:
+        if self._graph is not None:
+            self._loaded = self._graph
+            return
+        if not self._graph_file or not self._graph_file.is_file():
+            raise FileNotFoundError(f"graph_file not found: {self._graph_file}")
+        suf = self._graph_file.suffix.lower()
+        if suf == ".graphml":
+            self._loaded = nx.read_graphml(self._graph_file)
+        elif suf == ".gml":
+            self._loaded = nx.read_gml(self._graph_file)
+        else:
+            raise ValueError(f"Unsupported graph file extension: {suf} (use .graphml or .gml)")
+
+    def close(self) -> None:
+        self._loaded = None
+
+    def _g(self) -> nx.Graph | nx.DiGraph | nx.MultiDiGraph:
+        if self._loaded is None:
+            raise RuntimeError("adapter not connected")
+        return self._loaded
+
+    def get_nodes(self) -> list[Node]:
+        g = self._g()
+        out: list[Node] = []
+        for nid, data in g.nodes(data=True):
+            sid = _node_id_str(nid)
+            props = {str(k): v for k, v in dict(data or {}).items() if k not in ("_labels", "labels", "label")}
+            out.append(Node(id=sid, labels=_labels_for_node(dict(data or {})), properties=props))
+        return out
+
+    def get_relationships(self) -> list[Relationship]:
+        g = self._g()
+        out: list[Relationship] = []
+        directed = g.is_directed()
+        if isinstance(g, (nx.MultiDiGraph, nx.MultiGraph)):
+            idx = 0
+            for u, v, key, data in g.edges(keys=True, data=True):
+                props = {str(k): val for k, val in dict(data or {}).items()}
+                typ = str(props.pop("type", props.pop("label", "RELATED")))
+                rid = _rel_id_str(u, v, key, idx, directed)
+                if directed:
+                    out.append(Relationship(id=rid, type=typ, start_node=_node_id_str(u), end_node=_node_id_str(v), properties=props))
+                else:
+                    su, sv = _node_id_str(u), _node_id_str(v)
+                    a, b = (su, sv) if su <= sv else (sv, su)
+                    out.append(Relationship(id=rid, type=typ, start_node=a, end_node=b, properties=props))
+                idx += 1
+            return out
+        idx = 0
+        for u, v, data in g.edges(data=True):
+            props = {str(k): val for k, val in dict(data or {}).items()}
+            typ = str(props.pop("type", props.pop("label", "RELATED")))
+            rid = _rel_id_str(u, v, None, idx, directed)
+            if directed:
+                out.append(Relationship(id=rid, type=typ, start_node=_node_id_str(u), end_node=_node_id_str(v), properties=props))
+            else:
+                su, sv = _node_id_str(u), _node_id_str(v)
+                a, b = (su, sv) if su <= sv else (sv, su)
+                out.append(Relationship(id=rid, type=typ, start_node=a, end_node=b, properties=props))
+            idx += 1
+        return out

--- a/src/md_generator/graph/api/__init__.py
+++ b/src/md_generator/graph/api/__init__.py
@@ -1,0 +1,1 @@
+"""FastAPI service for graph-to-md."""

--- a/src/md_generator/graph/api/main.py
+++ b/src/md_generator/graph/api/main.py
@@ -1,0 +1,181 @@
+from __future__ import annotations
+
+import asyncio
+import zipfile
+from contextlib import asynccontextmanager
+from pathlib import Path
+
+from fastapi import FastAPI, HTTPException, Request
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import FileResponse, Response, StreamingResponse
+from starlette.background import BackgroundTask
+
+from md_generator.graph.api.schemas import GraphToMdRunBody
+from md_generator.graph.api.settings import GraphApiSettings, cors_list, sqlite_path_resolved
+from md_generator.graph.core.job_manager import GraphJobManager
+from md_generator.graph.core.zip_export import build_markdown_zip_bytes
+from md_generator.graph.mcp.server import build_mcp_stack
+from md_generator.graph.mcp.sse import format_sse
+
+_mcp, _mcp_http = build_mcp_stack(mount_under_fastapi=True)
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    settings = GraphApiSettings()
+    ws = Path(settings.job_workspace_root) if settings.job_workspace_root else None
+    jobs = GraphJobManager(sqlite_path=sqlite_path_resolved(settings), workspace_root=ws)
+    app.state.settings = settings
+    app.state.jobs = jobs
+    async with _mcp.session_manager.run():
+        yield
+    jobs.close()
+
+
+app = FastAPI(title="graph-to-md", lifespan=lifespan)
+app.mount("/mcp", _mcp_http)
+
+_bootstrap = GraphApiSettings()
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=cors_list(_bootstrap),
+    allow_credentials="*" not in cors_list(_bootstrap),
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+
+@app.get("/health")
+async def health() -> dict[str, str]:
+    return {"status": "ok"}
+
+
+@app.post("/graph-to-md/run")
+async def graph_run_sync(request: Request, body: GraphToMdRunBody) -> Response:
+    settings: GraphApiSettings = request.app.state.settings
+    cfg = body.to_run_config()
+    try:
+        data = build_markdown_zip_bytes(cfg)
+    except Exception as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+    max_b = settings.max_sync_zip_mb * 1024 * 1024
+    if len(data) > max_b:
+        raise HTTPException(
+            status_code=413,
+            detail=f"ZIP exceeds GRAPH_TO_MD_MAX_SYNC_ZIP_MB ({settings.max_sync_zip_mb}); use POST /graph-to-md/job",
+        )
+    return Response(
+        content=data,
+        media_type="application/zip",
+        headers={"Content-Disposition": 'attachment; filename="graph-metadata.zip"'},
+    )
+
+
+@app.post("/graph-to-md/job")
+async def graph_job_create(request: Request, body: GraphToMdRunBody) -> dict[str, str]:
+    jobs: GraphJobManager = request.app.state.jobs
+    cfg = body.to_run_config()
+    try:
+        rec = jobs.create_job(cfg)
+    except Exception as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+    jobs.run_job_thread(rec.job_id)
+    return {"job_id": rec.job_id}
+
+
+@app.get("/graph-to-md/job/{job_id}")
+async def graph_job_status(request: Request, job_id: str) -> dict:
+    jobs: GraphJobManager = request.app.state.jobs
+    rec = jobs.get(job_id)
+    if not rec:
+        raise HTTPException(404, detail="Unknown job_id")
+    return rec.to_api_dict()
+
+
+@app.get("/graph-to-md/job/{job_id}/download")
+async def graph_job_download(request: Request, job_id: str) -> FileResponse:
+    jobs: GraphJobManager = request.app.state.jobs
+    rec = jobs.get(job_id)
+    if not rec:
+        raise HTTPException(404, detail="Unknown job_id")
+    if rec.status != "COMPLETED" or not rec.zip_path:
+        raise HTTPException(400, detail="Job is not ready for download")
+    path = Path(rec.zip_path)
+    if not path.is_file():
+        raise HTTPException(400, detail="ZIP missing on disk")
+    task = BackgroundTask(jobs.remove_after_download, job_id)
+    return FileResponse(
+        path,
+        media_type="application/zip",
+        filename="graph-metadata.zip",
+        background=task,
+    )
+
+
+@app.get("/graph-to-md/job/{job_id}/events")
+async def graph_job_events(request: Request, job_id: str) -> StreamingResponse:
+    jobs: GraphJobManager = request.app.state.jobs
+
+    async def gen():
+        rec = jobs.get(job_id)
+        if not rec:
+            yield format_sse("job_failed", {"job_id": job_id, "error": "unknown job_id"}).encode("utf-8")
+            return
+        yield format_sse("graph_extraction_started", {"job_id": job_id}).encode("utf-8")
+        last_progress = -1
+        last_current = ""
+        while True:
+            rec = jobs.get(job_id)
+            if not rec:
+                yield format_sse("job_failed", {"job_id": job_id, "error": "job disappeared"}).encode("utf-8")
+                return
+            if rec.progress != last_progress or (rec.current and rec.current != last_current):
+                last_progress = rec.progress
+                last_current = rec.current or ""
+                ev = last_current if last_current else "progress_update"
+                yield format_sse(
+                    ev,
+                    {"job_id": job_id, "progress": rec.progress, "current": rec.current},
+                ).encode("utf-8")
+            if rec.status == "COMPLETED":
+                yield format_sse(
+                    "graph_completed",
+                    {"job_id": job_id, "zip_path": rec.zip_path},
+                ).encode("utf-8")
+                return
+            if rec.status == "FAILED":
+                yield format_sse(
+                    "job_failed",
+                    {"job_id": job_id, "error": rec.error or "unknown"},
+                ).encode("utf-8")
+                return
+            await asyncio.sleep(0.4)
+
+    return StreamingResponse(gen(), media_type="text/event-stream")
+
+
+@app.get("/graph-to-md/job/{job_id}/stream")
+async def graph_job_stream(request: Request, job_id: str) -> StreamingResponse:
+    jobs: GraphJobManager = request.app.state.jobs
+
+    async def gen():
+        while True:
+            rec = jobs.get(job_id)
+            if not rec:
+                yield b"# error: unknown job\n"
+                return
+            if rec.status == "FAILED":
+                yield (f"# job failed\n{rec.error or ''}\n").encode("utf-8")
+                return
+            if rec.status == "COMPLETED" and rec.zip_path:
+                zp = Path(rec.zip_path)
+                with zipfile.ZipFile(zp, "r") as zf:
+                    for name in sorted(zf.namelist()):
+                        if name.endswith(".md"):
+                            hdr = f"\n\n---\n# file: {name}\n---\n\n".encode("utf-8")
+                            yield hdr
+                            yield zf.read(name)
+                return
+            await asyncio.sleep(0.4)
+
+    return StreamingResponse(gen(), media_type="text/plain; charset=utf-8")

--- a/src/md_generator/graph/api/mcp_server.py
+++ b/src/md_generator/graph/api/mcp_server.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import argparse
+import asyncio
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="graph-to-md MCP server")
+    parser.add_argument(
+        "--transport",
+        choices=("stdio", "sse", "streamable-http"),
+        default="stdio",
+    )
+    args = parser.parse_args()
+
+    from md_generator.graph.mcp.server import build_mcp_stack
+
+    mcp, _ = build_mcp_stack(mount_under_fastapi=False)
+
+    if args.transport == "stdio":
+        asyncio.run(mcp.run_stdio_async())
+    elif args.transport == "sse":
+        asyncio.run(mcp.run_sse_async())
+    else:
+        asyncio.run(mcp.run_streamable_http_async())
+
+
+if __name__ == "__main__":
+    main()

--- a/src/md_generator/graph/api/run.py
+++ b/src/md_generator/graph/api/run.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+import os
+
+
+def main() -> None:
+    import uvicorn
+
+    host = os.environ.get("GRAPH_TO_MD_HOST", "127.0.0.1")
+    port = int(os.environ.get("GRAPH_TO_MD_PORT", "8012"))
+    uvicorn.run("md_generator.graph.api.main:app", host=host, port=port, reload=False)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/md_generator/graph/api/schemas.py
+++ b/src/md_generator/graph/api/schemas.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+from md_generator.graph.core.run_config import GraphRunConfig, VizConfig
+
+
+class GraphSection(BaseModel):
+    source: str = Field(..., description="networkx | neo4j")
+    uri: str = ""
+    user: str = ""
+    password: str = ""
+    database: str | None = Field(default=None, description="Neo4j database name")
+    graph_file: str | None = None
+    neo4j_id_mode: str = "element_id"
+    neo4j_page_size: int = Field(default=500, ge=1, le=10_000)
+    connection_timeout_s: float = Field(default=30.0, gt=0)
+    depth: int = Field(default=0, ge=0)
+    start_node: str | None = None
+    max_nodes: int = Field(default=10_000, ge=1)
+    max_edges: int = Field(default=50_000, ge=1)
+
+
+class OutputSection(BaseModel):
+    path: str = "./docs"
+    split_files: bool = True
+    combine_markdown: bool = True
+
+
+class ExecutionSection(BaseModel):
+    workers: int = Field(default=4, ge=1, le=32)
+
+
+class VizSection(BaseModel):
+    enabled: bool = False
+    mermaid: bool = True
+    formats: list[str] = Field(default_factory=lambda: ["png", "svg"])
+
+
+class GraphToMdRunBody(BaseModel):
+    graph: GraphSection
+    output: OutputSection = Field(default_factory=OutputSection)
+    execution: ExecutionSection = Field(default_factory=ExecutionSection)
+    viz: VizSection = Field(default_factory=VizSection)
+
+    def to_run_config(self) -> GraphRunConfig:
+        gf = Path(self.graph.graph_file).expanduser() if self.graph.graph_file else None
+        return GraphRunConfig(
+            source=self.graph.source,
+            uri=self.graph.uri,
+            user=self.graph.user,
+            password=self.graph.password,
+            neo4j_database=self.graph.database,
+            graph_file=gf,
+            neo4j_id_mode=self.graph.neo4j_id_mode,
+            neo4j_page_size=self.graph.neo4j_page_size,
+            connection_timeout_s=self.graph.connection_timeout_s,
+            depth=self.graph.depth,
+            start_node=self.graph.start_node,
+            max_nodes=self.graph.max_nodes,
+            max_edges=self.graph.max_edges,
+            output_path=Path(self.output.path),
+            split_files=self.output.split_files,
+            combine_markdown=self.output.combine_markdown,
+            workers=self.execution.workers,
+            viz=VizConfig(enabled=self.viz.enabled, mermaid=self.viz.mermaid, formats=tuple(self.viz.formats)),
+        ).normalized()

--- a/src/md_generator/graph/api/settings.py
+++ b/src/md_generator/graph/api/settings.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class GraphApiSettings(BaseSettings):
+    model_config = SettingsConfigDict(
+        env_prefix="GRAPH_TO_MD_",
+        env_file=".env",
+        extra="ignore",
+    )
+
+    job_sqlite_path: str | None = None
+    job_workspace_root: str | None = None
+    cors_origins: str = "*"
+    max_sync_zip_mb: int = 80
+
+
+def cors_list(settings: GraphApiSettings) -> list[str]:
+    raw = (settings.cors_origins or "*").strip()
+    if raw == "*":
+        return ["*"]
+    return [o.strip() for o in raw.split(",") if o.strip()]
+
+
+def sqlite_path_resolved(settings: GraphApiSettings) -> Path | None:
+    if settings.job_sqlite_path:
+        return Path(settings.job_sqlite_path)
+    return None

--- a/src/md_generator/graph/cli/__init__.py
+++ b/src/md_generator/graph/cli/__init__.py
@@ -1,0 +1,1 @@
+"""CLI for graph-to-md."""

--- a/src/md_generator/graph/cli/main.py
+++ b/src/md_generator/graph/cli/main.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from md_generator.graph.core.extractor import extract_to_markdown
+from md_generator.graph.core.job_manager import GraphJobManager
+from md_generator.graph.core.run_config import GraphRunConfig, VizConfig, load_graph_run_config
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(description="Export graph data to Markdown.")
+    p.add_argument("--config", type=Path, default=None, help="Path to YAML config")
+    p.add_argument("--source", default=None, choices=("networkx", "neo4j"))
+    p.add_argument("--uri", default=None)
+    p.add_argument("--user", default=None)
+    p.add_argument("--password", default=None)
+    p.add_argument(
+        "--database",
+        default=None,
+        help="Neo4j database name (e.g. neo4j); passed to driver session(database=...)",
+    )
+    p.add_argument("--graph-file", type=Path, default=None)
+    p.add_argument("--depth", type=int, default=None)
+    p.add_argument("--start-node", default=None)
+    p.add_argument("--max-nodes", type=int, default=None)
+    p.add_argument("--max-edges", type=int, default=None)
+    p.add_argument("--output", type=Path, default=None)
+    p.add_argument("--neo4j-id-mode", default=None, choices=("element_id", "internal_id"))
+    p.add_argument(
+        "--async",
+        dest="async_job",
+        action="store_true",
+        help="Enqueue background job (prints job_id; uses SQLite job store)",
+    )
+    p.add_argument(
+        "--markdown-layout",
+        choices=("combined", "individual"),
+        default=None,
+        help="combined (default): nodes.md, relationship.md, graph_summary with embedded sections; "
+        "individual: nodes/ and relationships/ per entity",
+    )
+    p.add_argument(
+        "--individual",
+        action="store_true",
+        help="Shortcut for --markdown-layout individual",
+    )
+    p.add_argument(
+        "--viz",
+        action="store_true",
+        help="Write output/graph/graph.dot and render PNG/SVG/PDF via Graphviz dot (if installed)",
+    )
+    p.add_argument(
+        "--viz-formats",
+        default=None,
+        help="Comma-separated formats for --viz (default png,svg). Example: png,svg,pdf",
+    )
+    p.add_argument(
+        "--no-mermaid",
+        action="store_true",
+        help="Disable Mermaid diagram (graph/graph.mmd and README fenced block)",
+    )
+    return p
+
+
+def _apply_cli_overrides(cfg: GraphRunConfig, ns: argparse.Namespace) -> GraphRunConfig:
+    from dataclasses import replace
+
+    kw: dict = {}
+    if ns.source:
+        kw["source"] = ns.source
+    if ns.uri is not None:
+        kw["uri"] = ns.uri
+    if ns.user is not None:
+        kw["user"] = ns.user
+    if ns.password is not None:
+        kw["password"] = ns.password
+    if ns.database is not None:
+        kw["neo4j_database"] = ns.database or None
+    if ns.graph_file is not None:
+        kw["graph_file"] = ns.graph_file
+    if ns.depth is not None:
+        kw["depth"] = ns.depth
+    if ns.start_node is not None:
+        kw["start_node"] = ns.start_node or None
+    if ns.max_nodes is not None:
+        kw["max_nodes"] = ns.max_nodes
+    if ns.max_edges is not None:
+        kw["max_edges"] = ns.max_edges
+    if ns.output is not None:
+        kw["output_path"] = ns.output
+    if ns.neo4j_id_mode is not None:
+        kw["neo4j_id_mode"] = ns.neo4j_id_mode
+    if ns.individual:
+        kw["combine_markdown"] = False
+    elif ns.markdown_layout == "individual":
+        kw["combine_markdown"] = False
+    elif ns.markdown_layout == "combined":
+        kw["combine_markdown"] = True
+    v = cfg.viz
+    if ns.viz:
+        if ns.viz_formats and ns.viz_formats.strip():
+            fmts = tuple(x.strip().lower() for x in ns.viz_formats.split(",") if x.strip())
+            if not fmts:
+                fmts = ("png", "svg")
+        else:
+            fmts = v.formats
+        v = VizConfig(enabled=True, mermaid=v.mermaid, formats=fmts)
+    if ns.no_mermaid:
+        v = replace(v, mermaid=False)
+    if ns.viz or ns.no_mermaid:
+        kw["viz"] = v
+    return replace(cfg, **kw) if kw else cfg
+
+
+def main(argv: list[str] | None = None) -> int:
+    argv = argv if argv is not None else sys.argv[1:]
+    ns = build_parser().parse_args(argv)
+    cfg = load_graph_run_config(ns.config, None)
+    cfg = _apply_cli_overrides(cfg, ns)
+    cfg = cfg.normalized()
+
+    if cfg.source == "networkx" and cfg.graph_file is None:
+        print("networkx source requires --graph-file or graph.graph_file in config", file=sys.stderr)
+        return 2
+
+    if ns.async_job:
+        jobs = GraphJobManager()
+        rec = jobs.create_job(cfg)
+        jobs.run_job_thread(rec.job_id)
+        print(rec.job_id)
+        jobs.close()
+        return 0
+
+    extract_to_markdown(cfg)
+    print(str(cfg.output_path.resolve()))
+    return 0

--- a/src/md_generator/graph/config/__init__.py
+++ b/src/md_generator/graph/config/__init__.py
@@ -1,0 +1,1 @@
+"""Default YAML for graph-to-md."""

--- a/src/md_generator/graph/config/default.yaml
+++ b/src/md_generator/graph/config/default.yaml
@@ -1,0 +1,30 @@
+graph:
+  source: networkx
+  uri: bolt://localhost:7687
+  database: neo4j
+  user: neo4j
+  password: password
+  graph_file: null
+  neo4j_id_mode: element_id
+  neo4j_page_size: 500
+  connection_timeout_s: 30.0
+  depth: 2
+  start_node: null
+  max_nodes: 10000
+  max_edges: 50000
+
+output:
+  path: ./docs
+  split_files: true
+  combine_markdown: true
+
+execution:
+  mode: async
+  workers: 4
+
+viz:
+  enabled: false
+  mermaid: true
+  formats:
+    - png
+    - svg

--- a/src/md_generator/graph/core/__init__.py
+++ b/src/md_generator/graph/core/__init__.py
@@ -1,0 +1,3 @@
+from md_generator.graph.core.models import GraphMetadata, Node, Relationship
+
+__all__ = ["GraphMetadata", "Node", "Relationship"]

--- a/src/md_generator/graph/core/base_adapter.py
+++ b/src/md_generator/graph/core/base_adapter.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+from md_generator.graph.core.models import GraphMetadata, Node, Relationship
+
+
+class BaseAdapter(ABC):
+    """Graph source adapter."""
+
+    @abstractmethod
+    def connect(self) -> None:
+        """Establish connection or load resources."""
+
+    @abstractmethod
+    def close(self) -> None:
+        """Release resources."""
+
+    def validate_connection(self) -> None:
+        """Raise if unreachable; default is connect + noop."""
+        self.connect()
+
+    @abstractmethod
+    def get_nodes(self) -> list[Node]:
+        ...
+
+    @abstractmethod
+    def get_relationships(self) -> list[Relationship]:
+        ...
+
+    def get_subgraph(self, depth: int, start_node: str | None = None) -> GraphMetadata:
+        """Bounded subgraph; default loads all nodes/rels then caller filters."""
+        nodes = self.get_nodes()
+        rels = self.get_relationships()
+        return GraphMetadata(nodes=tuple(nodes), relationships=tuple(rels))

--- a/src/md_generator/graph/core/extractor.py
+++ b/src/md_generator/graph/core/extractor.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Callable
+
+from md_generator.graph.adapters.factory import create_adapter
+from md_generator.graph.core.graph_builder import normalize_metadata
+from md_generator.graph.core.markdown_writer import write_markdown_tree
+from md_generator.graph.core.models import GraphMetadata
+from md_generator.graph.core.run_config import GraphRunConfig
+from md_generator.graph.core.viz import write_graph_mermaid, write_graph_viz
+
+logger = logging.getLogger(__name__)
+
+
+def _emit(on_progress: Callable[[int, str], None] | None, pct: int, cur: str) -> None:
+    if on_progress:
+        on_progress(pct, cur)
+
+
+def extract_to_markdown(
+    cfg: GraphRunConfig,
+    *,
+    on_progress: Callable[[int, str], None] | None = None,
+    on_file: Callable[[Path], None] | None = None,
+) -> GraphMetadata:
+    cfg = cfg.normalized()
+    adapter = create_adapter(cfg)
+    _emit(on_progress, 0, "connect")
+    adapter.validate_connection()
+    adapter.connect()
+    try:
+        _emit(on_progress, 5, "graph_extraction_started")
+        if cfg.source == "neo4j":
+            from md_generator.graph.adapters.neo4j_adapter import Neo4jAdapter
+
+            assert isinstance(adapter, Neo4jAdapter)
+            meta = adapter.extract_bounded(cfg)
+        else:
+            nodes = adapter.get_nodes()
+            rels = adapter.get_relationships()
+            full = GraphMetadata(nodes=tuple(nodes), relationships=tuple(rels))
+            meta = normalize_metadata(
+                full,
+                start_node=cfg.start_node,
+                depth=cfg.depth,
+                max_nodes=cfg.max_nodes,
+                max_edges=cfg.max_edges,
+            )
+        _emit(on_progress, 40, "nodes_processed")
+        _emit(on_progress, 50, "relationships_processed")
+
+        out = Path(cfg.output_path)
+        out.mkdir(parents=True, exist_ok=True)
+
+        pct = [70]
+
+        def _on_file(p: Path) -> None:
+            if on_file:
+                on_file(p)
+            pct[0] = min(95, pct[0] + 1)
+            _emit(on_progress, pct[0], "file_generated")
+
+        include_viz = False
+        if cfg.viz.enabled:
+            _emit(on_progress, 60, "viz")
+            include_viz = write_graph_viz(meta, out, formats=cfg.viz.formats)
+
+        mermaid_body: str | None = None
+        if cfg.viz.mermaid:
+            _emit(on_progress, 62, "mermaid")
+            mermaid_body = write_graph_mermaid(meta, out)
+            mp = out / "graph" / "graph.mmd"
+            if mp.is_file():
+                _on_file(mp)
+
+        _emit(on_progress, 65, "write_markdown")
+        write_markdown_tree(
+            meta,
+            out,
+            combine_markdown=cfg.combine_markdown,
+            mermaid_body=mermaid_body,
+            include_viz_readme=include_viz,
+            on_file=_on_file,
+        )
+        _emit(on_progress, 100, "graph_completed")
+        return meta
+    finally:
+        try:
+            adapter.close()
+        except Exception:
+            logger.exception("adapter close failed")

--- a/src/md_generator/graph/core/graph_builder.py
+++ b/src/md_generator/graph/core/graph_builder.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from collections import defaultdict, deque
+
+from md_generator.graph.core.models import GraphMetadata, Node, Relationship
+
+
+def _node_by_id(nodes: tuple[Node, ...]) -> dict[str, Node]:
+    return {n.id: n for n in nodes}
+
+
+def apply_caps_sorted(meta: GraphMetadata, *, max_nodes: int, max_edges: int) -> GraphMetadata:
+    """Truncate to max counts with stable ordering."""
+    snodes = sorted(meta.nodes, key=lambda n: n.id)[:max_nodes]
+    allowed = {n.id for n in snodes}
+    srels = [r for r in sorted(meta.relationships, key=lambda r: (r.type, r.id, r.start_node, r.end_node)) if r.start_node in allowed and r.end_node in allowed][:max_edges]
+    return GraphMetadata(nodes=tuple(snodes), relationships=tuple(srels))
+
+
+def bfs_subgraph(
+    meta: GraphMetadata,
+    start_node: str,
+    depth: int,
+    *,
+    max_nodes: int,
+    max_edges: int,
+) -> GraphMetadata:
+    """Undirected BFS from start_node; depth 0 means start only; unlimited use large depth."""
+    ids = _node_by_id(meta.nodes)
+    if start_node not in ids:
+        return GraphMetadata(nodes=tuple(), relationships=tuple())
+
+    if depth <= 0:
+        depth = 10**9
+
+    adj: dict[str, list[str]] = defaultdict(list)
+    for r in meta.relationships:
+        adj[r.start_node].append(r.end_node)
+        adj[r.end_node].append(r.start_node)
+
+    q: deque[tuple[str, int]] = deque([(start_node, 0)])
+    visited_depth: dict[str, int] = {start_node: 0}
+    while q:
+        nid, d = q.popleft()
+        if d >= depth:
+            continue
+        if len(visited_depth) >= max_nodes:
+            break
+        for nb in sorted(adj[nid]):
+            if nb in visited_depth:
+                continue
+            if len(visited_depth) >= max_nodes:
+                break
+            visited_depth[nb] = d + 1
+            q.append((nb, d + 1))
+
+    allowed = frozenset(visited_depth.keys())
+    cand_rels = [
+        r
+        for r in sorted(meta.relationships, key=lambda x: (x.type, x.id, x.start_node, x.end_node))
+        if r.start_node in allowed and r.end_node in allowed
+    ]
+    rels = cand_rels[:max_edges]
+    node_ids = allowed
+    nodes = tuple(sorted((ids[i] for i in node_ids if i in ids), key=lambda n: n.id))
+    return GraphMetadata(nodes=nodes, relationships=tuple(rels))
+
+
+def normalize_metadata(meta: GraphMetadata, *, start_node: str | None, depth: int, max_nodes: int, max_edges: int) -> GraphMetadata:
+    if start_node:
+        return bfs_subgraph(meta, start_node, depth, max_nodes=max_nodes, max_edges=max_edges)
+    return apply_caps_sorted(meta, max_nodes=max_nodes, max_edges=max_edges)

--- a/src/md_generator/graph/core/job_manager.py
+++ b/src/md_generator/graph/core/job_manager.py
@@ -1,0 +1,280 @@
+from __future__ import annotations
+
+import json
+import logging
+import shutil
+import sqlite3
+import threading
+import time
+import uuid
+import zipfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from md_generator.graph.core.extractor import extract_to_markdown
+from md_generator.graph.core.models import JobStatus
+from md_generator.graph.core.run_config import GraphRunConfig, VizConfig, graph_config_to_jsonable
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class GraphJobRecord:
+    job_id: str
+    status: str
+    progress: int
+    current: str
+    workspace: str
+    zip_path: str | None
+    error: str | None
+    created_at: float
+    updated_at: float
+
+    def to_api_dict(self) -> dict[str, Any]:
+        return {
+            "job_id": self.job_id,
+            "status": self.status,
+            "progress": self.progress,
+            "current": self.current,
+            "workspace": self.workspace,
+            "zip_path": self.zip_path,
+            "error": self.error,
+            "created_at": self.created_at,
+            "updated_at": self.updated_at,
+        }
+
+
+def _zip_dir(src_dir: Path, dest_zip: Path) -> None:
+    dest_zip.parent.mkdir(parents=True, exist_ok=True)
+    with zipfile.ZipFile(dest_zip, "w", zipfile.ZIP_DEFLATED) as zf:
+        for p in sorted(src_dir.rglob("*")):
+            if p.is_file():
+                arc = p.relative_to(src_dir).as_posix()
+                zf.write(p, arc)
+
+
+class GraphJobManager:
+    def __init__(
+        self,
+        *,
+        sqlite_path: str | Path | None = None,
+        workspace_root: Path | None = None,
+        in_memory: bool = False,
+    ) -> None:
+        self._lock = threading.Lock()
+        self._root = Path(workspace_root) if workspace_root else None
+        if in_memory:
+            self._conn: sqlite3.Connection | None = sqlite3.connect(":memory:", check_same_thread=False)
+        else:
+            path = Path(sqlite_path or _default_sqlite_path())
+            path.parent.mkdir(parents=True, exist_ok=True)
+            self._conn = sqlite3.connect(str(path), check_same_thread=False)
+        self._conn.row_factory = sqlite3.Row
+        self._init_db()
+
+    def _init_db(self) -> None:
+        assert self._conn is not None
+        self._conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS jobs (
+                job_id TEXT PRIMARY KEY,
+                status TEXT NOT NULL,
+                progress INTEGER NOT NULL DEFAULT 0,
+                current TEXT NOT NULL DEFAULT '',
+                workspace TEXT NOT NULL,
+                zip_path TEXT,
+                error TEXT,
+                created_at REAL NOT NULL,
+                updated_at REAL NOT NULL,
+                config_json TEXT NOT NULL
+            )
+            """
+        )
+        self._conn.commit()
+
+    def close(self) -> None:
+        if self._conn:
+            self._conn.close()
+            self._conn = None
+
+    def create_job(self, cfg: GraphRunConfig) -> GraphJobRecord:
+        jid = str(uuid.uuid4())
+        base = self._root or Path.cwd() / "graph-md-jobs"
+        ws = (base / jid).resolve()
+        ws.mkdir(parents=True, exist_ok=True)
+        now = time.time()
+        cfg_dump = json.dumps(graph_config_to_jsonable(cfg.normalized()), sort_keys=True)
+        assert self._conn is not None
+        with self._lock:
+            self._conn.execute(
+                """
+                INSERT INTO jobs (job_id, status, progress, current, workspace, zip_path, error, created_at, updated_at, config_json)
+                VALUES (?, ?, 0, '', ?, NULL, NULL, ?, ?, ?)
+                """,
+                (jid, JobStatus.PENDING.value, str(ws), now, now, cfg_dump),
+            )
+            self._conn.commit()
+        return self.get(jid)  # type: ignore[return-value]
+
+    def get(self, job_id: str) -> GraphJobRecord | None:
+        assert self._conn is not None
+        with self._lock:
+            row = self._conn.execute("SELECT * FROM jobs WHERE job_id = ?", (job_id,)).fetchone()
+        if not row:
+            return None
+        return _row_to_record(row)
+
+    def update_progress(self, job_id: str, progress: int, current: str) -> None:
+        assert self._conn is not None
+        now = time.time()
+        with self._lock:
+            self._conn.execute(
+                "UPDATE jobs SET progress = ?, current = ?, updated_at = ? WHERE job_id = ?",
+                (progress, current, now, job_id),
+            )
+            self._conn.commit()
+
+    def mark_running(self, job_id: str) -> None:
+        self._set_status(job_id, JobStatus.RUNNING.value)
+
+    def mark_completed(self, job_id: str, zip_path: Path | None) -> None:
+        assert self._conn is not None
+        now = time.time()
+        with self._lock:
+            self._conn.execute(
+                "UPDATE jobs SET status = ?, progress = 100, zip_path = ?, updated_at = ?, current = ? WHERE job_id = ?",
+                (JobStatus.COMPLETED.value, str(zip_path) if zip_path else None, now, "completed", job_id),
+            )
+            self._conn.commit()
+
+    def mark_failed(self, job_id: str, err: str) -> None:
+        assert self._conn is not None
+        now = time.time()
+        with self._lock:
+            self._conn.execute(
+                "UPDATE jobs SET status = ?, error = ?, updated_at = ?, current = ? WHERE job_id = ?",
+                (JobStatus.FAILED.value, err[:8000], now, "failed", job_id),
+            )
+            self._conn.commit()
+
+    def _set_status(self, job_id: str, status: str) -> None:
+        assert self._conn is not None
+        now = time.time()
+        with self._lock:
+            self._conn.execute(
+                "UPDATE jobs SET status = ?, updated_at = ? WHERE job_id = ?",
+                (status, now, job_id),
+            )
+            self._conn.commit()
+
+    def load_config(self, job_id: str) -> GraphRunConfig | None:
+        rec = self.get(job_id)
+        if not rec:
+            return None
+        assert self._conn is not None
+        with self._lock:
+            row = self._conn.execute("SELECT config_json FROM jobs WHERE job_id = ?", (job_id,)).fetchone()
+        if not row:
+            return None
+        data = json.loads(row["config_json"])
+        return _config_from_jsonable(data)
+
+    def run_job_thread(self, job_id: str) -> None:
+        def target() -> None:
+            try:
+                self.mark_running(job_id)
+                cfg = self.load_config(job_id)
+                if not cfg:
+                    self.mark_failed(job_id, "missing config")
+                    return
+                rec = self.get(job_id)
+                if not rec:
+                    return
+                ws = Path(rec.workspace)
+                out = ws / "markdown"
+
+                def on_progress(p: int, cur: str) -> None:
+                    self.update_progress(job_id, p, cur)
+
+                n_files = [0]
+
+                def on_file(_p: Path) -> None:
+                    n_files[0] += 1
+                    self.update_progress(job_id, min(95, 30 + n_files[0]), "file_generated")
+
+                cfg_run = cfg.with_output(out)
+                extract_to_markdown(cfg_run, on_progress=on_progress, on_file=on_file)
+                zpath = ws / "output.zip"
+                _zip_dir(out, zpath)
+                optional_json = ws / "job.json"
+                optional_json.write_text(
+                    json.dumps({"job_id": job_id, "config": graph_config_to_jsonable(cfg)}, indent=2),
+                    encoding="utf-8",
+                )
+                self.mark_completed(job_id, zpath)
+            except Exception as e:
+                logger.exception("job %s failed", job_id)
+                self.mark_failed(job_id, str(e))
+
+        threading.Thread(target=target, daemon=True).start()
+
+    def remove_after_download(self, job_id: str) -> None:
+        rec = self.get(job_id)
+        if not rec:
+            return
+        ws = Path(rec.workspace)
+        if ws.exists():
+            shutil.rmtree(ws, ignore_errors=True)
+        assert self._conn is not None
+        with self._lock:
+            self._conn.execute("DELETE FROM jobs WHERE job_id = ?", (job_id,))
+            self._conn.commit()
+
+
+def _default_sqlite_path() -> Path:
+    import tempfile
+
+    return Path(tempfile.gettempdir()) / "mdengine-graph-jobs" / "jobs.sqlite"
+
+
+def _config_from_jsonable(data: dict[str, Any]) -> GraphRunConfig:
+    gf = data.get("graph_file")
+    return GraphRunConfig(
+        source=str(data["source"]),
+        uri=str(data.get("uri", "")),
+        user=str(data.get("user", "")),
+        password=str(data.get("password", "")),
+        graph_file=Path(str(gf)) if gf else None,
+        neo4j_id_mode=str(data.get("neo4j_id_mode", "element_id")),
+        neo4j_database=data.get("neo4j_database"),
+        neo4j_page_size=int(data.get("neo4j_page_size", 500)),
+        connection_timeout_s=float(data.get("connection_timeout_s", 30.0)),
+        depth=int(data.get("depth", 0)),
+        start_node=data.get("start_node"),
+        max_nodes=int(data.get("max_nodes", 10_000)),
+        max_edges=int(data.get("max_edges", 50_000)),
+        output_path=Path(str(data["output_path"])),
+        split_files=bool(data.get("split_files", True)),
+        combine_markdown=bool(data.get("combine_markdown", True)),
+        workers=int(data.get("workers", 4)),
+        viz=VizConfig(
+            enabled=bool(data.get("viz_enabled", False)),
+            mermaid=bool(data.get("viz_mermaid", True)),
+            formats=tuple(str(x) for x in (data.get("viz_formats") or ["png", "svg"])),
+        ),
+    ).normalized()
+
+
+def _row_to_record(row: sqlite3.Row) -> GraphJobRecord:
+    return GraphJobRecord(
+        job_id=str(row["job_id"]),
+        status=str(row["status"]),
+        progress=int(row["progress"]),
+        current=str(row["current"] or ""),
+        workspace=str(row["workspace"]),
+        zip_path=str(row["zip_path"]) if row["zip_path"] else None,
+        error=str(row["error"]) if row["error"] else None,
+        created_at=float(row["created_at"]),
+        updated_at=float(row["updated_at"]),
+    )

--- a/src/md_generator/graph/core/markdown_writer.py
+++ b/src/md_generator/graph/core/markdown_writer.py
@@ -1,0 +1,280 @@
+from __future__ import annotations
+
+import json
+import re
+from collections import defaultdict
+from pathlib import Path
+from typing import Any, Callable
+
+from md_generator.graph.core.models import GraphMetadata, Node, Relationship
+
+
+def slugify_segment(name: str, max_len: int = 120) -> str:
+    s = str(name).strip()
+    s = re.sub(r"[^\w.\-]+", "_", s, flags=re.UNICODE)
+    s = s.strip("._") or "unnamed"
+    if len(s) > max_len:
+        s = s[:max_len].rstrip("._")
+    return s or "unnamed"
+
+
+def _md_escape_cell(text: str) -> str:
+    return text.replace("|", "\\|").replace("\n", " ")
+
+
+def _format_value(v: Any) -> str:
+    if v is None:
+        return ""
+    if isinstance(v, (dict, list, tuple)):
+        try:
+            return json.dumps(v, sort_keys=True, ensure_ascii=False)
+        except TypeError:
+            return str(v)
+    return str(v)
+
+
+def _props_table(props: dict[str, Any]) -> str:
+    if not props:
+        return "_No properties._\n"
+    lines = [
+        "| Key | Value |",
+        "| --- | ----- |",
+    ]
+    for k in sorted(props.keys()):
+        lines.append(f"| {_md_escape_cell(str(k))} | {_md_escape_cell(_format_value(props[k]))} |")
+    return "\n".join(lines) + "\n"
+
+
+def _node_labels_md(labels: tuple[str, ...]) -> str:
+    if not labels:
+        return "_No labels._\n"
+    return "\n".join(f"* {lab}" for lab in labels) + "\n"
+
+
+def _incident_rels_lines(nid: str, meta: GraphMetadata) -> list[str]:
+    incident: list[Relationship] = []
+    for r in meta.relationships:
+        if r.start_node == nid or r.end_node == nid:
+            incident.append(r)
+    lines: list[str] = []
+    for r in sorted(incident, key=lambda x: (x.type, x.id, x.start_node, x.end_node)):
+        a = _label_hint(meta, r.start_node)
+        b = _label_hint(meta, r.end_node)
+        lines.append(f"* ({a})-[:{r.type}]->({b})")
+    return lines
+
+
+def _label_hint(meta: GraphMetadata, node_id: str) -> str:
+    for n in meta.nodes:
+        if n.id == node_id:
+            if n.labels:
+                return n.labels_sorted()[0]
+            return "Node"
+    return "Node"
+
+
+def format_node_markdown(n: Node, meta: GraphMetadata) -> str:
+    rel_lines = _incident_rels_lines(n.id, meta)
+    rel_section = "\n".join(rel_lines) + "\n" if rel_lines else "_No relationships._\n"
+    parts = [
+        f"# Node: {n.id}",
+        "",
+        "## Labels",
+        "",
+        _node_labels_md(n.labels_sorted()),
+        "## Properties",
+        "",
+        _props_table(dict(n.properties)),
+        "## Relationships",
+        "",
+        rel_section,
+    ]
+    return "\n".join(parts).rstrip() + "\n"
+
+
+def format_relationship_markdown(r: Relationship, meta: GraphMetadata) -> str:
+    def node_line(nid: str) -> str:
+        for n in meta.nodes:
+            if n.id == nid:
+                lab = n.labels_sorted()[0] if n.labels else "Node"
+                return f"{lab} (id: {nid})"
+        return f"Node (id: {nid})"
+
+    parts = [
+        f"# Relationship: {r.type}",
+        "",
+        "## From",
+        "",
+        node_line(r.start_node),
+        "",
+        "## To",
+        "",
+        node_line(r.end_node),
+        "",
+        "## Properties",
+        "",
+        _props_table(dict(r.properties)),
+    ]
+    return "\n".join(parts).rstrip() + "\n"
+
+
+def format_graph_summary(meta: GraphMetadata) -> str:
+    rel_types = sorted({r.type for r in meta.relationships})
+    label_counts: dict[str, int] = defaultdict(int)
+    for n in meta.nodes:
+        for lab in n.labels:
+            label_counts[lab] += 1
+    label_lines = "\n".join(f"* {k}: {label_counts[k]}" for k in sorted(label_counts)) or "_None_"
+
+    parts = [
+        "# Graph Summary",
+        "",
+        "## Nodes Count",
+        "",
+        str(len(meta.nodes)),
+        "",
+        "## Relationships Count",
+        "",
+        str(len(meta.relationships)),
+        "",
+        "## Relationship Types",
+        "",
+    ]
+    if rel_types:
+        parts.append("\n".join(f"* {t}" for t in rel_types))
+    else:
+        parts.append("_None_")
+    parts.extend(
+        [
+            "",
+            "## Labels (nodes)",
+            "",
+            label_lines + "\n",
+        ]
+    )
+    return "\n".join(parts).rstrip() + "\n"
+
+
+def format_combined_nodes_document(meta: GraphMetadata) -> str:
+    blocks = [format_node_markdown(n, meta) for n in sorted(meta.nodes, key=lambda n: n.id)]
+    return "# Nodes\n\n" + "\n\n---\n\n".join(blocks).rstrip() + "\n"
+
+
+def format_combined_relationships_document(meta: GraphMetadata) -> str:
+    blocks = [
+        format_relationship_markdown(r, meta)
+        for r in sorted(meta.relationships, key=lambda r: (r.type, r.id, r.start_node, r.end_node))
+    ]
+    return "# Relationships\n\n" + "\n\n---\n\n".join(blocks).rstrip() + "\n"
+
+
+def format_graph_summary_with_embedded_documents(meta: GraphMetadata) -> str:
+    """Summary stats plus full combined nodes and relationships (for LLM-ready single file)."""
+    summary = format_graph_summary(meta).rstrip()
+    nodes_doc = format_combined_nodes_document(meta).rstrip()
+    rels_doc = format_combined_relationships_document(meta).rstrip()
+    return (
+        summary
+        + "\n\n---\n\n## All nodes\n\n"
+        + nodes_doc
+        + "\n\n---\n\n## All relationships\n\n"
+        + rels_doc
+        + "\n"
+    )
+
+
+def write_text(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8", newline="\n")
+
+
+def write_markdown_tree(
+    meta: GraphMetadata,
+    root: Path,
+    *,
+    combine_markdown: bool = True,
+    mermaid_body: str | None = None,
+    include_viz_readme: bool = False,
+    on_file: Callable[[Path], None] | None = None,
+) -> None:
+    root.mkdir(parents=True, exist_ok=True)
+
+    if combine_markdown:
+        nodes_doc = format_combined_nodes_document(meta)
+        rels_doc = format_combined_relationships_document(meta)
+        summary_path = root / "graph_summary.md"
+        write_text(summary_path, format_graph_summary_with_embedded_documents(meta))
+        if on_file:
+            on_file(summary_path)
+
+        nodes_combined = root / "nodes.md"
+        write_text(nodes_combined, nodes_doc)
+        if on_file:
+            on_file(nodes_combined)
+
+        rel_combined = root / "relationship.md"
+        write_text(rel_combined, rels_doc)
+        if on_file:
+            on_file(rel_combined)
+
+        readme_lines = [
+            "# Graph export (graph-to-md)",
+            "",
+            "- [Graph summary](./graph_summary.md) — summary plus embedded nodes and relationships",
+            "- [Nodes (combined)](./nodes.md)",
+            "- [Relationships (combined)](./relationship.md)",
+        ]
+    else:
+        nodes_dir = root / "nodes"
+        rels_dir = root / "relationships"
+        nodes_dir.mkdir(parents=True, exist_ok=True)
+        rels_dir.mkdir(parents=True, exist_ok=True)
+
+        summary_path = root / "graph_summary.md"
+        write_text(summary_path, format_graph_summary(meta))
+        if on_file:
+            on_file(summary_path)
+
+        sorted_nodes = sorted(meta.nodes, key=lambda n: n.id)
+        sorted_rels = sorted(meta.relationships, key=lambda r: (r.type, r.id, r.start_node, r.end_node))
+
+        for n in sorted_nodes:
+            p = nodes_dir / f"node_{slugify_segment(n.id)}.md"
+            write_text(p, format_node_markdown(n, meta))
+            if on_file:
+                on_file(p)
+
+        for r in sorted_rels:
+            p = rels_dir / f"rel_{slugify_segment(r.id)}.md"
+            write_text(p, format_relationship_markdown(r, meta))
+            if on_file:
+                on_file(p)
+
+        readme_lines = [
+            "# Graph export (graph-to-md)",
+            "",
+            "- [Graph summary](./graph_summary.md)",
+            "- [Nodes](./nodes/)",
+            "- [Relationships](./relationships/)",
+        ]
+
+    if mermaid_body and mermaid_body.strip():
+        readme_lines.extend(
+            [
+                "",
+                "## Diagram (Mermaid)",
+                "",
+                "Source file: [graph/graph.mmd](./graph/graph.mmd)",
+                "",
+                "```mermaid",
+                mermaid_body.strip(),
+                "```",
+            ]
+        )
+    if include_viz_readme:
+        readme_lines.extend(["", "## Diagram (Graphviz)", "", "![Graph](./graph/graph.png)"])
+    readme_lines.append("")
+    readme_path = root / "README.md"
+    write_text(readme_path, "\n".join(readme_lines))
+    if on_file:
+        on_file(readme_path)

--- a/src/md_generator/graph/core/models.py
+++ b/src/md_generator/graph/core/models.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any
+
+
+class JobStatus(str, Enum):
+    PENDING = "PENDING"
+    RUNNING = "RUNNING"
+    COMPLETED = "COMPLETED"
+    FAILED = "FAILED"
+
+
+@dataclass(frozen=True)
+class Node:
+    id: str
+    labels: tuple[str, ...]
+    properties: dict[str, Any]
+
+    def labels_sorted(self) -> tuple[str, ...]:
+        return tuple(sorted(self.labels))
+
+
+@dataclass(frozen=True)
+class Relationship:
+    id: str
+    type: str
+    start_node: str
+    end_node: str
+    properties: dict[str, Any]
+
+
+@dataclass
+class GraphMetadata:
+    nodes: tuple[Node, ...] = field(default_factory=tuple)
+    relationships: tuple[Relationship, ...] = field(default_factory=tuple)

--- a/src/md_generator/graph/core/run_config.py
+++ b/src/md_generator/graph/core/run_config.py
@@ -1,0 +1,174 @@
+from __future__ import annotations
+
+import copy
+from dataclasses import dataclass, field, replace
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+ALLOWED_SOURCES = frozenset({"networkx", "neo4j"})
+ALLOWED_NEO4J_ID_MODE = frozenset({"element_id", "internal_id"})
+
+
+@dataclass
+class VizConfig:
+    enabled: bool = False
+    """When True, run Graphviz ``dot`` on ``graph.dot`` (requires ``dot`` on PATH)."""
+    mermaid: bool = True
+    """When True (default), write ``graph/graph.mmd`` and embed Mermaid in README (no Graphviz required)."""
+    formats: tuple[str, ...] = ("png", "svg")  # dot always written when enabled
+
+
+@dataclass
+class GraphRunConfig:
+    source: str = "networkx"
+    uri: str = ""
+    user: str = ""
+    password: str = ""
+    graph_file: Path | None = None
+    neo4j_id_mode: str = "element_id"
+    neo4j_database: str | None = None
+    neo4j_page_size: int = 500
+    connection_timeout_s: float = 30.0
+    depth: int = 0  # 0 = unlimited depth for BFS cap only by max_nodes/edges
+    start_node: str | None = None
+    max_nodes: int = 10_000
+    max_edges: int = 50_000
+    output_path: Path = field(default_factory=lambda: Path("docs"))
+    split_files: bool = True  # legacy; layout is controlled by combine_markdown
+    combine_markdown: bool = True  # nodes.md + relationship.md + merged graph_summary.md
+    workers: int = 4
+    viz: VizConfig = field(default_factory=VizConfig)
+
+    def with_output(self, path: Path) -> GraphRunConfig:
+        return replace(self, output_path=path)
+
+    def normalized(self) -> GraphRunConfig:
+        src = (self.source or "networkx").lower().strip()
+        if src not in ALLOWED_SOURCES:
+            src = "networkx"
+        mode = (self.neo4j_id_mode or "element_id").lower().strip()
+        if mode not in ALLOWED_NEO4J_ID_MODE:
+            mode = "element_id"
+        depth = max(0, int(self.depth))
+        max_nodes = max(1, min(int(self.max_nodes), 1_000_000))
+        max_edges = max(1, min(int(self.max_edges), 5_000_000))
+        ps = max(1, min(int(self.neo4j_page_size), 10_000))
+        workers = max(1, min(int(self.workers), 32))
+        to_s = float(self.connection_timeout_s)
+        if to_s <= 0:
+            to_s = 30.0
+        fmts = tuple(
+            f.strip().lower()
+            for f in (self.viz.formats if self.viz.formats else ("png", "svg"))
+            if f.strip()
+        )
+        if not fmts:
+            fmts = ("png", "svg")
+        viz = VizConfig(enabled=bool(self.viz.enabled), mermaid=bool(self.viz.mermaid), formats=fmts)
+        db = (str(self.neo4j_database).strip() or None) if self.neo4j_database else None
+        return GraphRunConfig(
+            source=src,
+            uri=str(self.uri or ""),
+            user=str(self.user or ""),
+            password=str(self.password or ""),
+            graph_file=self.graph_file,
+            neo4j_id_mode=mode,
+            neo4j_database=db,
+            neo4j_page_size=ps,
+            connection_timeout_s=to_s,
+            depth=depth,
+            start_node=(str(self.start_node).strip() or None) if self.start_node else None,
+            max_nodes=max_nodes,
+            max_edges=max_edges,
+            output_path=Path(self.output_path),
+            split_files=bool(self.split_files),
+            combine_markdown=bool(self.combine_markdown),
+            workers=workers,
+            viz=viz,
+        )
+
+
+def _deep_merge(base: dict[str, Any], override: dict[str, Any]) -> dict[str, Any]:
+    out = copy.deepcopy(base)
+    for k, v in override.items():
+        if k in out and isinstance(out[k], dict) and isinstance(v, dict):
+            out[k] = _deep_merge(out[k], v)
+        else:
+            out[k] = copy.deepcopy(v)
+    return out
+
+
+def load_graph_run_config(path: Path | None, overrides: dict[str, Any] | None = None) -> GraphRunConfig:
+    raw: dict[str, Any] = {}
+    if path is not None and path.is_file():
+        raw = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    elif path is None:
+        try:
+            import importlib.resources as ir
+
+            txt = ir.files("md_generator.graph.config").joinpath("default.yaml").read_text(encoding="utf-8")
+            raw = yaml.safe_load(txt) or {}
+        except Exception:
+            raw = {}
+    if overrides:
+        raw = _deep_merge(raw, overrides)
+
+    g = raw.get("graph") or {}
+    out = raw.get("output") or {}
+    exe = raw.get("execution") or {}
+    viz_raw = raw.get("viz") or {}
+
+    gf = g.get("graph_file") or g.get("path") or out.get("graph_file")
+    graph_file = Path(str(gf)).expanduser() if gf else None
+
+    return GraphRunConfig(
+        source=str(g.get("source", "networkx")).lower(),
+        uri=str(g.get("uri", "")),
+        user=str(g.get("user", "")),
+        password=str(g.get("password", "")),
+        graph_file=graph_file,
+        neo4j_id_mode=str(g.get("neo4j_id_mode", "element_id")),
+        neo4j_database=g.get("database") or g.get("neo4j_database"),
+        neo4j_page_size=int(g.get("neo4j_page_size", 500)),
+        connection_timeout_s=float(g.get("connection_timeout_s", 30.0)),
+        depth=int(g.get("depth", 0)),
+        start_node=g.get("start_node"),
+        max_nodes=int(g.get("max_nodes", 10_000)),
+        max_edges=int(g.get("max_edges", 50_000)),
+        output_path=Path(str(out.get("path", "./docs"))),
+        split_files=bool(out.get("split_files", True)),
+        combine_markdown=bool(out.get("combine_markdown", True)),
+        workers=int(exe.get("workers", 4)),
+        viz=VizConfig(
+            enabled=bool(viz_raw.get("enabled", False)),
+            mermaid=bool(viz_raw.get("mermaid", True)),
+            formats=tuple(str(x) for x in (viz_raw.get("formats") or ["png", "svg"])),
+        ),
+    ).normalized()
+
+
+def graph_config_to_jsonable(cfg: GraphRunConfig) -> dict[str, Any]:
+    return {
+        "source": cfg.source,
+        "uri": cfg.uri,
+        "user": cfg.user,
+        "password": cfg.password,
+        "graph_file": str(cfg.graph_file) if cfg.graph_file else None,
+        "neo4j_id_mode": cfg.neo4j_id_mode,
+        "neo4j_database": cfg.neo4j_database,
+        "neo4j_page_size": cfg.neo4j_page_size,
+        "connection_timeout_s": cfg.connection_timeout_s,
+        "depth": cfg.depth,
+        "start_node": cfg.start_node,
+        "max_nodes": cfg.max_nodes,
+        "max_edges": cfg.max_edges,
+        "output_path": str(cfg.output_path),
+        "split_files": cfg.split_files,
+        "combine_markdown": cfg.combine_markdown,
+        "workers": cfg.workers,
+        "viz_enabled": cfg.viz.enabled,
+        "viz_mermaid": cfg.viz.mermaid,
+        "viz_formats": list(cfg.viz.formats),
+    }

--- a/src/md_generator/graph/core/viz.py
+++ b/src/md_generator/graph/core/viz.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+import logging
+import shutil
+import subprocess
+from pathlib import Path
+
+from md_generator.graph.core.models import GraphMetadata
+
+logger = logging.getLogger(__name__)
+
+_MERMAID_MAX_LABEL = 200
+
+
+def _mermaid_sanitize_display(text: str, *, max_len: int = _MERMAID_MAX_LABEL) -> str:
+    """Escape text for inside Mermaid `["..."]` and edge labels."""
+    t = str(text).replace("\r\n", "\n").replace("\r", "\n")
+    t = t.replace("\\", "/")
+    t = t.replace('"', "#quot;")
+    t = t.replace("\n", "<br/>")
+    t = t.replace("[", "(").replace("]", ")")
+    t = t.replace("{", "(").replace("}", ")")
+    t = t.replace("|", " ")
+    t = t.strip() or " "
+    if len(t) > max_len:
+        t = t[: max_len - 3] + "..."
+    return t
+
+
+def metadata_to_mermaid_body(meta: GraphMetadata) -> str:
+    """Return Mermaid source (no fences). Uses ``flowchart LR`` with stable synthetic node ids."""
+    nodes_sorted = sorted(meta.nodes, key=lambda n: n.id)
+    if not nodes_sorted and not meta.relationships:
+        return "flowchart LR\n  empty[Empty graph]"
+    id_map = {n.id: f"n{i}" for i, n in enumerate(nodes_sorted)}
+    lines: list[str] = ["flowchart LR"]
+    for n in nodes_sorted:
+        mid = id_map[n.id]
+        lab0 = ",".join(n.labels_sorted()) or "Node"
+        lab = _mermaid_sanitize_display(f"{lab0} — {n.id}")
+        lines.append(f'  {mid}["{lab}"]')
+    for r in sorted(meta.relationships, key=lambda x: (x.type, x.id, x.start_node, x.end_node)):
+        a = id_map.get(r.start_node)
+        b = id_map.get(r.end_node)
+        if not a or not b:
+            continue
+        typ = _mermaid_sanitize_display(r.type, max_len=80)
+        lines.append(f'  {a} -->|"{typ}"| {b}')
+    return "\n".join(lines)
+
+
+def write_graph_mermaid(meta: GraphMetadata, root: Path) -> str:
+    """Write ``graph/graph.mmd`` and return the diagram body (for README embedding)."""
+    body = metadata_to_mermaid_body(meta)
+    gdir = root / "graph"
+    gdir.mkdir(parents=True, exist_ok=True)
+    path = gdir / "graph.mmd"
+    path.write_text(body + "\n", encoding="utf-8", newline="\n")
+    return body
+
+
+def _dot_escape(s: str) -> str:
+    t = str(s).replace("\\", "\\\\").replace('"', '\\"')
+    return f'"{t}"'
+
+
+def metadata_to_dot(meta: GraphMetadata) -> str:
+    lines = ["digraph G {", "  rankdir=LR;"]
+    for n in sorted(meta.nodes, key=lambda x: x.id):
+        lab = ",".join(n.labels_sorted()) or "Node"
+        lines.append(f"  {_dot_escape(n.id)} [label={_dot_escape(lab)}];")
+    seen: set[tuple[str, str, str]] = set()
+    for r in sorted(meta.relationships, key=lambda x: (x.type, x.id, x.start_node, x.end_node)):
+        key = (r.start_node, r.end_node, r.id)
+        if key in seen:
+            continue
+        seen.add(key)
+        lines.append(
+            f"  {_dot_escape(r.start_node)} -> {_dot_escape(r.end_node)} "
+            f"[label={_dot_escape(r.type)}];"
+        )
+    lines.append("}")
+    return "\n".join(lines) + "\n"
+
+
+def _which_dot() -> str | None:
+    import os
+
+    env = os.environ.get("GRAPHVIZ_DOT")
+    if env and Path(env).is_file():
+        return str(Path(env).resolve())
+    return shutil.which("dot")
+
+
+def write_graph_viz(meta: GraphMetadata, root: Path, *, formats: tuple[str, ...]) -> bool:
+    """Write graph/graph.dot and optionally PNG/SVG via Graphviz. Returns True if PNG exists."""
+    root.mkdir(parents=True, exist_ok=True)
+    gdir = root / "graph"
+    gdir.mkdir(parents=True, exist_ok=True)
+    dot_path = gdir / "graph.dot"
+    dot_path.write_text(metadata_to_dot(meta), encoding="utf-8", newline="\n")
+    dot_exe = _which_dot()
+    if not dot_exe:
+        logger.info("Graphviz dot not found; skipped PNG/SVG (DOT written).")
+        return False
+    wrote_png = False
+    for fmt in formats:
+        fmt = fmt.lower().strip()
+        if fmt not in ("png", "svg", "pdf"):
+            continue
+        out_path = gdir / f"graph.{fmt}"
+        cmd = [dot_exe, f"-T{fmt}", "-o", str(out_path), str(dot_path)]
+        r = subprocess.run(cmd, capture_output=True, text=True, check=False)
+        if r.returncode != 0:
+            logger.warning("dot failed for %s: %s", fmt, (r.stderr or r.stdout or "").strip())
+            continue
+        if fmt == "png":
+            wrote_png = True
+    return wrote_png

--- a/src/md_generator/graph/core/zip_export.py
+++ b/src/md_generator/graph/core/zip_export.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import io
+import zipfile
+from pathlib import Path
+
+from md_generator.graph.core.extractor import extract_to_markdown
+from md_generator.graph.core.run_config import GraphRunConfig
+
+
+def build_markdown_zip_bytes(cfg: GraphRunConfig) -> bytes:
+    import tempfile
+
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td) / "out"
+        cfg_run = cfg.with_output(root)
+        extract_to_markdown(cfg_run)
+        buf = io.BytesIO()
+        with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+            for p in sorted(root.rglob("*")):
+                if p.is_file():
+                    arc = p.relative_to(root).as_posix()
+                    zf.write(p, arc)
+        return buf.getvalue()

--- a/src/md_generator/graph/mcp/__init__.py
+++ b/src/md_generator/graph/mcp/__init__.py
@@ -1,0 +1,1 @@
+"""MCP helpers for graph-to-md."""

--- a/src/md_generator/graph/mcp/server.py
+++ b/src/md_generator/graph/mcp/server.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+import base64
+import json
+from pathlib import Path
+
+from mcp.server.fastmcp import FastMCP
+
+from md_generator.graph.api.schemas import GraphToMdRunBody
+from md_generator.graph.core.markdown_writer import format_node_markdown, format_relationship_markdown
+from md_generator.graph.core.zip_export import build_markdown_zip_bytes
+from md_generator.graph.core.extractor import extract_to_markdown
+
+
+def _metadata_to_jsonable(meta: object) -> dict:
+    from md_generator.graph.core.models import GraphMetadata
+
+    assert isinstance(meta, GraphMetadata)
+    return {
+        "nodes": [
+            {"id": n.id, "labels": list(n.labels), "properties": dict(n.properties)} for n in sorted(meta.nodes, key=lambda x: x.id)
+        ],
+        "relationships": [
+            {
+                "id": r.id,
+                "type": r.type,
+                "start_node": r.start_node,
+                "end_node": r.end_node,
+                "properties": dict(r.properties),
+            }
+            for r in sorted(meta.relationships, key=lambda x: (x.type, x.id, x.start_node, x.end_node))
+        ],
+    }
+
+
+def build_mcp_stack(*, mount_under_fastapi: bool = False) -> tuple[FastMCP, object]:
+    path = "/" if mount_under_fastapi else "/mcp"
+    mcp = FastMCP(
+        "graph-to-md",
+        instructions="Export graph data (NetworkX, Neo4j) to deterministic Markdown.",
+        streamable_http_path=path,
+    )
+
+    @mcp.tool()
+    def graph_validate_config(config_json: str) -> str:
+        data = json.loads(config_json)
+        GraphToMdRunBody.model_validate(data)
+        return "ok"
+
+    @mcp.tool()
+    def graph_run_sync_zip_base64(config_json: str) -> str:
+        body = GraphToMdRunBody.model_validate(json.loads(config_json))
+        cfg = body.to_run_config()
+        data = build_markdown_zip_bytes(cfg)
+        return base64.b64encode(data).decode("ascii")
+
+    @mcp.tool()
+    def graph_run_sync_write_zip(config_json: str, output_zip_path: str) -> str:
+        body = GraphToMdRunBody.model_validate(json.loads(config_json))
+        cfg = body.to_run_config()
+        data = build_markdown_zip_bytes(cfg)
+        out = Path(output_zip_path).expanduser().resolve()
+        out.write_bytes(data)
+        return str(out)
+
+    @mcp.tool()
+    def graph_preview_readme_markdown(config_json: str) -> str:
+        body = GraphToMdRunBody.model_validate(json.loads(config_json))
+        cfg = body.to_run_config()
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td) / "out"
+            extract_to_markdown(cfg.with_output(root))
+            p = root / "README.md"
+            return p.read_text(encoding="utf-8") if p.is_file() else ""
+
+    @mcp.tool()
+    def graph_metadata_json(config_json: str) -> str:
+        body = GraphToMdRunBody.model_validate(json.loads(config_json))
+        cfg = body.to_run_config()
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td) / "out"
+            meta = extract_to_markdown(cfg.with_output(root))
+        return json.dumps(_metadata_to_jsonable(meta), indent=2, sort_keys=True)
+
+    @mcp.tool()
+    def graph_preview_node_markdown(config_json: str, node_id: str) -> str:
+        body = GraphToMdRunBody.model_validate(json.loads(config_json))
+        cfg = body.to_run_config()
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td) / "out"
+            meta = extract_to_markdown(cfg.with_output(root))
+        for n in meta.nodes:
+            if n.id == node_id:
+                return format_node_markdown(n, meta)
+        return ""
+
+    @mcp.tool()
+    def graph_preview_rel_markdown(config_json: str, relationship_id: str) -> str:
+        body = GraphToMdRunBody.model_validate(json.loads(config_json))
+        cfg = body.to_run_config()
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td) / "out"
+            meta = extract_to_markdown(cfg.with_output(root))
+        for r in meta.relationships:
+            if r.id == relationship_id:
+                return format_relationship_markdown(r, meta)
+        return ""
+
+    sub = mcp.streamable_http_app()
+    return mcp, sub

--- a/src/md_generator/graph/mcp/sse.py
+++ b/src/md_generator/graph/mcp/sse.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+import json
+from typing import Any
+
+
+def format_sse(event: str, payload: dict[str, Any]) -> str:
+    return f"event: {event}\ndata: {json.dumps(payload, sort_keys=True)}\n\n"

--- a/src/md_generator/graph/mcp/stream.py
+++ b/src/md_generator/graph/mcp/stream.py
@@ -1,0 +1,5 @@
+"""Stream helpers for graph-to-md MCP (re-export SSE formatter)."""
+
+from md_generator.graph.mcp.sse import format_sse
+
+__all__ = ["format_sse"]


### PR DESCRIPTION
## Summary

Introduces **graph-to-md**: turn **graph-shaped data** (e.g. **Neo4j** query results and **NetworkX** structures) into **Markdown** documentation—tables, summaries, and optional diagram-friendly output as implemented in this branch—plus **CLI**, **HTTP API**, and **MCP** entry points.

Closes #11

## What’s included

- **Optional extra:** `graph` — `networkx>=3.2`, `neo4j>=5.14`, `pyyaml>=6` (see `pyproject.toml`).
- **CLI:** `md-graph` → `md_generator.graph.cli.main:main`
- **HTTP API:** `md-graph-api` → `md_generator.graph.api.run:main`
- **MCP:** `md-graph-mcp` → `md_generator.graph.api.mcp_server:main`
- **Config:** package data includes `md_generator.graph.config` `*.yaml` for connection / export profiles (per implementation).
- **Tests:** `graph-to-md/tests/` (listed in `pytest` `testpaths`).

## Usage (outline)

```bash
pip install "mdengine[graph]"
md-graph --help