### PR TITLE
feat(codeflow-to-md): multi-language execution flow → Markdown & diagrams (AST + runtime) (#18)

### DIFF
--- a/codeflow-to-md/converter.py
+++ b/codeflow-to-md/converter.py
@@ -1,0 +1,15 @@
+"""Shim CLI: ``md-codeflow`` after ``pip install mdengine[codeflow]``."""
+
+from __future__ import annotations
+
+import sys
+
+
+def main() -> None:
+    from md_generator.codeflow.cli.main import main as _main
+
+    raise SystemExit(_main(sys.argv[1:]))
+
+
+if __name__ == "__main__":
+    main()

--- a/codeflow-to-md/examples/codeflow_go_dump/go.mod
+++ b/codeflow-to-md/examples/codeflow_go_dump/go.mod
@@ -1,0 +1,3 @@
+module codeflow_go_dump
+
+go 1.21

--- a/codeflow-to-md/examples/codeflow_go_dump/main.go
+++ b/codeflow-to-md/examples/codeflow_go_dump/main.go
@@ -1,0 +1,116 @@
+// Codeflow: dump Go call graph edges as JSON for Python consumer.
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+)
+
+type call struct {
+	Caller string `json:"caller"`
+	Callee string `json:"callee"`
+	Line   int    `json:"line"`
+}
+
+type fn struct {
+	ID    string  `json:"id"`
+	Calls []call  `json:"calls"`
+}
+
+type outDoc struct {
+	File  string `json:"file"`
+	Funcs []fn   `json:"funcs"`
+}
+
+func calleeString(e *ast.CallExpr) string {
+	switch t := e.Fun.(type) {
+	case *ast.SelectorExpr:
+		if x, ok := t.X.(*ast.Ident); ok {
+			return x.Name + "." + t.Sel.Name
+		}
+		return "." + t.Sel.Name
+	case *ast.Ident:
+		return t.Name
+	default:
+		return "unknown"
+	}
+}
+
+func recvTypeString(fd *ast.FuncDecl) string {
+	if fd.Recv == nil || len(fd.Recv.List) == 0 {
+		return ""
+	}
+	ft := fd.Recv.List[0].Type
+	switch x := ft.(type) {
+	case *ast.StarExpr:
+		if id, ok := x.X.(*ast.Ident); ok {
+			return id.Name
+		}
+	case *ast.Ident:
+		return x.Name
+	}
+	return "recv"
+}
+
+func funcID(fileKey, recv, name string) string {
+	if recv == "" {
+		return fileKey + "::" + name
+	}
+	return fileKey + "::" + recv + "." + name
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: codeflow_go_dump <file.go> [fileKey]")
+		os.Exit(2)
+	}
+	fp := os.Args[1]
+	fileKey := fp
+	if len(os.Args) >= 3 && os.Args[2] != "" {
+		fileKey = os.Args[2]
+	}
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, fp, nil, parser.ParseComments)
+	if err != nil {
+		_ = json.NewEncoder(os.Stdout).Encode(map[string]string{"error": err.Error()})
+		os.Exit(1)
+	}
+	doc := outDoc{File: fp, Funcs: nil}
+
+	for _, decl := range f.Decls {
+		fd, ok := decl.(*ast.FuncDecl)
+		if !ok {
+			continue
+		}
+		if fd.Body == nil {
+			continue
+		}
+		recv := recvTypeString(fd)
+		id := funcID(fileKey, recv, fd.Name.Name)
+		entry := fn{ID: id, Calls: nil}
+		ast.Inspect(fd.Body, func(n ast.Node) bool {
+			ce, ok := n.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+			pos := fset.Position(ce.Pos())
+			entry.Calls = append(entry.Calls, call{
+				Caller: id,
+				Callee: calleeString(ce),
+				Line:   pos.Line,
+			})
+			return true
+		})
+		doc.Funcs = append(doc.Funcs, entry)
+	}
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(doc); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}

--- a/codeflow-to-md/examples/codeflow_go_dump/main_test.go
+++ b/codeflow-to-md/examples/codeflow_go_dump/main_test.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"go/ast"
+	"testing"
+)
+
+func TestFuncID(t *testing.T) {
+	if got := funcID("pkg/a.go", "", "main"); got != "pkg/a.go::main" {
+		t.Fatalf("funcID module: got %q", got)
+	}
+	if got := funcID("pkg/a.go", "T", "M"); got != "pkg/a.go::T.M" {
+		t.Fatalf("funcID method: got %q", got)
+	}
+}
+
+func TestCalleeString_selector(t *testing.T) {
+	ce := &ast.CallExpr{
+		Fun: &ast.SelectorExpr{
+			X:   &ast.Ident{Name: "fmt"},
+			Sel: &ast.Ident{Name: "Println"},
+		},
+	}
+	if got := calleeString(ce); got != "fmt.Println" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestCalleeString_ident(t *testing.T) {
+	ce := &ast.CallExpr{Fun: &ast.Ident{Name: "foo"}}
+	if got := calleeString(ce); got != "foo" {
+		t.Fatalf("got %q", got)
+	}
+}

--- a/codeflow-to-md/examples/codeflow_php_dump/composer.json
+++ b/codeflow-to-md/examples/codeflow_php_dump/composer.json
@@ -1,0 +1,8 @@
+{
+  "name": "mdengine/codeflow-php-dump",
+  "description": "PHP AST JSON bridge for codeflow-to-md",
+  "require": {
+    "php": ">=8.1",
+    "nikic/php-parser": "^5.0"
+  }
+}

--- a/codeflow-to-md/examples/codeflow_php_dump/dump.php
+++ b/codeflow-to-md/examples/codeflow_php_dump/dump.php
@@ -1,0 +1,117 @@
+<?php
+declare(strict_types=1);
+
+// Usage: php dump.php <file.php> [fileKey]
+
+if ($argc < 2) {
+    fwrite(STDERR, "usage: php dump.php <file.php> [fileKey]\n");
+    exit(2);
+}
+
+$autoload = __DIR__ . '/vendor/autoload.php';
+if (!is_file($autoload)) {
+    echo json_encode(['error' => 'run composer install in tools/codeflow_php_dump'], JSON_UNESCAPED_SLASHES) . "\n";
+    exit(1);
+}
+
+require $autoload;
+
+use PhpParser\Error;
+use PhpParser\Node;
+use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\StaticCall;
+use PhpParser\Node\Stmt\Class_;
+use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\Node\Stmt\Function_;
+use PhpParser\NodeTraverser;
+use PhpParser\NodeVisitorAbstract;
+use PhpParser\ParserFactory;
+
+$path = $argv[1];
+$fileKey = $argc >= 3 ? $argv[2] : $path;
+$code = file_get_contents($path);
+if ($code === false) {
+    echo json_encode(['error' => 'cannot read file'], JSON_UNESCAPED_SLASHES) . "\n";
+    exit(1);
+}
+
+$parser = (new ParserFactory())->createForNewestSupportedVersion();
+try {
+    $ast = $parser->parse($code);
+} catch (Error $e) {
+    echo json_encode(['error' => $e->getMessage()], JSON_UNESCAPED_SLASHES) . "\n";
+    exit(1);
+}
+
+final class DumpVisitor extends NodeVisitorAbstract
+{
+    /** @var list<string> */
+    private array $classStack = [];
+
+    /** @var list<array{id:string,calls:list<array{caller:string,callee:string,line:int}>}> */
+    private array $fnStack = [];
+
+    /** @var list<array{id:string,calls:list<array{caller:string,callee:string,line:int}>}> */
+    public array $completed = [];
+
+    public function __construct(private string $fileKey)
+    {
+    }
+
+    public function enterNode(Node $node)
+    {
+        if ($node instanceof Class_) {
+            $this->classStack[] = (string) $node->name->name;
+        } elseif ($node instanceof Function_) {
+            $id = $this->fileKey . '::' . (string) $node->name->name;
+            $this->fnStack[] = ['id' => $id, 'calls' => []];
+        } elseif ($node instanceof ClassMethod) {
+            $cls = $this->classStack[count($this->classStack) - 1] ?? 'anon';
+            $id = $this->fileKey . '::' . $cls . '.' . (string) $node->name->name;
+            $this->fnStack[] = ['id' => $id, 'calls' => []];
+        } elseif ($node instanceof FuncCall || $node instanceof MethodCall || $node instanceof StaticCall) {
+            if ($this->fnStack === []) {
+                return null;
+            }
+            $caller = $this->fnStack[count($this->fnStack) - 1]['id'];
+            $callee = 'unknown';
+            if ($node instanceof FuncCall) {
+                $n = $node->name;
+                if ($n instanceof Node\Name) {
+                    $callee = $n->toString();
+                }
+            } elseif ($node instanceof MethodCall) {
+                $callee = (string) $node->name->name;
+            } elseif ($node instanceof StaticCall) {
+                $callee = (string) $node->name->name;
+            }
+            $this->fnStack[count($this->fnStack) - 1]['calls'][] = [
+                'caller' => $caller,
+                'callee' => $callee,
+                'line' => $node->getStartLine(),
+            ];
+        }
+        return null;
+    }
+
+    public function leaveNode(Node $node)
+    {
+        if ($node instanceof Class_) {
+            array_pop($this->classStack);
+        } elseif ($node instanceof Function_ || $node instanceof ClassMethod) {
+            $top = array_pop($this->fnStack);
+            if ($top !== null) {
+                $this->completed[] = $top;
+            }
+        }
+        return null;
+    }
+}
+
+$visitor = new DumpVisitor($fileKey);
+$trav = new NodeTraverser();
+$trav->addVisitor($visitor);
+$trav->traverse($ast);
+
+echo json_encode(['file' => $path, 'funcs' => $visitor->completed], JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT) . "\n";

--- a/codeflow-to-md/examples/mini_java/demo/DemoController.java
+++ b/codeflow-to-md/examples/mini_java/demo/DemoController.java
@@ -1,0 +1,17 @@
+package demo;
+
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@RestController
+public class DemoController {
+
+    @GetMapping("/hello")
+    public String hello() {
+        return greet();
+    }
+
+    private String greet() {
+        return "ok";
+    }
+}

--- a/codeflow-to-md/examples/mini_python/demo.py
+++ b/codeflow-to-md/examples/mini_python/demo.py
@@ -1,0 +1,35 @@
+"""Sample flow: ClassA.a → b → branch → c / B methods."""
+
+from __future__ import annotations
+
+
+class ClassB:
+    def method1(self) -> None:
+        pass
+
+    def method2(self) -> None:
+        pass
+
+
+class ClassA:
+    def a(self) -> None:
+        self.b()
+
+    def b(self, cond1: bool = False, cond2: bool = False) -> None:
+        if cond1:
+            self.c()
+        elif cond2:
+            ClassB().method1()
+        else:
+            ClassB().method2()
+
+    def c(self) -> None:
+        pass
+
+
+def main() -> None:
+    ClassA().a()
+
+
+if __name__ == "__main__":
+    main()

--- a/codeflow-to-md/examples/sample-output/demo.py____main__/flow.md
+++ b/codeflow-to-md/examples/sample-output/demo.py____main__/flow.md
@@ -1,0 +1,4 @@
+# Entry: `demo.py::__main__`
+
+## Flow
+

--- a/codeflow-to-md/examples/sample-output/demo.py____main__/flow.mmd
+++ b/codeflow-to-md/examples/sample-output/demo.py____main__/flow.mmd
@@ -1,0 +1,1 @@
+flowchart TD

--- a/codeflow-to-md/examples/sample-output/demo.py____main__/graph.json
+++ b/codeflow-to-md/examples/sample-output/demo.py____main__/graph.json
@@ -1,0 +1,15 @@
+{
+  "nodes": [
+    {
+      "id": "demo.py::__main__",
+      "type": "entry",
+      "class_name": null,
+      "method_name": "__main__",
+      "file_path": "demo.py",
+      "language": "python",
+      "entry_kind": "main",
+      "entry_label": "Python __main__ guard"
+    }
+  ],
+  "edges": []
+}

--- a/codeflow-to-md/examples/sample-output/demo.py____main__/sequence.mmd
+++ b/codeflow-to-md/examples/sample-output/demo.py____main__/sequence.mmd
@@ -1,0 +1,2 @@
+sequenceDiagram
+  participant E as demo.py::__main__

--- a/codeflow-to-md/examples/sample-output/graph-full.json
+++ b/codeflow-to-md/examples/sample-output/graph-full.json
@@ -1,0 +1,142 @@
+{
+  "nodes": [
+    {
+      "id": "demo.py::ClassB.method1",
+      "type": "method",
+      "class_name": "ClassB",
+      "method_name": "method1",
+      "file_path": "demo.py",
+      "language": "python"
+    },
+    {
+      "id": "demo.py::ClassB.method2",
+      "type": "method",
+      "class_name": "ClassB",
+      "method_name": "method2",
+      "file_path": "demo.py",
+      "language": "python"
+    },
+    {
+      "id": "demo.py::ClassA.a",
+      "type": "method",
+      "class_name": "ClassA",
+      "method_name": "a",
+      "file_path": "demo.py",
+      "language": "python"
+    },
+    {
+      "id": "demo.py::ClassA.b",
+      "type": "method",
+      "class_name": "ClassA",
+      "method_name": "b",
+      "file_path": "demo.py",
+      "language": "python"
+    },
+    {
+      "id": "demo.py::ClassA.c",
+      "type": "method",
+      "class_name": "ClassA",
+      "method_name": "c",
+      "file_path": "demo.py",
+      "language": "python"
+    },
+    {
+      "id": "demo.py::main",
+      "type": "method",
+      "class_name": null,
+      "method_name": "main",
+      "file_path": "demo.py",
+      "language": "python"
+    },
+    {
+      "id": "demo.py::__main__",
+      "type": "entry",
+      "class_name": null,
+      "method_name": "__main__",
+      "file_path": "demo.py",
+      "language": "python",
+      "entry_kind": "main",
+      "entry_label": "Python __main__ guard"
+    },
+    {
+      "id": "ClassB().method1",
+      "type": "method",
+      "class_name": "ClassB()",
+      "method_name": "method1",
+      "file_path": "",
+      "language": "python",
+      "unresolved": false
+    },
+    {
+      "id": "ClassB().method2",
+      "type": "method",
+      "class_name": "ClassB()",
+      "method_name": "method2",
+      "file_path": "",
+      "language": "python",
+      "unresolved": false
+    },
+    {
+      "id": "ClassA().a",
+      "type": "method",
+      "class_name": "ClassA()",
+      "method_name": "a",
+      "file_path": "",
+      "language": "python",
+      "unresolved": false
+    }
+  ],
+  "edges": [
+    {
+      "source": "demo.py::ClassA.a",
+      "target": "demo.py::ClassA.b",
+      "type": "sync",
+      "resolution": "static",
+      "condition": null,
+      "labels": [],
+      "async_": false
+    },
+    {
+      "source": "demo.py::ClassA.b",
+      "target": "demo.py::ClassA.c",
+      "type": "sync",
+      "resolution": "static",
+      "condition": "if(cond1)",
+      "labels": [
+        "if(cond1)"
+      ],
+      "async_": false
+    },
+    {
+      "source": "demo.py::ClassA.b",
+      "target": "ClassB().method1",
+      "type": "sync",
+      "resolution": "dynamic",
+      "condition": "if(cond2)",
+      "labels": [
+        "if(cond2)"
+      ],
+      "async_": false
+    },
+    {
+      "source": "demo.py::ClassA.b",
+      "target": "ClassB().method2",
+      "type": "sync",
+      "resolution": "dynamic",
+      "condition": "else(L21)",
+      "labels": [
+        "else(L21)"
+      ],
+      "async_": false
+    },
+    {
+      "source": "demo.py::main",
+      "target": "ClassA().a",
+      "type": "sync",
+      "resolution": "dynamic",
+      "condition": null,
+      "labels": [],
+      "async_": false
+    }
+  ]
+}

--- a/codeflow-to-md/tests/test_business_rules.py
+++ b/codeflow-to-md/tests/test_business_rules.py
@@ -1,0 +1,422 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import networkx as nx
+
+from md_generator.codeflow.analyzers.flow_analyzer import FlowSlice
+from md_generator.codeflow.api.schemas import scan_config_dump, scan_config_load
+from md_generator.codeflow.core.extractor import run_scan
+from md_generator.codeflow.core.run_config import ScanConfig
+from md_generator.codeflow.generators.business_rules_markdown import (
+    write_business_rules_markdown,
+    write_combined_entry_markdown,
+)
+from md_generator.codeflow.generators.entry_markdown import write_entry_markdown
+from md_generator.codeflow.models.ir import BranchPoint, BusinessRule, FileParseResult
+from md_generator.codeflow.rules.collector import collect_business_rules, dedupe_rules
+
+
+def test_dedupe_rules_identical() -> None:
+    r = BusinessRule(
+        source="predicate",
+        symbol_id="a",
+        file_path="f.py",
+        line=1,
+        title="t",
+        detail="same",
+        confidence="high",
+    )
+    out = dedupe_rules([r, r])
+    assert len(out) == 1
+
+
+def test_collect_from_conditional_edges(tmp_path: Path) -> None:
+    root = tmp_path
+    g = nx.DiGraph()
+    g.add_node("m.py::A.f", file_path="m.py", class_name="A", method_name="f", type="method")
+    g.add_node("m.py::A.g", file_path="m.py", class_name="A", method_name="g", type="method")
+    g.add_edge(
+        "m.py::A.f",
+        "m.py::A.g",
+        type="sync",
+        condition="x > 0",
+        labels=["x > 0"],
+    )
+    sl = FlowSlice(
+        entry_id="m.py::A.f",
+        nodes=set(g.nodes),
+        edges=[("m.py::A.f", "m.py::A.g", dict(g.edges["m.py::A.f", "m.py::A.g"]))],
+        depth=3,
+    )
+    cfg = ScanConfig(
+        project_root=root,
+        output_path=root / "out",
+        formats=("md",),
+        business_rules=True,
+        business_rules_sql=False,
+    )
+    rules = collect_business_rules("m.py::A.f", sl, g, [], cfg, project_root=root)
+    assert any("x > 0" in r.detail for r in rules)
+
+
+def test_sql_trigger_scan(tmp_path: Path) -> None:
+    (tmp_path / "db.sql").write_text("-- hi\nCREATE TRIGGER trg BEFORE INSERT ON t BEGIN END;\n", encoding="utf-8")
+    g = nx.DiGraph()
+    g.add_node("m.py::A.f", file_path="m.py", type="method")
+    sl = FlowSlice(entry_id="m.py::A.f", nodes={"m.py::A.f"}, edges=[], depth=3)
+    cfg = ScanConfig(
+        project_root=tmp_path,
+        output_path=tmp_path / "out",
+        formats=("md",),
+        business_rules=True,
+        business_rules_sql=True,
+    )
+    rules = collect_business_rules("m.py::A.f", sl, g, [], cfg, project_root=tmp_path)
+    assert any(r.source == "sql_trigger" for r in rules)
+
+
+def test_write_combined_merges_headings(tmp_path: Path) -> None:
+    entry = tmp_path / "entry.md"
+    rules_path = tmp_path / "business_rules.md"
+    comb = tmp_path / "entry.combined.md"
+    entry.write_text("# Execution Flow\n\nbody\n", encoding="utf-8")
+    write_business_rules_markdown(rules_path, [], entry_hint="x")
+    write_combined_entry_markdown(entry, rules_path, comb)
+    text = comb.read_text(encoding="utf-8")
+    assert "# Execution Flow" in text
+    assert "# Business rules" in text
+    assert "\n---\n" in text
+
+
+def test_entry_markdown_includes_rules_section(tmp_path: Path) -> None:
+    g = nx.DiGraph()
+    g.add_node("k.py::M.x", file_path="k.py", class_name="M", method_name="x", type="entry")
+    sl = FlowSlice(entry_id="k.py::M.x", nodes={"k.py::M.x"}, edges=[], depth=2)
+    rlist = [
+        BusinessRule(
+            source="validation",
+            symbol_id="k.py::M.x",
+            file_path="k.py",
+            line=3,
+            title="Assert",
+            detail="a == 1",
+            confidence="low",
+        ),
+    ]
+    write_entry_markdown(tmp_path / "e.md", "k.py::M.x", sl, g, None, rules=rlist)
+    body = (tmp_path / "e.md").read_text(encoding="utf-8")
+    assert "## Business rules" in body
+    assert "business_rules.md" in body
+
+
+def test_run_scan_emits_rules_artifacts(tmp_path: Path) -> None:
+    root = Path(__file__).resolve().parents[1] / "examples" / "mini_python"
+    out = tmp_path / "o"
+    cfg = ScanConfig(
+        project_root=root,
+        output_path=out,
+        formats=("md",),
+        depth=4,
+        languages="python",
+        business_rules=True,
+        business_rules_combined=True,
+    )
+    run_scan(cfg)
+    found = False
+    for sub in out.iterdir():
+        if sub.is_dir() and (sub / "entry.md").is_file():
+            found = True
+            assert (sub / "business_rules.md").is_file()
+            assert (sub / "entry.combined.md").is_file()
+            combined = (sub / "entry.combined.md").read_text(encoding="utf-8")
+            assert "Execution Flow Documentation" in combined
+            assert "Business rules" in combined
+    assert found
+
+
+def test_run_scan_no_business_rules_skips_extra_files(tmp_path: Path) -> None:
+    root = Path(__file__).resolve().parents[1] / "examples" / "mini_python"
+    out = tmp_path / "o2"
+    cfg = ScanConfig(
+        project_root=root,
+        output_path=out,
+        formats=("md",),
+        depth=4,
+        languages="python",
+        business_rules=False,
+    )
+    run_scan(cfg)
+    for sub in out.iterdir():
+        if sub.is_dir() and (sub / "entry.md").is_file():
+            assert not (sub / "business_rules.md").exists()
+            assert not (sub / "entry.combined.md").exists()
+            em = (sub / "entry.md").read_text(encoding="utf-8")
+            assert "## Business rules" not in em
+
+
+def test_collect_returns_empty_when_business_rules_disabled(tmp_path: Path) -> None:
+    g = nx.DiGraph()
+    g.add_node("a.py::f", file_path="a.py")
+    sl = FlowSlice(entry_id="a.py::f", nodes={"a.py::f"}, edges=[], depth=2)
+    cfg = ScanConfig(
+        project_root=tmp_path,
+        output_path=tmp_path / "o",
+        business_rules=False,
+    )
+    assert collect_business_rules("a.py::f", sl, g, [], cfg, project_root=tmp_path) == []
+
+
+def test_collect_merges_file_parse_result_rules(tmp_path: Path) -> None:
+    xpy = tmp_path / "x.py"
+    xpy.write_text("class M:\n    def m(self):\n        pass\n", encoding="utf-8")
+    g = nx.DiGraph()
+    g.add_node("x.py::M.m", file_path="x.py")
+    sl = FlowSlice(entry_id="x.py::M.m", nodes={"x.py::M.m"}, edges=[], depth=2)
+    injected = BusinessRule(
+        source="validation",
+        symbol_id="x.py::M.m",
+        file_path="x.py",
+        line=9,
+        title="From parser rules",
+        detail="custom",
+        confidence="high",
+    )
+    fr = FileParseResult(path=xpy, language="python")
+    fr.rules.append(injected)
+    cfg = ScanConfig(project_root=tmp_path, output_path=tmp_path / "o", business_rules=True)
+    out = collect_business_rules("x.py::M.m", sl, g, [fr], cfg, project_root=tmp_path)
+    assert any(r.title == "From parser rules" and r.detail == "custom" for r in out)
+
+
+def test_collect_branch_points_from_parse_results(tmp_path: Path) -> None:
+    ppy = tmp_path / "p.py"
+    ppy.write_text("class C:\n    def run(self):\n        pass\n", encoding="utf-8")
+    g = nx.DiGraph()
+    g.add_node("p.py::C.run", file_path="p.py", class_name="C", method_name="run")
+    sl = FlowSlice(entry_id="p.py::C.run", nodes={"p.py::C.run"}, edges=[], depth=2)
+    fr = FileParseResult(path=ppy, language="python")
+    fr.branches.append(
+        BranchPoint(caller_id="p.py::C.run", kind="if", label="qty > 0", line=12),
+    )
+    cfg = ScanConfig(project_root=tmp_path, output_path=tmp_path / "o", business_rules=True)
+    out = collect_business_rules("p.py::C.run", sl, g, [fr], cfg, project_root=tmp_path)
+    br = [r for r in out if r.source == "branch"]
+    assert len(br) == 1
+    assert br[0].detail == "qty > 0"
+    assert "Branch (if)" in br[0].title
+
+
+def test_collect_python_field_validator_assert_and_raise(tmp_path: Path) -> None:
+    root = tmp_path
+    mod = root / "mod.py"
+    mod.write_text(
+        '''\
+class M:
+    @field_validator("x")
+    @classmethod
+    def validate_x(cls, v):
+        return v
+
+    def f(self):
+        assert 1 == 1
+        raise ValueError("invalid input")
+''',
+        encoding="utf-8",
+    )
+    g = nx.DiGraph()
+    g.add_node("mod.py::M.validate_x", file_path="mod.py", class_name="M", method_name="validate_x", type="method")
+    g.add_node("mod.py::M.f", file_path="mod.py", class_name="M", method_name="f", type="method")
+    sl = FlowSlice(
+        entry_id="mod.py::M.f",
+        nodes={"mod.py::M.f", "mod.py::M.validate_x"},
+        edges=[],
+        depth=2,
+    )
+    fr = FileParseResult(path=mod, language="python")
+    cfg = ScanConfig(project_root=root, output_path=root / "out", business_rules=True)
+    out = collect_business_rules("mod.py::M.f", sl, g, [fr], cfg, project_root=root)
+    titles = [r.title for r in out]
+    assert any("field_validator" in t for t in titles)
+    assert any(t == "Assert" for t in titles)
+    assert any("Raise ValueError" in t for t in titles)
+
+
+def test_write_business_rules_markdown_non_empty_sections(tmp_path: Path) -> None:
+    rules = [
+        BusinessRule(
+            source="predicate",
+            symbol_id="a::X",
+            file_path="f.py",
+            line=1,
+            title="t1",
+            detail="d1",
+            confidence="high",
+        ),
+        BusinessRule(
+            source="branch",
+            symbol_id="a::X",
+            file_path="f.py",
+            line=4,
+            title="Branch (if)",
+            detail="flag set",
+            confidence="medium",
+        ),
+        BusinessRule(
+            source="validation",
+            symbol_id="a::X",
+            file_path="f.py",
+            line=2,
+            title="t2",
+            detail="d2",
+            confidence="low",
+        ),
+        BusinessRule(
+            source="sql_trigger",
+            symbol_id=None,
+            file_path="s.sql",
+            line=3,
+            title="SQL trigger",
+            detail="CREATE TRIGGER trg",
+            confidence="medium",
+        ),
+    ]
+    path = tmp_path / "br.md"
+    write_business_rules_markdown(path, rules, entry_hint="e1")
+    text = path.read_text(encoding="utf-8")
+    assert "## Predicates and branch conditions (from call graph)" in text
+    assert "## Branch points (parser)" in text
+    assert "## Validation-style hints (assert, raise, decorators)" in text
+    assert "## SQL triggers (workspace scan)" in text
+    assert "| Line | Symbol | Title | Detail | Conf. |" in text
+    assert "| 1 |" in text
+
+
+def test_run_scan_combined_disabled_writes_no_combined_file(tmp_path: Path) -> None:
+    root = Path(__file__).resolve().parents[1] / "examples" / "mini_python"
+    out = tmp_path / "o3"
+    cfg = ScanConfig(
+        project_root=root,
+        output_path=out,
+        formats=("md",),
+        depth=4,
+        languages="python",
+        business_rules=True,
+        business_rules_combined=False,
+    )
+    run_scan(cfg)
+    for sub in out.iterdir():
+        if sub.is_dir() and (sub / "entry.md").is_file():
+            assert (sub / "business_rules.md").is_file()
+            assert not (sub / "entry.combined.md").exists()
+
+
+def test_sql_scan_respects_paths_override_parent(tmp_path: Path) -> None:
+    sub = tmp_path / "pkg"
+    other = tmp_path / "other"
+    sub.mkdir()
+    other.mkdir()
+    (sub / "in.sql").write_text("CREATE TRIGGER t1 BEFORE INSERT ON a;\n", encoding="utf-8")
+    (other / "out.sql").write_text("CREATE TRIGGER t2 BEFORE DELETE ON b;\n", encoding="utf-8")
+    (sub / "marker.py").write_text("x = 1\n", encoding="utf-8")
+
+    g = nx.DiGraph()
+    g.add_node("pkg/marker.py::x", file_path="pkg/marker.py")
+    sl = FlowSlice(entry_id="pkg/marker.py::x", nodes={"pkg/marker.py::x"}, edges=[], depth=2)
+    cfg = ScanConfig(
+        project_root=tmp_path,
+        output_path=tmp_path / "out",
+        business_rules=True,
+        business_rules_sql=True,
+        paths_override=[sub / "marker.py"],
+    )
+    rules = collect_business_rules("pkg/marker.py::x", sl, g, [], cfg, project_root=tmp_path)
+    sql_rules = [r for r in rules if r.source == "sql_trigger"]
+    assert len(sql_rules) == 1
+    assert "t1" in sql_rules[0].detail
+    assert "t2" not in sql_rules[0].detail
+
+
+def test_scan_config_dump_load_roundtrip_business_flags(tmp_path: Path) -> None:
+    cfg = ScanConfig(
+        project_root=tmp_path,
+        output_path=tmp_path / "o",
+        business_rules=False,
+        business_rules_sql=True,
+        business_rules_combined=False,
+    )
+    raw = json.dumps(scan_config_dump(cfg))
+    cfg2 = scan_config_load(json.loads(raw))
+    assert cfg2.business_rules is False
+    assert cfg2.business_rules_sql is True
+    assert cfg2.business_rules_combined is False
+
+
+def test_cli_no_business_rules_combined(tmp_path: Path) -> None:
+    root = Path(__file__).resolve().parents[1] / "examples" / "mini_python"
+    out = tmp_path / "cli_out"
+    env = dict(**__import__("os").environ)
+    env["PYTHONPATH"] = str(Path(__file__).resolve().parents[2] / "src")
+    r = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "md_generator.codeflow.cli.main",
+            "scan",
+            str(root),
+            "--output",
+            str(out),
+            "--depth",
+            "3",
+            "--formats",
+            "md",
+            "--no-business-rules-combined",
+        ],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    assert r.returncode == 0, r.stderr + r.stdout
+    found = False
+    for sub in out.iterdir():
+        if sub.is_dir() and (sub / "entry.md").is_file():
+            found = True
+            assert (sub / "business_rules.md").is_file()
+            assert not (sub / "entry.combined.md").exists()
+    assert found
+
+
+def test_cli_no_business_rules(tmp_path: Path) -> None:
+    root = Path(__file__).resolve().parents[1] / "examples" / "mini_python"
+    out = tmp_path / "cli_out2"
+    env = dict(**__import__("os").environ)
+    env["PYTHONPATH"] = str(Path(__file__).resolve().parents[2] / "src")
+    r = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "md_generator.codeflow.cli.main",
+            "scan",
+            str(root),
+            "--output",
+            str(out),
+            "--depth",
+            "3",
+            "--formats",
+            "md",
+            "--no-business-rules",
+        ],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    assert r.returncode == 0, r.stderr + r.stdout
+    for sub in out.iterdir():
+        if sub.is_dir() and (sub / "entry.md").is_file():
+            assert not (sub / "business_rules.md").exists()
+            assert not (sub / "entry.combined.md").exists()

--- a/codeflow-to-md/tests/test_cli_scan.py
+++ b/codeflow-to-md/tests/test_cli_scan.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_cli_scan_mini_python(tmp_path: Path) -> None:
+    root = Path(__file__).resolve().parents[1] / "examples" / "mini_python"
+    out = tmp_path / "out"
+    env = dict(**__import__("os").environ)
+    env["PYTHONPATH"] = str(Path(__file__).resolve().parents[2] / "src")
+    r = subprocess.run(
+        [sys.executable, "-m", "md_generator.codeflow.cli.main", "scan", str(root), "--output", str(out), "--depth", "3"],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    assert r.returncode == 0, r.stderr + r.stdout
+    graph = out / "graph-full.json"
+    assert graph.is_file()
+    assert graph.read_text(encoding="utf-8").strip().startswith("{")

--- a/codeflow-to-md/tests/test_cytoscape_enrich.py
+++ b/codeflow-to-md/tests/test_cytoscape_enrich.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from md_generator.codeflow.analyzers.flow_analyzer import FlowSlice
+from md_generator.codeflow.generators.cytoscape_enrich import enrich_graph_for_views
+from md_generator.codeflow.generators.html import write_html_bundle
+
+
+def test_enrich_adds_depth_preset_cluster(tmp_path: Path) -> None:
+    graph = {
+        "nodes": [
+            {"id": "a", "file_path": "pkg/x.py", "class_name": "X", "method_name": "a"},
+            {"id": "b", "file_path": "pkg/y.py", "class_name": "Y", "method_name": "b"},
+        ],
+        "edges": [{"source": "a", "target": "b", "type": "sync"}],
+    }
+    out = enrich_graph_for_views(graph, "a")
+    assert out["entry_id"] == "a"
+    assert len(out["compound_parents"]) == 1
+    na = next(n for n in out["nodes"] if n["id"] == "a")
+    nb = next(n for n in out["nodes"] if n["id"] == "b")
+    assert na["cy_depth"] == 0
+    assert nb["cy_depth"] == 1
+    assert "cy_preset_x" in na and "cy_cluster_id" in na
+
+
+def test_write_html_bundle_writes_tabbed_and_standalone(tmp_path: Path) -> None:
+    graph = {
+        "nodes": [{"id": "e", "type": "entry"}, {"id": "m", "type": "method"}],
+        "edges": [{"source": "e", "target": "m", "type": "sync"}],
+    }
+    sl = FlowSlice(entry_id="e", nodes={"e", "m"}, edges=[], depth=2)
+    out = tmp_path / "index.html"
+    write_html_bundle(out, "e", sl, graph)
+    assert out.is_file()
+    d = tmp_path
+    assert (d / "graph-view-flow.html").is_file()
+    assert (d / "graph-view-layered.html").is_file()
+    assert (d / "graph-view-clustered.html").is_file()
+    text = out.read_text(encoding="utf-8")
+    assert 'data-tab="flow"' in text
+    assert "cy-flow" in text and "wireFilterAll" in text
+    assert "index.html" in (d / "graph-view-layered.html").read_text(encoding="utf-8")

--- a/codeflow-to-md/tests/test_entry_rank_and_docs.py
+++ b/codeflow-to-md/tests/test_entry_rank_and_docs.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import networkx as nx
+
+from md_generator.codeflow.analyzers.flow_analyzer import FlowSlice
+from md_generator.codeflow.core.extractor import run_scan
+from md_generator.codeflow.core.run_config import ScanConfig
+from md_generator.codeflow.detectors.entry_rank import entry_kind_rank, sort_entry_ids
+from md_generator.codeflow.generators.entry_markdown import (
+    pretty_start_method,
+    type_label_for_kind,
+    write_system_overview,
+)
+from md_generator.codeflow.generators.flow_summary import format_flow_description, format_method_summary_lines
+from md_generator.codeflow.graph.builder import build_graph
+from md_generator.codeflow.models.ir import EntryKind, EntryRecord, FileParseResult
+
+
+def test_entry_kind_rank_order() -> None:
+    assert entry_kind_rank(EntryKind.API_REST.value) < entry_kind_rank(EntryKind.KAFKA.value)
+    assert entry_kind_rank(EntryKind.KAFKA.value) == entry_kind_rank(EntryKind.QUEUE.value)
+    assert entry_kind_rank(EntryKind.SCHEDULER.value) < entry_kind_rank(EntryKind.MAIN.value)
+    assert entry_kind_rank(EntryKind.MAIN.value) < entry_kind_rank(EntryKind.UNKNOWN.value)
+
+
+def test_sort_entry_ids_stable_by_kind() -> None:
+    g = nx.DiGraph()
+    entries = [
+        EntryRecord("b.py::Main.main", EntryKind.MAIN, "m", "b.py", 1),
+        EntryRecord("a.py::Api.handler", EntryKind.API_REST, "GET /x", "a.py", 1),
+        EntryRecord("c.py::Cons.run", EntryKind.KAFKA, "t", "c.py", 1),
+    ]
+    for e in entries:
+        g.add_node(e.symbol_id, entry_kind=e.kind.value)
+    ids = ["b.py::Main.main", "c.py::Cons.run", "a.py::Api.handler"]
+    ranked = sort_entry_ids(ids, g, entries)
+    assert ranked[0] == "a.py::Api.handler"
+    assert ranked[1] == "c.py::Cons.run"
+    assert ranked[2] == "b.py::Main.main"
+
+
+def test_format_flow_description_branching() -> None:
+    g = nx.DiGraph()
+    for sid, cls, meth in (
+        ("t.py::ClassA.a", "ClassA", "a"),
+        ("t.py::ClassA.b", "ClassA", "b"),
+        ("t.py::ClassA.c", "ClassA", "c"),
+        ("t.py::ClassB.method1", "ClassB", "method1"),
+        ("t.py::ClassB.method2", "ClassB", "method2"),
+    ):
+        g.add_node(sid, class_name=cls, method_name=meth, type="method")
+    g.add_edge("t.py::ClassA.a", "t.py::ClassA.b", type="sync")
+    g.add_edge(
+        "t.py::ClassA.b",
+        "t.py::ClassA.c",
+        type="sync",
+        condition="condition1 == true",
+        labels=["condition1 == true"],
+    )
+    g.add_edge(
+        "t.py::ClassA.b",
+        "t.py::ClassB.method1",
+        type="sync",
+        condition="condition2 == true",
+        labels=["condition2 == true"],
+    )
+    g.add_edge("t.py::ClassA.b", "t.py::ClassB.method2", type="sync")
+    edge_rows = []
+    for u, v in (
+        ("t.py::ClassA.a", "t.py::ClassA.b"),
+        ("t.py::ClassA.b", "t.py::ClassA.c"),
+        ("t.py::ClassA.b", "t.py::ClassB.method1"),
+        ("t.py::ClassA.b", "t.py::ClassB.method2"),
+    ):
+        edge_rows.append((u, v, dict(g.edges[u, v])))
+    sl = FlowSlice(
+        entry_id="t.py::ClassA.a",
+        nodes=set(g.nodes),
+        edges=edge_rows,
+        depth=5,
+    )
+    text = "\n".join(format_flow_description(sl, g))
+    assert "1. ClassA.a()" in text
+    assert "→ calls ClassA.b()" in text
+    assert "→ if (condition1 == true)" in text
+    assert "ClassA.c()" in text
+    assert "→ else" in text
+    assert "method1()" in text or "ClassB.method1()" in text
+    assert "method2()" in text or "ClassB.method2()" in text
+
+
+def test_method_summary_headings() -> None:
+    g = nx.DiGraph()
+    g.add_node("t.py::ClassA.a", class_name="ClassA", method_name="a", type="entry")
+    g.add_node("t.py::ClassA.b", class_name="ClassA", method_name="b", type="method")
+    g.add_edge("t.py::ClassA.a", "t.py::ClassA.b", type="sync")
+    sl = FlowSlice(
+        entry_id="t.py::ClassA.a",
+        nodes=set(g.nodes),
+        edges=[(u, v, dict(g.edges[u, v])) for u, v in g.edges()],
+        depth=5,
+    )
+    lines = format_method_summary_lines(sl, g, "t.py::ClassA.a")
+    body = "\n".join(lines)
+    assert "### ClassA" in body
+    assert "- a() → start method" in body
+    assert "- b() →" in body
+
+
+def test_system_overview_contains_entry_links(tmp_path: Path) -> None:
+    rows = [
+        (
+            "slug_a",
+            "API",
+            "Api.handler()",
+            "[entry](./slug_a/entry.md)",
+            "Api.handler() → …",
+        ),
+    ]
+    p = tmp_path / "system_overview.md"
+    write_system_overview(p, rows)
+    content = p.read_text(encoding="utf-8")
+    assert "system_overview" in content.lower() or "# System overview" in content
+    assert "./slug_a/entry.md" in content
+
+
+def test_run_scan_writes_entry_md_and_overview(tmp_path: Path) -> None:
+    root = Path(__file__).resolve().parents[1] / "examples" / "mini_python"
+    out = tmp_path / "scan_out"
+    cfg = ScanConfig(
+        project_root=root,
+        output_path=out,
+        formats=("md",),
+        depth=4,
+        languages="python",
+    )
+    run_scan(cfg)
+    assert (out / "system_overview.md").is_file()
+    found_entry = False
+    for sub in out.iterdir():
+        if sub.is_dir() and (sub / "entry.md").is_file():
+            found_entry = True
+            em = (sub / "entry.md").read_text(encoding="utf-8")
+            assert "# Execution Flow Documentation" in em
+            assert "## Entry Point" in em
+            assert "## Flow Description" in em
+            assert "## Method Summary" in em
+    assert found_entry
+
+
+def test_type_label_for_kind() -> None:
+    assert type_label_for_kind(EntryKind.API_REST.value) == "API"
+    assert type_label_for_kind(EntryKind.KAFKA.value) == "Event"
+
+
+def test_pretty_start_method(tmp_path: Path) -> None:
+    fr = FileParseResult(path=tmp_path / "x.py", language="python")
+    fr.symbol_ids = ["x.py::Foo.bar"]
+    fr.calls = []
+    g = build_graph([fr], tmp_path).graph
+    assert pretty_start_method(g, "x.py::Foo.bar") == "Foo.bar()"

--- a/codeflow-to-md/tests/test_go_parser.py
+++ b/codeflow-to-md/tests/test_go_parser.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+import pytest
+
+from md_generator.codeflow.parsers.go_parser import GoParser
+
+
+@pytest.mark.skipif(shutil.which("go") is None, reason="go not on PATH")
+def test_go_parser_smoke(tmp_path: Path) -> None:
+    p = tmp_path / "x.go"
+    p.write_text(
+        """package x
+func A() { B() }
+func B() {}
+""",
+        encoding="utf-8",
+    )
+    fr = GoParser().parse_file(p, tmp_path)
+    assert any("B" in c.callee_hint for c in fr.calls)

--- a/codeflow-to-md/tests/test_graph_builder.py
+++ b/codeflow-to-md/tests/test_graph_builder.py
@@ -16,8 +16,31 @@ def test_build_graph_merge(tmp_path: Path) -> None:
             resolution="static",
             is_async=False,
             line=1,
-        )
+        ),
+        CallSite(
+            caller_id="a.py::f",
+            callee_hint="a.py::f",
+            resolution="static",
+            is_async=False,
+            line=2,
+        ),
+        CallSite(
+            caller_id="a.py::f",
+            callee_hint="unknown::dyn",
+            resolution="dynamic",
+            is_async=False,
+            line=3,
+        ),
     ]
     r = build_graph([fr], tmp_path)
     ser = graph_to_serializable(r.graph)
     assert any(n["id"] == "a.py::f" for n in ser["nodes"])
+    edges = ser["edges"]
+    e_fg = next(x for x in edges if x["source"] == "a.py::f" and x["target"] == "a.py::g")
+    assert e_fg.get("unknown_call") is False
+    assert e_fg.get("recursive") is False
+    e_ff = next(x for x in edges if x["source"] == "a.py::f" and x["target"] == "a.py::f")
+    assert e_ff.get("recursive") is True
+    assert e_ff.get("unknown_call") is False
+    e_fun = next(x for x in edges if x["target"] == "unknown::dyn")
+    assert e_fun.get("unknown_call") is True

--- a/codeflow-to-md/tests/test_graph_builder.py
+++ b/codeflow-to-md/tests/test_graph_builder.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from md_generator.codeflow.graph.builder import build_graph, graph_to_serializable
+from md_generator.codeflow.models.ir import CallSite, FileParseResult
+
+
+def test_build_graph_merge(tmp_path: Path) -> None:
+    fr = FileParseResult(path=tmp_path / "a.py", language="python")
+    fr.symbol_ids = ["a.py::f"]
+    fr.calls = [
+        CallSite(
+            caller_id="a.py::f",
+            callee_hint="a.py::g",
+            resolution="static",
+            is_async=False,
+            line=1,
+        )
+    ]
+    r = build_graph([fr], tmp_path)
+    ser = graph_to_serializable(r.graph)
+    assert any(n["id"] == "a.py::f" for n in ser["nodes"])

--- a/codeflow-to-md/tests/test_lang_dispatch.py
+++ b/codeflow-to-md/tests/test_lang_dispatch.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from md_generator.codeflow.lang_dispatch import (
+    extensions_for_languages,
+    lang_for_path,
+    normalize_language_filter,
+    should_parse_file_lang,
+)
+
+
+def test_normalize_mixed_includes_js() -> None:
+    exts = extensions_for_languages(normalize_language_filter("mixed"))
+    assert ".ts" in exts
+    assert ".go" in exts
+
+
+def test_lang_for_path() -> None:
+    assert lang_for_path(Path("a.tsx")) == "tsx"
+    assert lang_for_path(Path("b.go")) == "go"
+
+
+def test_should_parse_filter() -> None:
+    allowed = normalize_language_filter("python,javascript")
+    assert should_parse_file_lang("python", allowed)
+    assert should_parse_file_lang("javascript", allowed)
+    assert not should_parse_file_lang("go", allowed)

--- a/codeflow-to-md/tests/test_python_parser.py
+++ b/codeflow-to-md/tests/test_python_parser.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from md_generator.codeflow.parsers.python_parser import PythonParser
+
+
+def test_python_parser_resolves_self_calls(tmp_path: Path) -> None:
+    p = tmp_path / "m.py"
+    p.write_text(
+        """
+class A:
+    def a(self):
+        self.b()
+    def b(self):
+        pass
+""",
+        encoding="utf-8",
+    )
+    fr = PythonParser().parse_file(p, tmp_path)
+    ids = set(fr.symbol_ids)
+    assert any("A.a" in x for x in ids)
+    assert any("A.b" in x for x in ids)
+    assert any(c.caller_id.endswith("A.a") and "A.b" in c.callee_hint for c in fr.calls)

--- a/codeflow-to-md/tests/test_treesitter_js.py
+++ b/codeflow-to-md/tests/test_treesitter_js.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("tree_sitter_javascript")
+
+from pathlib import Path
+
+from tree_sitter import Language
+
+import tree_sitter_javascript as tsjs
+
+from md_generator.codeflow.parsers.treesitter_js_ts_parser import TreesitterJsTsParser
+
+
+def test_treesitter_finds_call(tmp_path: Path) -> None:
+    p = tmp_path / "a.js"
+    p.write_text(
+        """
+function outer() {
+  function inner() {
+    foo();
+  }
+  inner();
+}
+""",
+        encoding="utf-8",
+    )
+    lang = Language(tsjs.language())
+    fr = TreesitterJsTsParser("javascript", lang).parse_file(p, tmp_path)
+    assert any("foo" in c.callee_hint for c in fr.calls)
+    assert any("inner" in c.callee_hint for c in fr.calls)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,6 +115,15 @@ codeflow = [
   "networkx>=3.2.0",
   "javalang>=0.13.0",
 ]
+codeflow-treesitter = [
+  "tree-sitter>=0.21.0",
+  "tree-sitter-javascript>=0.21.0",
+  "tree-sitter-typescript>=0.23.0",
+  "tree-sitter-cpp>=0.23.0",
+]
+codeflow-clang = [
+  "clang>=16.0.0",
+]
 api = [
   "fastapi>=0.115.0",
   "uvicorn[standard]>=0.32.0",
@@ -137,6 +146,7 @@ dev = [
   "mdengine[graph]",
   "mdengine[openapi]",
   "mdengine[codeflow]",
+  "mdengine[codeflow-treesitter]",
 ]
 all = [
   "pymupdf>=1.24.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ requires-python = ">=3.10"
 license = "MIT"
 license-files = ["LICENSE"]
 authors = [{ name = "mdengine contributors" }]
-keywords = ["markdown", "pdf", "docx", "pptx", "xlsx", "ocr", "zip", "url", "html", "youtube", "playwright", "database", "openapi"]
+keywords = ["markdown", "pdf", "docx", "pptx", "xlsx", "ocr", "zip", "url", "html", "youtube", "playwright", "database", "openapi", "codeflow"]
 classifiers = [
   "Programming Language :: Python :: 3",
   "Programming Language :: Python :: 3 :: Only",
@@ -111,6 +111,10 @@ openapi = [
   "prance>=23.6.0",
   "openapi-spec-validator>=0.7.0",
 ]
+codeflow = [
+  "networkx>=3.2.0",
+  "javalang>=0.13.0",
+]
 api = [
   "fastapi>=0.115.0",
   "uvicorn[standard]>=0.32.0",
@@ -132,6 +136,7 @@ dev = [
   "mdengine[db]",
   "mdengine[graph]",
   "mdengine[openapi]",
+  "mdengine[codeflow]",
 ]
 all = [
   "pymupdf>=1.24.0",
@@ -196,6 +201,10 @@ md-graph-mcp = "md_generator.graph.api.mcp_server:main"
 md-openapi = "md_generator.openapi.cli.main:main"
 md-openapi-api = "md_generator.openapi.api.run:main"
 md-openapi-mcp = "md_generator.openapi.api.mcp_server:main"
+md-codeflow = "md_generator.codeflow.cli.main:main"
+codeflow = "md_generator.codeflow.cli.main:main"
+md-codeflow-api = "md_generator.codeflow.api.run:main"
+md-codeflow-mcp = "md_generator.codeflow.api.mcp_server:main"
 mdengine = "md_generator.engine_cli:main"
 
 [tool.setuptools.packages.find]
@@ -224,5 +233,6 @@ testpaths = [
   "db-to-md/tests",
   "graph-to-md/tests",
   "openapi-to-md/tests",
+  "codeflow-to-md/tests",
 ]
 markers = ["integration: optional dependency or slower checks"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mdengine"
-version = "0.6.0"
+version = "0.7.0"
 description = "Convert PDF, Office, images, audio, video, text/JSON/XML, ZIP archives, web URLs, databases, graphs, and OpenAPI specs to Markdown."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/scripts/run_codeflow_batch.ps1
+++ b/scripts/run_codeflow_batch.ps1
@@ -1,0 +1,37 @@
+$ErrorActionPreference = "Stop"
+$RepoRoot = "C:\Task\Project\md-generator"
+$BaseOut = Join-Path $RepoRoot "docs\codeflow"
+New-Item -ItemType Directory -Force -Path $BaseOut | Out-Null
+$env:PYTHONPATH = Join-Path $RepoRoot "src"
+Set-Location $RepoRoot
+
+$projects = @(
+    @{ Name = "document-qa"; Src = "C:\Task\Project\document-qa" },
+    @{ Name = "BowlingGame"; Src = "C:\MyWork\workspace\BowlingGame" },
+    @{ Name = "mtb"; Src = "C:\MyWork\workspace\mtb" },
+    @{ Name = "react-design-patterns-2895130"; Src = "C:\MyWork\react_workspace\react-design-patterns-2895130" },
+    @{ Name = "html-to-pdf-to-images"; Src = "C:\Task\Project\html-to-pdf-to-images" }
+)
+
+foreach ($p in $projects) {
+    if (-not (Test-Path -LiteralPath $p.Src)) {
+        Write-Host "SKIP (missing): $($p.Src)"
+        continue
+    }
+    $out = Join-Path $BaseOut $p.Name
+    Write-Host "=== SCAN $($p.Name) -> $out ==="
+    $args = @(
+        "-m", "md_generator.codeflow.cli.main", "scan",
+        $p.Src,
+        "--output", $out,
+        "--formats", "md,mermaid,json,html",
+        "--depth", "8",
+        "--lang", "mixed"
+    )
+    & python @args
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host "FAILED $($p.Name) exit $LASTEXITCODE"
+        exit $LASTEXITCODE
+    }
+}
+Write-Host "Done. Output under $BaseOut"

--- a/src/md_generator/__init__.py
+++ b/src/md_generator/__init__.py
@@ -1,5 +1,5 @@
 """md_generator: PDF, Office, image, text, and ZIP to Markdown conversion."""
 
-__version__ = "0.6.0"
+__version__ = "0.7.0"
 
 __all__ = ["__version__"]

--- a/src/md_generator/codeflow/__init__.py
+++ b/src/md_generator/codeflow/__init__.py
@@ -1,0 +1,7 @@
+"""Multi-language execution flow extraction → Markdown, Mermaid, graph JSON, HTML."""
+
+from __future__ import annotations
+
+__all__ = ["__version__"]
+
+__version__ = "0.1.0"

--- a/src/md_generator/codeflow/analyzers/__init__.py
+++ b/src/md_generator/codeflow/analyzers/__init__.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+
+from md_generator.codeflow.analyzers.flow_analyzer import (
+    FlowSlice,
+    slice_from_entry,
+    walk_with_depth,
+)
+
+__all__ = ["FlowSlice", "slice_from_entry", "walk_with_depth"]

--- a/src/md_generator/codeflow/analyzers/flow_analyzer.py
+++ b/src/md_generator/codeflow/analyzers/flow_analyzer.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+import networkx as nx
+
+
+@dataclass(slots=True)
+class FlowSlice:
+    entry_id: str
+    nodes: set[str]
+    edges: list[tuple[str, str, dict]]
+    depth: int
+    cycle_nodes: set[str] = field(default_factory=set)
+    truncated: bool = False
+
+
+def walk_with_depth(
+    g: nx.DiGraph,
+    start: str,
+    max_depth: int,
+) -> tuple[set[str], list[tuple[str, str, dict]], set[str], bool]:
+    """Reachability from start within ``max_depth`` hops (shortest-path layering)."""
+    if start not in g:
+        return {start}, [], set(), False
+    try:
+        plen = nx.single_source_shortest_path_length(g, start, cutoff=max_depth)
+    except nx.NetworkXError:
+        plen = {start: 0}
+
+    nodes = set(plen.keys())
+    edges_out: list[tuple[str, str, dict]] = []
+    cycle_guess: set[str] = set()
+    truncated = False
+
+    for u in nodes:
+        du = plen[u]
+        if du >= max_depth:
+            succ = list(g.successors(u))
+            if succ:
+                truncated = True
+            continue
+        for v in g.successors(u):
+            ed = dict(g.edges[u, v])
+            edges_out.append((u, v, ed))
+            dv = plen.get(v)
+            if dv is not None and dv <= du:
+                cycle_guess.add(v)
+            if v not in plen and du + 1 > max_depth:
+                truncated = True
+
+    return nodes, edges_out, cycle_guess, truncated
+
+
+def slice_from_entry(
+    g: nx.DiGraph,
+    entry_id: str,
+    max_depth: int,
+) -> FlowSlice:
+    nodes, edges, cycles, truncated = walk_with_depth(g, entry_id, max_depth)
+    return FlowSlice(
+        entry_id=entry_id,
+        nodes=nodes,
+        edges=edges,
+        depth=max_depth,
+        cycle_nodes=cycles,
+        truncated=truncated,
+    )

--- a/src/md_generator/codeflow/api/__init__.py
+++ b/src/md_generator/codeflow/api/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import annotations

--- a/src/md_generator/codeflow/api/job_manager.py
+++ b/src/md_generator/codeflow/api/job_manager.py
@@ -115,6 +115,9 @@ class CodeflowJobManager:
             jobs=True,
             runtime=cfg_template.runtime,
             paths_override=cfg_template.paths_override,
+            business_rules=cfg_template.business_rules,
+            business_rules_sql=cfg_template.business_rules_sql,
+            business_rules_combined=cfg_template.business_rules_combined,
         )
         now = time.time()
         cfg_dump = json.dumps(scan_config_dump(cfg), sort_keys=True)

--- a/src/md_generator/codeflow/api/job_manager.py
+++ b/src/md_generator/codeflow/api/job_manager.py
@@ -1,0 +1,246 @@
+from __future__ import annotations
+
+import json
+import shutil
+import sqlite3
+import threading
+import time
+import uuid
+import zipfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from md_generator.codeflow.api.schemas import scan_config_dump, scan_config_load
+from md_generator.codeflow.core.extractor import run_scan
+from md_generator.codeflow.core.run_config import ScanConfig
+from md_generator.codeflow.ingestion.loader import LoadedWorkspace
+
+
+@dataclass
+class CodeflowJobRecord:
+    job_id: str
+    status: str
+    progress: int
+    current: str
+    workspace: str
+    zip_path: str | None
+    error: str | None
+    created_at: float
+    updated_at: float
+
+    def to_api_dict(self) -> dict[str, Any]:
+        return {
+            "job_id": self.job_id,
+            "status": self.status,
+            "progress": self.progress,
+            "current": self.current,
+            "workspace": self.workspace,
+            "zip_path": self.zip_path,
+            "error": self.error,
+            "created_at": self.created_at,
+            "updated_at": self.updated_at,
+        }
+
+
+class CodeflowJobManager:
+    """SQLite-backed job store (same pattern as db-to-md ``JobManager``)."""
+
+    def __init__(
+        self,
+        *,
+        sqlite_path: str | Path | None = None,
+        workspace_root: Path | None = None,
+        in_memory: bool = False,
+    ) -> None:
+        self._lock = threading.Lock()
+        self._root = Path(workspace_root) if workspace_root else None
+        if in_memory:
+            self._conn = sqlite3.connect(":memory:", check_same_thread=False)
+        else:
+            path = Path(sqlite_path or _default_sqlite_path())
+            path.parent.mkdir(parents=True, exist_ok=True)
+            self._conn = sqlite3.connect(str(path), check_same_thread=False)
+        self._conn.row_factory = sqlite3.Row
+        self._init_db()
+
+    def _init_db(self) -> None:
+        assert self._conn is not None
+        self._conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS jobs (
+                job_id TEXT PRIMARY KEY,
+                status TEXT NOT NULL,
+                progress INTEGER NOT NULL DEFAULT 0,
+                current TEXT NOT NULL DEFAULT '',
+                workspace TEXT NOT NULL,
+                zip_path TEXT,
+                error TEXT,
+                created_at REAL NOT NULL,
+                updated_at REAL NOT NULL,
+                config_json TEXT NOT NULL
+            )
+            """
+        )
+        self._conn.commit()
+
+    def close(self) -> None:
+        if self._conn:
+            self._conn.close()
+
+    def create_zip_job(self, zip_bytes: bytes, cfg_template: ScanConfig) -> CodeflowJobRecord:
+        jid = str(uuid.uuid4())
+        base = self._root or Path.cwd() / "codeflow-jobs"
+        ws = (base / jid).resolve()
+        ws.mkdir(parents=True, exist_ok=True)
+        src = ws / "src"
+        src.mkdir(parents=True, exist_ok=True)
+        raw_zip = ws / "upload.zip"
+        raw_zip.write_bytes(zip_bytes)
+        with zipfile.ZipFile(raw_zip, "r") as zf:
+            zf.extractall(src)
+
+        out = ws / "out"
+        cfg = ScanConfig(
+            project_root=src,
+            output_path=out,
+            formats=cfg_template.formats,
+            depth=cfg_template.depth,
+            languages=cfg_template.languages,
+            entry=cfg_template.entry,
+            include=cfg_template.include,
+            exclude=cfg_template.exclude,
+            include_internal=cfg_template.include_internal,
+            async_mode=cfg_template.async_mode,
+            jobs=True,
+            runtime=cfg_template.runtime,
+            paths_override=cfg_template.paths_override,
+        )
+        now = time.time()
+        cfg_dump = json.dumps(scan_config_dump(cfg), sort_keys=True)
+        assert self._conn is not None
+        with self._lock:
+            self._conn.execute(
+                """
+                INSERT INTO jobs (job_id, status, progress, current, workspace, zip_path, error, created_at, updated_at, config_json)
+                VALUES (?, ?, 0, '', ?, NULL, NULL, ?, ?, ?)
+                """,
+                (jid, "PENDING", str(ws), now, now, cfg_dump),
+            )
+            self._conn.commit()
+        return self.get(jid)  # type: ignore[return-value]
+
+    def get(self, job_id: str) -> CodeflowJobRecord | None:
+        assert self._conn is not None
+        with self._lock:
+            row = self._conn.execute("SELECT * FROM jobs WHERE job_id = ?", (job_id,)).fetchone()
+        if not row:
+            return None
+        return CodeflowJobRecord(
+            job_id=row["job_id"],
+            status=row["status"],
+            progress=row["progress"],
+            current=row["current"],
+            workspace=row["workspace"],
+            zip_path=row["zip_path"],
+            error=row["error"],
+            created_at=row["created_at"],
+            updated_at=row["updated_at"],
+        )
+
+    def update_progress(self, job_id: str, progress: int, current: str) -> None:
+        assert self._conn is not None
+        now = time.time()
+        with self._lock:
+            self._conn.execute(
+                "UPDATE jobs SET progress = ?, current = ?, updated_at = ? WHERE job_id = ?",
+                (progress, current, now, job_id),
+            )
+            self._conn.commit()
+
+    def mark_running(self, job_id: str) -> None:
+        self._set_status(job_id, "RUNNING")
+
+    def mark_completed(self, job_id: str, zip_path: Path | None) -> None:
+        assert self._conn is not None
+        now = time.time()
+        with self._lock:
+            self._conn.execute(
+                "UPDATE jobs SET status = ?, progress = 100, zip_path = ?, updated_at = ?, current = ? WHERE job_id = ?",
+                ("COMPLETED", str(zip_path) if zip_path else None, now, "completed", job_id),
+            )
+            self._conn.commit()
+
+    def mark_failed(self, job_id: str, err: str) -> None:
+        assert self._conn is not None
+        now = time.time()
+        with self._lock:
+            self._conn.execute(
+                "UPDATE jobs SET status = ?, error = ?, updated_at = ?, current = ? WHERE job_id = ?",
+                ("FAILED", err[:8000], now, "failed", job_id),
+            )
+            self._conn.commit()
+
+    def _set_status(self, job_id: str, status: str) -> None:
+        assert self._conn is not None
+        now = time.time()
+        with self._lock:
+            self._conn.execute(
+                "UPDATE jobs SET status = ?, updated_at = ? WHERE job_id = ?",
+                (status, now, job_id),
+            )
+            self._conn.commit()
+
+    def load_config(self, job_id: str) -> ScanConfig | None:
+        assert self._conn is not None
+        with self._lock:
+            row = self._conn.execute(
+                "SELECT config_json FROM jobs WHERE job_id = ?", (job_id,)
+            ).fetchone()
+        if not row:
+            return None
+        return scan_config_load(json.loads(row["config_json"]))
+
+    def run_job_thread(self, job_id: str) -> None:
+        def target() -> None:
+            try:
+                self.mark_running(job_id)
+                cfg = self.load_config(job_id)
+                if not cfg:
+                    self.mark_failed(job_id, "missing config")
+                    return
+                rec = self.get(job_id)
+                if not rec:
+                    return
+                ws_path = Path(rec.workspace)
+
+                def on_prog(p: int, cur: str) -> None:
+                    self.update_progress(job_id, p, cur)
+
+                lw = LoadedWorkspace(root=cfg.project_root, cleanup_dir=None)
+
+                self.update_progress(job_id, 10, "scan")
+                run_scan(cfg, workspace=lw)
+                on_prog(90, "zip")
+
+                zpath = ws_path / "output.zip"
+                self._zip_output(ws_path, cfg.output_path, zpath)
+                self.mark_completed(job_id, zpath)
+            except Exception as e:
+                self.mark_failed(job_id, str(e))
+
+        threading.Thread(target=target, daemon=True).start()
+
+    def _zip_output(self, workspace: Path, out_dir: Path, dest_zip: Path) -> None:
+        dest_zip.parent.mkdir(parents=True, exist_ok=True)
+        with zipfile.ZipFile(dest_zip, "w", zipfile.ZIP_DEFLATED) as zf:
+            if out_dir.exists():
+                for p in sorted(out_dir.rglob("*")):
+                    if p.is_file():
+                        zf.write(p, p.relative_to(workspace).as_posix())
+
+
+def _default_sqlite_path() -> Path:
+    import tempfile
+
+    return Path(tempfile.gettempdir()) / "mdengine-codeflow-jobs" / "jobs.sqlite"

--- a/src/md_generator/codeflow/api/main.py
+++ b/src/md_generator/codeflow/api/main.py
@@ -1,0 +1,185 @@
+from __future__ import annotations
+
+import asyncio
+from contextlib import asynccontextmanager
+from pathlib import Path
+
+from fastapi import FastAPI, File, Form, HTTPException, Request, UploadFile
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import FileResponse, Response, StreamingResponse
+
+from md_generator.codeflow.api.job_manager import CodeflowJobManager
+from md_generator.codeflow.api.schemas import merge_upload_options_json, options_to_scan_config
+from md_generator.codeflow.api.settings import CodeflowApiSettings, cors_list, sqlite_path_resolved
+from md_generator.codeflow.core.extractor import build_output_zip
+from md_generator.codeflow.core.run_config import ScanConfig
+
+try:
+    from md_generator.codeflow.mcp.server import build_mcp_stack
+
+    _mcp, _mcp_http = build_mcp_stack(mount_under_fastapi=True)
+except Exception:
+    _mcp = None  # type: ignore[misc]
+    _mcp_http = None
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    settings = CodeflowApiSettings()
+    ws = Path(settings.job_workspace_root) if settings.job_workspace_root else None
+    jobs = CodeflowJobManager(sqlite_path=sqlite_path_resolved(settings), workspace_root=ws)
+    app.state.settings = settings
+    app.state.jobs = jobs
+    if _mcp is not None:
+        async with _mcp.session_manager.run():
+            yield
+    else:
+        yield
+    jobs.close()
+
+
+app = FastAPI(title="codeflow-to-md", lifespan=lifespan)
+if _mcp_http is not None:
+    app.mount("/mcp", _mcp_http)
+
+_bootstrap = CodeflowApiSettings()
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=cors_list(_bootstrap),
+    allow_credentials="*" not in cors_list(_bootstrap),
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+
+@app.get("/health")
+async def health() -> dict[str, str]:
+    return {"status": "ok"}
+
+
+@app.post("/analyze")
+async def analyze_upload(
+    request: Request,
+    file: UploadFile = File(...),
+    options_json: str | None = Form(default=None),
+) -> dict[str, str]:
+    """Upload a ZIP of source code; returns ``job_id`` for async processing."""
+    settings: CodeflowApiSettings = request.app.state.settings
+    jobs: CodeflowJobManager = request.app.state.jobs
+    raw = await file.read()
+    max_b = max(1, settings.max_upload_zip_mb) * 1024 * 1024
+    if len(raw) > max_b:
+        raise HTTPException(status_code=413, detail=f"ZIP exceeds CODEFLOW_MAX_UPLOAD_ZIP_MB ({settings.max_upload_zip_mb})")
+    try:
+        opts = merge_upload_options_json(options_json)
+    except Exception as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+    # template: output path overwritten in job manager
+    tmp_src = Path(".")
+    cfg_tpl = options_to_scan_config(tmp_src, "out", opts)
+    try:
+        rec = jobs.create_zip_job(raw, cfg_tpl)
+        jobs.run_job_thread(rec.job_id)
+    except Exception as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+    return {"job_id": rec.job_id}
+
+
+@app.get("/status/{job_id}")
+async def job_status(request: Request, job_id: str) -> dict:
+    jobs: CodeflowJobManager = request.app.state.jobs
+    rec = jobs.get(job_id)
+    if not rec:
+        raise HTTPException(404, detail="Unknown job_id")
+    return rec.to_api_dict()
+
+
+@app.get("/result/{job_id}")
+async def job_result(request: Request, job_id: str) -> FileResponse:
+    jobs: CodeflowJobManager = request.app.state.jobs
+    rec = jobs.get(job_id)
+    if not rec:
+        raise HTTPException(404, detail="Unknown job_id")
+    if rec.status != "COMPLETED" or not rec.zip_path:
+        raise HTTPException(400, detail="Job is not ready")
+    path = Path(rec.zip_path)
+    if not path.is_file():
+        raise HTTPException(400, detail="ZIP missing on disk")
+    return FileResponse(path, media_type="application/zip", filename="codeflow-output.zip")
+
+
+@app.post("/analyze/sync")
+async def analyze_sync(
+    request: Request,
+    file: UploadFile = File(...),
+    options_json: str | None = Form(default=None),
+) -> Response:
+    """Small ZIP → immediate ZIP response (bounded by ``CODEFLOW_MAX_SYNC_ZIP_MB``)."""
+    settings: CodeflowApiSettings = request.app.state.settings
+    raw = await file.read()
+    max_up = max(1, settings.max_upload_zip_mb) * 1024 * 1024
+    if len(raw) > max_up:
+        raise HTTPException(status_code=413, detail="ZIP too large")
+    try:
+        opts = merge_upload_options_json(options_json)
+    except Exception as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+    import tempfile
+
+    td = Path(tempfile.mkdtemp(prefix="codeflow-sync-"))
+    src = td / "src"
+    src.mkdir(parents=True, exist_ok=True)
+    zin = td / "in.zip"
+    zin.write_bytes(raw)
+    import zipfile
+
+    with zipfile.ZipFile(zin, "r") as zf:
+        zf.extractall(src)
+    cfg = options_to_scan_config(src, "out", opts)
+    try:
+        data = build_output_zip(cfg, workspace_root=src)
+    except Exception as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+    max_b = settings.max_sync_zip_mb * 1024 * 1024
+    if len(data) > max_b:
+        raise HTTPException(status_code=413, detail=f"Output exceeds CODEFLOW_MAX_SYNC_ZIP_MB ({settings.max_sync_zip_mb}); use POST /analyze")
+    return Response(
+        content=data,
+        media_type="application/zip",
+        headers={"Content-Disposition": 'attachment; filename="codeflow-output.zip"'},
+    )
+
+
+@app.get("/analyze/job/{job_id}/events")
+async def job_events(request: Request, job_id: str) -> StreamingResponse:
+    from md_generator.codeflow.api.sse import format_sse
+
+    jobs: CodeflowJobManager = request.app.state.jobs
+
+    async def gen():
+        rec = jobs.get(job_id)
+        if not rec:
+            yield format_sse("job_failed", {"job_id": job_id, "error": "unknown job_id"}).encode("utf-8")
+            return
+        yield format_sse("job_started", {"job_id": job_id}).encode("utf-8")
+        last_progress = -1
+        while True:
+            rec = jobs.get(job_id)
+            if not rec:
+                yield format_sse("job_failed", {"job_id": job_id, "error": "job disappeared"}).encode("utf-8")
+                return
+            if rec.progress != last_progress or rec.current:
+                last_progress = rec.progress
+                yield format_sse(
+                    "progress_update",
+                    {"progress": rec.progress, "current": rec.current},
+                ).encode("utf-8")
+            if rec.status == "COMPLETED":
+                yield format_sse("job_completed", {"job_id": job_id, "zip_path": rec.zip_path}).encode("utf-8")
+                return
+            if rec.status == "FAILED":
+                yield format_sse("job_failed", {"job_id": job_id, "error": rec.error or "unknown"}).encode("utf-8")
+                return
+            await asyncio.sleep(0.4)
+
+    return StreamingResponse(gen(), media_type="text/event-stream")

--- a/src/md_generator/codeflow/api/mcp_server.py
+++ b/src/md_generator/codeflow/api/mcp_server.py
@@ -1,0 +1,16 @@
+"""Standalone MCP server for codeflow (stdio)."""
+
+from __future__ import annotations
+
+import asyncio
+
+
+def main() -> None:
+    from md_generator.codeflow.mcp.server import build_mcp_stack
+
+    mcp, _ = build_mcp_stack(mount_under_fastapi=False)
+    asyncio.run(mcp.run_stdio_async())
+
+
+if __name__ == "__main__":
+    main()

--- a/src/md_generator/codeflow/api/run.py
+++ b/src/md_generator/codeflow/api/run.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+import os
+
+
+def main() -> None:
+    import uvicorn
+
+    host = os.environ.get("CODEFLOW_TO_MD_HOST", "127.0.0.1")
+    port = int(os.environ.get("CODEFLOW_TO_MD_PORT", "8016"))
+    uvicorn.run("md_generator.codeflow.api.main:app", host=host, port=port, reload=False)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/md_generator/codeflow/api/schemas.py
+++ b/src/md_generator/codeflow/api/schemas.py
@@ -16,6 +16,9 @@ class AnalyzeOptions(BaseModel):
     entry: str | None = None
     include: str | None = None
     exclude: str | None = None
+    business_rules: bool | None = Field(default=None, description="If set, enable/disable business rule MD")
+    business_rules_sql: bool | None = Field(default=None, description="If true, scan *.sql for triggers")
+    business_rules_combined: bool | None = Field(default=None, description="If set, control entry.combined.md")
 
 
 def options_to_scan_config(workspace_src: Path, output_subdir: str, raw: AnalyzeOptions | None) -> ScanConfig:
@@ -25,6 +28,9 @@ def options_to_scan_config(workspace_src: Path, output_subdir: str, raw: Analyze
     entry_list = None
     if raw and raw.entry:
         entry_list = [x.strip() for x in raw.entry.split(",") if x.strip()]
+    br = True if not raw or raw.business_rules is None else raw.business_rules
+    br_sql = False if not raw or raw.business_rules_sql is None else raw.business_rules_sql
+    br_comb = True if not raw or raw.business_rules_combined is None else raw.business_rules_combined
     return ScanConfig(
         project_root=workspace_src,
         output_path=workspace_src.parent / output_subdir,
@@ -34,6 +40,9 @@ def options_to_scan_config(workspace_src: Path, output_subdir: str, raw: Analyze
         entry=entry_list,
         include=raw.include if raw else None,
         exclude=raw.exclude if raw else None,
+        business_rules=br,
+        business_rules_sql=br_sql,
+        business_rules_combined=br_comb,
     )
 
 
@@ -59,6 +68,9 @@ def scan_config_dump(cfg: ScanConfig) -> dict[str, Any]:
         "async_mode": cfg.async_mode,
         "jobs": cfg.jobs,
         "runtime": cfg.runtime,
+        "business_rules": cfg.business_rules,
+        "business_rules_sql": cfg.business_rules_sql,
+        "business_rules_combined": cfg.business_rules_combined,
     }
 
 
@@ -78,4 +90,7 @@ def scan_config_load(data: dict[str, Any]) -> ScanConfig:
         async_mode=bool(data.get("async_mode", True)),
         jobs=bool(data.get("jobs", False)),
         runtime=bool(data.get("runtime", False)),
+        business_rules=bool(data.get("business_rules", True)),
+        business_rules_sql=bool(data.get("business_rules_sql", False)),
+        business_rules_combined=bool(data.get("business_rules_combined", True)),
     )

--- a/src/md_generator/codeflow/api/schemas.py
+++ b/src/md_generator/codeflow/api/schemas.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+from md_generator.codeflow.core.run_config import ScanConfig
+
+
+class AnalyzeOptions(BaseModel):
+    formats: str | None = Field(default=None, description="Comma-separated: md,html,mermaid,json")
+    depth: int = 5
+    languages: str = "mixed"
+    entry: str | None = None
+    include: str | None = None
+    exclude: str | None = None
+
+
+def options_to_scan_config(workspace_src: Path, output_subdir: str, raw: AnalyzeOptions | None) -> ScanConfig:
+    fmts = ("md", "mermaid", "json")
+    if raw and raw.formats:
+        fmts = tuple(x.strip().lower() for x in raw.formats.split(",") if x.strip())
+    entry_list = None
+    if raw and raw.entry:
+        entry_list = [x.strip() for x in raw.entry.split(",") if x.strip()]
+    return ScanConfig(
+        project_root=workspace_src,
+        output_path=workspace_src.parent / output_subdir,
+        formats=fmts,
+        depth=(raw.depth if raw else 5),
+        languages=(raw.languages if raw else "mixed"),
+        entry=entry_list,
+        include=raw.include if raw else None,
+        exclude=raw.exclude if raw else None,
+    )
+
+
+def merge_upload_options_json(options_json: str | None) -> AnalyzeOptions | None:
+    if not options_json:
+        return None
+    data = json.loads(options_json)
+    return AnalyzeOptions.model_validate(data)
+
+
+def scan_config_dump(cfg: ScanConfig) -> dict[str, Any]:
+    return {
+        "project_root": str(cfg.project_root),
+        "output_path": str(cfg.output_path),
+        "paths_override": [str(p) for p in cfg.paths_override] if cfg.paths_override else None,
+        "formats": list(cfg.formats),
+        "depth": cfg.depth,
+        "languages": cfg.languages,
+        "entry": cfg.entry,
+        "include": cfg.include,
+        "exclude": cfg.exclude,
+        "include_internal": cfg.include_internal,
+        "async_mode": cfg.async_mode,
+        "jobs": cfg.jobs,
+        "runtime": cfg.runtime,
+    }
+
+
+def scan_config_load(data: dict[str, Any]) -> ScanConfig:
+    po = data.get("paths_override")
+    return ScanConfig(
+        project_root=Path(data["project_root"]),
+        output_path=Path(data["output_path"]),
+        paths_override=[Path(p) for p in po] if po else None,
+        formats=tuple(data.get("formats") or ("md", "mermaid", "json")),
+        depth=int(data.get("depth", 5)),
+        languages=str(data.get("languages", "mixed")),
+        entry=list(data["entry"]) if data.get("entry") else None,
+        include=data.get("include"),
+        exclude=data.get("exclude"),
+        include_internal=bool(data.get("include_internal", True)),
+        async_mode=bool(data.get("async_mode", True)),
+        jobs=bool(data.get("jobs", False)),
+        runtime=bool(data.get("runtime", False)),
+    )

--- a/src/md_generator/codeflow/api/settings.py
+++ b/src/md_generator/codeflow/api/settings.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class CodeflowApiSettings(BaseSettings):
+    model_config = SettingsConfigDict(env_prefix="CODEFLOW_", extra="ignore")
+
+    host: str = "127.0.0.1"
+    port: int = 8016
+    max_upload_zip_mb: int = 64
+    max_sync_zip_mb: int = 8
+    job_workspace_root: str | None = None
+    sqlite_path: str | None = None
+
+
+def cors_list(settings: CodeflowApiSettings) -> list[str]:
+    raw = os.environ.get("CODEFLOW_CORS", "http://localhost:3000")
+    return [x.strip() for x in raw.split(",") if x.strip()]
+
+
+def sqlite_path_resolved(settings: CodeflowApiSettings) -> Path | None:
+    if settings.sqlite_path:
+        return Path(settings.sqlite_path)
+    return None

--- a/src/md_generator/codeflow/api/sse.py
+++ b/src/md_generator/codeflow/api/sse.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+import json
+from typing import Any
+
+
+def format_sse(event: str, payload: dict[str, Any]) -> str:
+    return f"event: {event}\ndata: {json.dumps(payload, sort_keys=True)}\n\n"

--- a/src/md_generator/codeflow/cli/__init__.py
+++ b/src/md_generator/codeflow/cli/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import annotations

--- a/src/md_generator/codeflow/cli/main.py
+++ b/src/md_generator/codeflow/cli/main.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from md_generator.codeflow.core.extractor import run_scan
+from md_generator.codeflow.core.run_config import ScanConfig
+from md_generator.codeflow.ingestion.loader import load_workspace
+
+
+def _parse_formats(s: str | None) -> tuple[str, ...]:
+    if s is None or not str(s).strip():
+        return ("md", "mermaid", "json")
+    parts = tuple(x.strip().lower() for x in str(s).split(",") if x.strip())
+    return parts if parts else ("md", "mermaid", "json")
+
+
+def _parse_entry(s: str | None) -> list[str] | None:
+    if not s or not str(s).strip():
+        return None
+    return [x.strip() for x in str(s).split(",") if x.strip()]
+
+
+def _normalize_include(raw: str | None) -> str | None:
+    if not raw:
+        return None
+    mapping = {
+        "api": "api_rest",
+        "rest": "api_rest",
+        "event": "kafka",
+        "kafka": "kafka",
+        "main": "main",
+        "cli": "cli",
+        "scheduler": "scheduler",
+        "queue": "queue",
+    }
+    parts = []
+    for x in raw.split(","):
+        x = x.strip().lower()
+        parts.append(mapping.get(x, x))
+    return ",".join(parts)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(description="Analyze source code execution flows → Markdown/Mermaid/graph.")
+    sub = p.add_subparsers(dest="cmd", required=True)
+    scan = sub.add_parser("scan", help="Scan a folder, file, or zip archive")
+    scan.add_argument("path", type=Path, help="Directory, source file, or .zip archive")
+    scan.add_argument("--output", "-o", type=Path, default=None, help="Output directory")
+    scan.add_argument("--entry", default=None, help="Comma-separated symbol ids (Class.method style)")
+    scan.add_argument("--lang", default="mixed", choices=("mixed", "python", "java"))
+    scan.add_argument("--formats", "--output-formats", dest="formats", default=None, help="Comma-separated: md,html,mermaid,json")
+    scan.add_argument("--depth", type=int, default=5)
+    scan.add_argument("--include", default=None, help="Filter entry kinds: api,event,main,...")
+    scan.add_argument("--exclude", default=None, help="Reserved for path/symbol exclusions")
+    scan.add_argument("--async", dest="async_flag", action="store_true", default=True)
+    scan.add_argument("--no-async", dest="async_flag", action="store_false")
+    scan.add_argument("--jobs", action="store_true", default=False, help="No-op in CLI (reserved for API)")
+    scan.add_argument("--runtime", action="store_true", default=False, help="Reserved: runtime tracing")
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    argv = argv if argv is not None else sys.argv[1:]
+    ns = build_parser().parse_args(argv)
+    if ns.cmd != "scan":
+        return 2
+
+    src = Path(ns.path).expanduser().resolve()
+    ws = load_workspace(path=src)
+    try:
+        root = ws.root
+        paths_override: list[Path] | None = None
+        if src.is_file() and src.suffix.lower() in (".py", ".java"):
+            paths_override = [src]
+
+        out = ns.output
+        if out is None:
+            out = Path.cwd() / "codeflow-out"
+        cfg = ScanConfig(
+            project_root=root,
+            paths_override=paths_override,
+            output_path=out.resolve(),
+            formats=_parse_formats(ns.formats),
+            depth=int(ns.depth),
+            languages=str(ns.lang),
+            entry=_parse_entry(ns.entry),
+            include=_normalize_include(ns.include),
+            exclude=ns.exclude,
+            include_internal=True,
+            async_mode=bool(ns.async_flag),
+            jobs=bool(ns.jobs),
+            runtime=bool(ns.runtime),
+        )
+        run_scan(cfg, workspace=ws)
+        print(str(cfg.output_path.resolve()))
+        return 0
+    finally:
+        ws.close()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/md_generator/codeflow/cli/main.py
+++ b/src/md_generator/codeflow/cli/main.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 from md_generator.codeflow.core.extractor import run_scan
 from md_generator.codeflow.core.run_config import ScanConfig
-from md_generator.codeflow.ingestion.loader import load_workspace
+from md_generator.codeflow.ingestion.loader import load_workspace, source_file_extensions
 
 
 def _parse_formats(s: str | None) -> tuple[str, ...]:
@@ -49,7 +49,14 @@ def build_parser() -> argparse.ArgumentParser:
     scan.add_argument("path", type=Path, help="Directory, source file, or .zip archive")
     scan.add_argument("--output", "-o", type=Path, default=None, help="Output directory")
     scan.add_argument("--entry", default=None, help="Comma-separated symbol ids (Class.method style)")
-    scan.add_argument("--lang", default="mixed", choices=("mixed", "python", "java"))
+    scan.add_argument(
+        "--lang",
+        default="mixed",
+        help=(
+            "mixed | python | java | javascript | typescript | tsx | cpp | go | php | "
+            "comma-separated (e.g. python,javascript). Aliases: js→javascript, ts→typescript."
+        ),
+    )
     scan.add_argument("--formats", "--output-formats", dest="formats", default=None, help="Comma-separated: md,html,mermaid,json")
     scan.add_argument("--depth", type=int, default=5)
     scan.add_argument("--include", default=None, help="Filter entry kinds: api,event,main,...")
@@ -58,6 +65,24 @@ def build_parser() -> argparse.ArgumentParser:
     scan.add_argument("--no-async", dest="async_flag", action="store_false")
     scan.add_argument("--jobs", action="store_true", default=False, help="No-op in CLI (reserved for API)")
     scan.add_argument("--runtime", action="store_true", default=False, help="Reserved: runtime tracing")
+    scan.add_argument(
+        "--business-rules",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Emit business_rules.md, entry section, and (unless disabled) entry.combined.md (default: on)",
+    )
+    scan.add_argument(
+        "--business-rules-sql",
+        action="store_true",
+        default=False,
+        help="Scan workspace *.sql for CREATE TRIGGER lines",
+    )
+    scan.add_argument(
+        "--business-rules-combined",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Write entry.combined.md (entry.md + business_rules.md) (default: on)",
+    )
     return p
 
 
@@ -72,7 +97,7 @@ def main(argv: list[str] | None = None) -> int:
     try:
         root = ws.root
         paths_override: list[Path] | None = None
-        if src.is_file() and src.suffix.lower() in (".py", ".java"):
+        if src.is_file() and src.suffix.lower() in source_file_extensions():
             paths_override = [src]
 
         out = ns.output
@@ -92,6 +117,9 @@ def main(argv: list[str] | None = None) -> int:
             async_mode=bool(ns.async_flag),
             jobs=bool(ns.jobs),
             runtime=bool(ns.runtime),
+            business_rules=bool(ns.business_rules),
+            business_rules_sql=bool(ns.business_rules_sql),
+            business_rules_combined=bool(ns.business_rules_combined),
         )
         run_scan(cfg, workspace=ws)
         print(str(cfg.output_path.resolve()))

--- a/src/md_generator/codeflow/core/__init__.py
+++ b/src/md_generator/codeflow/core/__init__.py
@@ -1,0 +1,6 @@
+from __future__ import annotations
+
+from md_generator.codeflow.core.run_config import ScanConfig
+from md_generator.codeflow.core.extractor import run_scan
+
+__all__ = ["ScanConfig", "run_scan"]

--- a/src/md_generator/codeflow/core/extractor.py
+++ b/src/md_generator/codeflow/core/extractor.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+import json
+import shutil
+import tempfile
+import zipfile
+from pathlib import Path
+
+from md_generator.codeflow.analyzers.flow_analyzer import slice_from_entry
+from md_generator.codeflow.detectors.entry_detector import apply_entry_detectors, resolve_entry_symbol_ids
+from md_generator.codeflow.graph.builder import GraphBuildResult, build_graph, graph_to_serializable
+from md_generator.codeflow.generators.html import write_html_bundle
+from md_generator.codeflow.generators.markdown import write_flow_markdown
+from md_generator.codeflow.generators.mermaid import write_flow_mermaid
+from md_generator.codeflow.generators.sequence import write_sequence_mermaid
+from md_generator.codeflow.ingestion.loader import LoadedWorkspace, collect_source_files
+from md_generator.codeflow.models.ir import FileParseResult
+from md_generator.codeflow.parsers.base import ParserRegistry, register_defaults
+from md_generator.codeflow.core.run_config import ScanConfig
+
+
+def _parse_results_for_workspace(ws: LoadedWorkspace, cfg: ScanConfig) -> list[FileParseResult]:
+    reg = ParserRegistry()
+    register_defaults(reg)
+    files = cfg.paths_override if cfg.paths_override else collect_source_files(ws.root, cfg.languages)
+    results: list[FileParseResult] = []
+    for p in files:
+        lang = _lang_for_path(p)
+        if cfg.languages == "python" and lang != "python":
+            continue
+        if cfg.languages == "java" and lang != "java":
+            continue
+        pr = reg.parse_file(p, ws.root, lang)
+        if pr:
+            results.append(pr)
+    apply_entry_detectors(files, ws.root, results)
+    return results
+
+
+def _lang_for_path(p: Path) -> str:
+    suf = p.suffix.lower()
+    if suf == ".py":
+        return "python"
+    if suf == ".java":
+        return "java"
+    return "unknown"
+
+
+def run_scan(cfg: ScanConfig, *, workspace: LoadedWorkspace | None = None) -> Path:
+    """Analyze code under workspace root and write outputs."""
+    ws = workspace or LoadedWorkspace(root=cfg.project_root.resolve(), cleanup_dir=None)
+
+    parse_results = _parse_results_for_workspace(ws, cfg)
+    gb: GraphBuildResult = build_graph(parse_results, ws.root)
+    g = gb.graph
+
+    out = cfg.output_path
+    out.mkdir(parents=True, exist_ok=True)
+
+    all_entries = [e for pr in parse_results for e in pr.entries]
+    entry_ids = resolve_entry_symbol_ids(cfg.entry, all_entries)
+
+    fmts = {x.strip().lower() for x in cfg.formats}
+
+    entry_ids = [e for e in entry_ids if e in g]
+    if not entry_ids:
+        entry_ids = [n for n, d in g.nodes(data=True) if d.get("type") == "entry" and n in g]
+    if not entry_ids:
+        entry_ids = [n for n in g.nodes()][: min(10, max(1, g.number_of_nodes()))]
+
+    include_map = cfg.parsed_include()
+
+    for eid in entry_ids:
+        if include_map:
+            ndata = dict(g.nodes[eid]) if eid in g else {}
+            ek = ndata.get("entry_kind")
+            if ek and ek not in include_map:
+                continue
+        sl = slice_from_entry(g, eid, cfg.depth)
+        slug = _slug(eid)
+        sub = out / slug
+        sub.mkdir(parents=True, exist_ok=True)
+        if "md" in fmts:
+            write_flow_markdown(sub / "flow.md", eid, sl, g)
+        if "mermaid" in fmts:
+            write_flow_mermaid(sub / "flow.mmd", eid, sl)
+            write_sequence_mermaid(sub / "sequence.mmd", eid, sl)
+        if "json" in fmts:
+            sub_g = g.subgraph(sl.nodes).copy()
+            sub_json = graph_to_serializable(sub_g)
+            (sub / "graph.json").write_text(json.dumps(sub_json, indent=2), encoding="utf-8")
+        if "html" in fmts:
+            sub_g = g.subgraph(sl.nodes).copy()
+            write_html_bundle(sub / "index.html", eid, sl, graph_to_serializable(sub_g))
+
+    if "json" in fmts:
+        full = graph_to_serializable(g)
+        (out / "graph-full.json").write_text(json.dumps(full, indent=2), encoding="utf-8")
+
+    return out
+
+
+def _slug(entry_id: str) -> str:
+    s = "".join(c if c.isalnum() or c in "._-" else "_" for c in entry_id)
+    return s[:180] if len(s) > 180 else s
+
+
+def build_output_zip(cfg: ScanConfig, workspace_root: Path | None = None) -> bytes:
+    """Run scan into a temp dir and return zip bytes (for API)."""
+    td = Path(tempfile.mkdtemp(prefix="codeflow-scan-"))
+    try:
+        root = workspace_root or cfg.project_root
+        wc = LoadedWorkspace(root=root.resolve(), cleanup_dir=None)
+        cfg2 = ScanConfig(
+            project_root=root.resolve(),
+            paths_override=cfg.paths_override,
+            output_path=td / "out",
+            formats=cfg.formats,
+            depth=cfg.depth,
+            languages=cfg.languages,
+            entry=cfg.entry,
+            include=cfg.include,
+            exclude=cfg.exclude,
+            include_internal=cfg.include_internal,
+            async_mode=cfg.async_mode,
+            jobs=cfg.jobs,
+            runtime=cfg.runtime,
+        )
+        run_scan(cfg2, workspace=wc)
+        buf = td / "bundle.zip"
+        with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+            for p in (td / "out").rglob("*"):
+                if p.is_file():
+                    zf.write(p, p.relative_to(td).as_posix())
+        return buf.read_bytes()
+    finally:
+        shutil.rmtree(td, ignore_errors=True)

--- a/src/md_generator/codeflow/core/extractor.py
+++ b/src/md_generator/codeflow/core/extractor.py
@@ -8,13 +8,27 @@ from pathlib import Path
 
 from md_generator.codeflow.analyzers.flow_analyzer import slice_from_entry
 from md_generator.codeflow.detectors.entry_detector import apply_entry_detectors, resolve_entry_symbol_ids
+from md_generator.codeflow.detectors.entry_rank import sort_entry_ids
 from md_generator.codeflow.graph.builder import GraphBuildResult, build_graph, graph_to_serializable
 from md_generator.codeflow.generators.html import write_html_bundle
+from md_generator.codeflow.generators.business_rules_markdown import (
+    write_business_rules_markdown,
+    write_combined_entry_markdown,
+)
+from md_generator.codeflow.generators.entry_markdown import (
+    pretty_start_method,
+    type_label_for_kind,
+    write_entry_markdown,
+    write_system_overview,
+)
+from md_generator.codeflow.generators.flow_summary import one_line_summary
 from md_generator.codeflow.generators.markdown import write_flow_markdown
 from md_generator.codeflow.generators.mermaid import write_flow_mermaid
 from md_generator.codeflow.generators.sequence import write_sequence_mermaid
 from md_generator.codeflow.ingestion.loader import LoadedWorkspace, collect_source_files
+from md_generator.codeflow.lang_dispatch import lang_for_path, normalize_language_filter, should_parse_file_lang
 from md_generator.codeflow.models.ir import FileParseResult
+from md_generator.codeflow.rules.collector import collect_business_rules
 from md_generator.codeflow.parsers.base import ParserRegistry, register_defaults
 from md_generator.codeflow.core.run_config import ScanConfig
 
@@ -23,27 +37,17 @@ def _parse_results_for_workspace(ws: LoadedWorkspace, cfg: ScanConfig) -> list[F
     reg = ParserRegistry()
     register_defaults(reg)
     files = cfg.paths_override if cfg.paths_override else collect_source_files(ws.root, cfg.languages)
+    allowed = normalize_language_filter(cfg.languages)
     results: list[FileParseResult] = []
     for p in files:
-        lang = _lang_for_path(p)
-        if cfg.languages == "python" and lang != "python":
-            continue
-        if cfg.languages == "java" and lang != "java":
+        lang = lang_for_path(p)
+        if not should_parse_file_lang(lang, allowed):
             continue
         pr = reg.parse_file(p, ws.root, lang)
         if pr:
             results.append(pr)
     apply_entry_detectors(files, ws.root, results)
     return results
-
-
-def _lang_for_path(p: Path) -> str:
-    suf = p.suffix.lower()
-    if suf == ".py":
-        return "python"
-    if suf == ".java":
-        return "java"
-    return "unknown"
 
 
 def run_scan(cfg: ScanConfig, *, workspace: LoadedWorkspace | None = None) -> Path:
@@ -68,7 +72,11 @@ def run_scan(cfg: ScanConfig, *, workspace: LoadedWorkspace | None = None) -> Pa
     if not entry_ids:
         entry_ids = [n for n in g.nodes()][: min(10, max(1, g.number_of_nodes()))]
 
+    entry_ids = sort_entry_ids(entry_ids, g, all_entries)
+    entry_by_symbol = {e.symbol_id: e for e in all_entries}
+
     include_map = cfg.parsed_include()
+    overview_rows: list[tuple[str, str, str, str, str]] = []
 
     for eid in entry_ids:
         if include_map:
@@ -80,8 +88,46 @@ def run_scan(cfg: ScanConfig, *, workspace: LoadedWorkspace | None = None) -> Pa
         slug = _slug(eid)
         sub = out / slug
         sub.mkdir(parents=True, exist_ok=True)
+        rec = entry_by_symbol.get(eid)
         if "md" in fmts:
             write_flow_markdown(sub / "flow.md", eid, sl, g)
+            rules = None
+            if cfg.business_rules:
+                rules = collect_business_rules(
+                    eid,
+                    sl,
+                    g,
+                    parse_results,
+                    cfg,
+                    project_root=ws.root.resolve(),
+                )
+                write_business_rules_markdown(
+                    sub / "business_rules.md",
+                    rules,
+                    entry_hint=eid,
+                )
+                write_entry_markdown(sub / "entry.md", eid, sl, g, rec, rules=rules)
+                if cfg.business_rules_combined:
+                    write_combined_entry_markdown(
+                        sub / "entry.md",
+                        sub / "business_rules.md",
+                        sub / "entry.combined.md",
+                    )
+            else:
+                write_entry_markdown(sub / "entry.md", eid, sl, g, rec, rules=None)
+            if eid in g:
+                k = rec.kind.value if rec else g.nodes[eid].get("entry_kind")
+            else:
+                k = rec.kind.value if rec else None
+            overview_rows.append(
+                (
+                    slug,
+                    type_label_for_kind(k),
+                    pretty_start_method(g, eid),
+                    f"[entry](./{slug}/entry.md)",
+                    one_line_summary(sl, g),
+                ),
+            )
         if "mermaid" in fmts:
             write_flow_mermaid(sub / "flow.mmd", eid, sl)
             write_sequence_mermaid(sub / "sequence.mmd", eid, sl)
@@ -96,6 +142,13 @@ def run_scan(cfg: ScanConfig, *, workspace: LoadedWorkspace | None = None) -> Pa
     if "json" in fmts:
         full = graph_to_serializable(g)
         (out / "graph-full.json").write_text(json.dumps(full, indent=2), encoding="utf-8")
+
+    if "md" in fmts and overview_rows:
+        write_system_overview(
+            out / "system_overview.md",
+            overview_rows,
+            project_hint=f"Project: `{ws.root.resolve().as_posix()}`",
+        )
 
     return out
 
@@ -125,6 +178,9 @@ def build_output_zip(cfg: ScanConfig, workspace_root: Path | None = None) -> byt
             async_mode=cfg.async_mode,
             jobs=cfg.jobs,
             runtime=cfg.runtime,
+            business_rules=cfg.business_rules,
+            business_rules_sql=cfg.business_rules_sql,
+            business_rules_combined=cfg.business_rules_combined,
         )
         run_scan(cfg2, workspace=wc)
         buf = td / "bundle.zip"

--- a/src/md_generator/codeflow/core/run_config.py
+++ b/src/md_generator/codeflow/core/run_config.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+
+@dataclass
+class ScanConfig:
+    """Input and output options for a codeflow scan."""
+
+    project_root: Path
+    output_path: Path
+    paths_override: list[Path] | None = None
+    formats: tuple[str, ...] = ("md", "mermaid", "json")
+    depth: int = 5
+    languages: str = "mixed"  # mixed|python|java
+    entry: list[str] | None = None
+    include: str | None = None  # api,event,main,...
+    exclude: str | None = None
+    include_internal: bool = True
+    async_mode: bool = True
+    jobs: bool = False
+    runtime: bool = False
+
+    def parsed_include(self) -> set[str] | None:
+        if not self.include or not str(self.include).strip():
+            return None
+        return {x.strip() for x in str(self.include).split(",") if x.strip()}

--- a/src/md_generator/codeflow/core/run_config.py
+++ b/src/md_generator/codeflow/core/run_config.py
@@ -13,7 +13,7 @@ class ScanConfig:
     paths_override: list[Path] | None = None
     formats: tuple[str, ...] = ("md", "mermaid", "json")
     depth: int = 5
-    languages: str = "mixed"  # mixed|python|java
+    languages: str = "mixed"  # mixed|python|java|javascript|typescript|tsx|cpp|go|php|comma list
     entry: list[str] | None = None
     include: str | None = None  # api,event,main,...
     exclude: str | None = None
@@ -21,6 +21,9 @@ class ScanConfig:
     async_mode: bool = True
     jobs: bool = False
     runtime: bool = False
+    business_rules: bool = True
+    business_rules_sql: bool = False
+    business_rules_combined: bool = True
 
     def parsed_include(self) -> set[str] | None:
         if not self.include or not str(self.include).strip():

--- a/src/md_generator/codeflow/detectors/__init__.py
+++ b/src/md_generator/codeflow/detectors/__init__.py
@@ -1,0 +1,7 @@
+from __future__ import annotations
+
+from md_generator.codeflow.detectors.entry_detector import apply_entry_detectors
+from md_generator.codeflow.detectors.api_detector import detect_api_entries
+from md_generator.codeflow.detectors.kafka_detector import detect_kafka_entries
+
+__all__ = ["apply_entry_detectors", "detect_api_entries", "detect_kafka_entries"]

--- a/src/md_generator/codeflow/detectors/api_detector.py
+++ b/src/md_generator/codeflow/detectors/api_detector.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import ast
+import re
 from pathlib import Path
 
 from md_generator.codeflow.models.ir import EntryKind, EntryRecord
@@ -116,10 +117,106 @@ def detect_api_entries_java(path: Path, project_root: Path) -> list[EntryRecord]
     return out
 
 
+_HTTP_ROUTE = re.compile(
+    r"\b(app|router|server)\s*\.\s*(get|post|put|delete|patch|options|head|use)\s*\(",
+    re.I,
+)
+
+
+def detect_api_entries_js_ts(path: Path, project_root: Path) -> list[EntryRecord]:
+    """Express / Fastify / similar: handlers using ``app.get`` / ``router.post`` style calls."""
+    suf = path.suffix.lower()
+    if suf not in (".js", ".jsx", ".mjs", ".cjs", ".ts", ".tsx", ".mts", ".cts"):
+        return []
+    text = path.read_text(encoding="utf-8", errors="replace")
+    if not _HTTP_ROUTE.search(text):
+        return []
+    if not re.search(
+        r"(express|fastify|koa|@nestjs|from\s+['\"]express['\"]|require\(\s*['\"]express['\"]\))",
+        text,
+        re.I,
+    ):
+        return []
+    key = path.resolve().relative_to(project_root.resolve()).as_posix()
+    out: list[EntryRecord] = []
+    try:
+        from tree_sitter import Language, Parser
+        import tree_sitter_javascript as tsjs
+        import tree_sitter_typescript as tsts
+
+        suf2 = path.suffix.lower()
+        if suf2 in (".ts", ".mts", ".cts"):
+            lang = Language(tsts.language_typescript())
+        elif suf2 == ".tsx":
+            lang = Language(tsts.language_tsx())
+        else:
+            lang = Language(tsjs.language())
+        parser = Parser(lang)
+        tree = parser.parse(text.encode("utf-8"))
+        source = text.encode("utf-8")
+
+        def node_text(n: object) -> str:
+            return source[n.start_byte : n.end_byte].decode("utf-8", errors="replace")
+
+        def is_http_route_call(n: object) -> bool:
+            if n.type != "call_expression":
+                return False
+            fn = n.child_by_field_name("function")
+            if fn is None:
+                return False
+            t = node_text(fn).replace(" ", "")
+            return bool(_HTTP_ROUTE.search(t + "("))
+
+        def enclosing_function_name(n: object) -> str | None:
+            cur = getattr(n, "parent", None)
+            while cur is not None:
+                if cur.type in ("function_declaration", "method_definition"):
+                    nm = cur.child_by_field_name("name")
+                    return node_text(nm).strip() if nm else None
+                cur = getattr(cur, "parent", None)
+            return None
+
+        seen: set[str] = set()
+
+        def visit(n: object) -> None:
+            for c in n.children:
+                visit(c)
+            if is_http_route_call(n):
+                fname = enclosing_function_name(n) or "__handler__"
+                sid = _sid(key, None, fname)
+                if sid not in seen:
+                    seen.add(sid)
+                    out.append(
+                        EntryRecord(
+                            symbol_id=sid,
+                            kind=EntryKind.API_REST,
+                            label="JS/TS HTTP route (Express/Fastify-style)",
+                            file_path=str(path.resolve()),
+                            line=n.start_point[0] + 1,
+                        )
+                    )
+
+        visit(tree.root_node)
+    except Exception:
+        if not out:
+            out.append(
+                EntryRecord(
+                    symbol_id=_sid(key, None, "__http__"),
+                    kind=EntryKind.API_REST,
+                    label="JS/TS HTTP routes (file-level heuristic)",
+                    file_path=str(path.resolve()),
+                    line=1,
+                )
+            )
+    return out
+
+
 def detect_api_entries(path: Path, project_root: Path) -> list[EntryRecord]:
     suf = path.suffix.lower()
     if suf == ".py":
         return detect_api_entries_python(path, project_root)
     if suf == ".java":
         return detect_api_entries_java(path, project_root)
+    if suf in (".js", ".jsx", ".mjs", ".cjs", ".ts", ".tsx", ".mts", ".cts"):
+        return detect_api_entries_js_ts(path, project_root)
     return []

--- a/src/md_generator/codeflow/detectors/api_detector.py
+++ b/src/md_generator/codeflow/detectors/api_detector.py
@@ -1,0 +1,125 @@
+"""Framework-specific API entry hints (REST)."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+from md_generator.codeflow.models.ir import EntryKind, EntryRecord
+
+
+def _sid(key: str, cls: str | None, name: str) -> str:
+    if cls:
+        return f"{key}::{cls}.{name}"
+    return f"{key}::{name}"
+
+
+def detect_api_entries_python(path: Path, project_root: Path) -> list[EntryRecord]:
+    key = path.resolve().relative_to(project_root.resolve()).as_posix()
+    src = path.read_text(encoding="utf-8", errors="replace")
+    tree = ast.parse(src, filename=str(path))
+    out: list[EntryRecord] = []
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef):
+            deco_names: list[str] = []
+            for d in node.decorator_list:
+                name = ""
+                if isinstance(d, ast.Name):
+                    name = d.id
+                elif isinstance(d, ast.Attribute):
+                    name = d.attr
+                elif isinstance(d, ast.Call):
+                    func = d.func
+                    if isinstance(func, ast.Attribute):
+                        name = func.attr
+                    elif isinstance(func, ast.Name):
+                        name = func.id
+                deco_names.append(name.lower())
+                try:
+                    deco_names.append(ast.unparse(d).lower())
+                except Exception:
+                    pass
+            blob = " ".join(deco_names)
+            # FastAPI / Flask-style heuristics
+            if any(
+                x in blob
+                for x in (
+                    "router.get",
+                    "router.post",
+                    "router.put",
+                    "router.delete",
+                    "router.patch",
+                    "route",
+                    "get",
+                    "post",
+                    "put",
+                    "delete",
+                    "api_route",
+                )
+            ):
+                cls = None
+                for p in ast.walk(tree):
+                    if isinstance(p, ast.ClassDef) and node in p.body:
+                        cls = p.name
+                        break
+                out.append(
+                    EntryRecord(
+                        symbol_id=_sid(key, cls, node.name),
+                        kind=EntryKind.API_REST,
+                        label="Python API route (heuristic)",
+                        file_path=str(path.resolve()),
+                        line=node.lineno,
+                    )
+                )
+    return out
+
+
+def detect_api_entries_java(path: Path, project_root: Path) -> list[EntryRecord]:
+    text = path.read_text(encoding="utf-8", errors="replace")
+    key = path.resolve().relative_to(project_root.resolve()).as_posix()
+    out: list[EntryRecord] = []
+    if "@RestController" not in text and "@RequestMapping" not in text:
+        return out
+    try:
+        import javalang
+
+        tree = javalang.parse.parse(text)
+    except Exception:
+        return out
+
+    for t in tree.types or []:
+        cls_name = getattr(t, "name", "")
+        restish = False
+        for ann in getattr(t, "annotations", None) or []:
+            an = getattr(ann, "name", None) or str(ann)
+            if an in ("RestController", "Controller", "RequestMapping"):
+                restish = True
+                break
+        if not restish:
+            continue
+        for m in getattr(t, "methods", None) or []:
+            names = []
+            for ann in getattr(m, "annotations", None) or []:
+                names.append(str(getattr(ann, "name", ann)))
+            if any(n.startswith(("GetMapping", "PostMapping", "PutMapping", "DeleteMapping", "PatchMapping", "RequestMapping")) for n in names):
+                sym = _sid(key, cls_name, m.name)
+                out.append(
+                    EntryRecord(
+                        symbol_id=sym,
+                        kind=EntryKind.API_REST,
+                        label="Java Spring MVC mapping",
+                        file_path=str(path.resolve()),
+                        line=int(getattr(getattr(m, "position", None), "line", 0) or 0),
+                    )
+                )
+    return out
+
+
+def detect_api_entries(path: Path, project_root: Path) -> list[EntryRecord]:
+    suf = path.suffix.lower()
+    if suf == ".py":
+        return detect_api_entries_python(path, project_root)
+    if suf == ".java":
+        return detect_api_entries_java(path, project_root)
+    return []

--- a/src/md_generator/codeflow/detectors/entry_detector.py
+++ b/src/md_generator/codeflow/detectors/entry_detector.py
@@ -1,0 +1,46 @@
+"""Compose detectors and merge entry records onto parse results."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from md_generator.codeflow.detectors.api_detector import detect_api_entries
+from md_generator.codeflow.detectors.kafka_detector import detect_kafka_entries
+from md_generator.codeflow.models.ir import EntryKind, EntryRecord, FileParseResult
+
+
+def apply_entry_detectors(paths: list[Path], project_root: Path, results: list[FileParseResult]) -> None:
+    """Mutate ``results`` in place with additional ``EntryRecord`` rows."""
+    by_path = {r.path.resolve(): r for r in results}
+    for p in paths:
+        pr = by_path.get(p.resolve())
+        if not pr:
+            continue
+        pr.entries.extend(detect_api_entries(p, project_root))
+        pr.entries.extend(detect_kafka_entries(p, project_root))
+
+
+def filter_entries_by_include(
+    entries: list[EntryRecord],
+    include_kinds: set[str] | None,
+    exclude_internal: bool,
+) -> list[EntryRecord]:
+    """include_kinds uses EntryKind value strings, e.g. {\"api_rest\",\"main\"}."""
+    out: list[EntryRecord] = []
+    for e in entries:
+        k = e.kind.value
+        if include_kinds and k not in include_kinds:
+            continue
+        if exclude_internal and k == EntryKind.UNKNOWN.value:
+            continue
+        out.append(e)
+    return out
+
+
+def resolve_entry_symbol_ids(
+    explicit: list[str] | None,
+    detected: list[EntryRecord],
+) -> list[str]:
+    if explicit:
+        return list(explicit)
+    return list({e.symbol_id for e in detected})

--- a/src/md_generator/codeflow/detectors/entry_rank.py
+++ b/src/md_generator/codeflow/detectors/entry_rank.py
@@ -1,0 +1,51 @@
+"""Rank entry points for documentation order (API first, then events, scheduler, main, etc.)."""
+
+from __future__ import annotations
+
+import networkx as nx
+
+from md_generator.codeflow.models.ir import EntryKind, EntryRecord
+
+
+def entry_kind_rank(kind: str | None) -> int:
+    """Lower rank = earlier in docs. Unknown kinds sort last."""
+    if not kind:
+        return 90
+    order = {
+        EntryKind.API_REST.value: 0,
+        EntryKind.KAFKA.value: 1,
+        EntryKind.QUEUE.value: 1,
+        EntryKind.SCHEDULER.value: 2,
+        EntryKind.MAIN.value: 3,
+        EntryKind.CLI.value: 4,
+        EntryKind.UNKNOWN.value: 5,
+    }
+    return order.get(kind, 50)
+
+
+def _kind_for_entry_id(
+    entry_id: str,
+    g: nx.DiGraph,
+    by_symbol: dict[str, EntryRecord],
+) -> str | None:
+    rec = by_symbol.get(entry_id)
+    if rec is not None:
+        return rec.kind.value
+    if entry_id in g:
+        return g.nodes[entry_id].get("entry_kind")
+    return None
+
+
+def sort_entry_ids(
+    entry_ids: list[str],
+    g: nx.DiGraph,
+    all_entries: list[EntryRecord],
+) -> list[str]:
+    """Stable sort: API → event (kafka/queue) → scheduler → main → cli → unknown; tie-break by ``entry_id``."""
+    by_symbol = {e.symbol_id: e for e in all_entries}
+
+    def sort_key(eid: str) -> tuple[int, str]:
+        k = _kind_for_entry_id(eid, g, by_symbol)
+        return (entry_kind_rank(k), eid)
+
+    return sorted(entry_ids, key=sort_key)

--- a/src/md_generator/codeflow/detectors/kafka_detector.py
+++ b/src/md_generator/codeflow/detectors/kafka_detector.py
@@ -1,0 +1,47 @@
+"""Kafka / messaging listener hints (best-effort)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from md_generator.codeflow.models.ir import EntryKind, EntryRecord
+
+
+def detect_kafka_entries_java_source(path: Path, project_root: Path) -> list[EntryRecord]:
+    """TODO: Full topic graph linking (producer → topic → consumer) needs runtime/config."""
+    text = path.read_text(encoding="utf-8", errors="replace")
+    if "@KafkaListener" not in text and "KafkaListener" not in text:
+        return []
+    key = path.resolve().relative_to(project_root.resolve()).as_posix()
+    out: list[EntryRecord] = []
+    try:
+        import javalang
+
+        tree = javalang.parse.parse(text)
+    except Exception:
+        return out
+
+    for t in tree.types or []:
+        cls_name = getattr(t, "name", "")
+        for m in getattr(t, "methods", None) or []:
+            ann_blob = " ".join(str(getattr(a, "name", a)) for a in (getattr(m, "annotations", None) or []))
+            if "KafkaListener" in ann_blob:
+                sym = f"{key}::{cls_name}.{m.name}"
+                pos = getattr(m, "position", None)
+                line = int(getattr(pos, "line", 0) or 0) if pos else 0
+                out.append(
+                    EntryRecord(
+                        symbol_id=sym,
+                        kind=EntryKind.KAFKA,
+                        label="@KafkaListener",
+                        file_path=str(path.resolve()),
+                        line=line,
+                    )
+                )
+    return out
+
+
+def detect_kafka_entries(path: Path, project_root: Path) -> list[EntryRecord]:
+    if path.suffix.lower() == ".java":
+        return detect_kafka_entries_java_source(path, project_root)
+    return []

--- a/src/md_generator/codeflow/generators/__init__.py
+++ b/src/md_generator/codeflow/generators/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import annotations

--- a/src/md_generator/codeflow/generators/business_rules_markdown.py
+++ b/src/md_generator/codeflow/generators/business_rules_markdown.py
@@ -1,0 +1,68 @@
+"""Markdown writers for extracted business rules and combined entry documentation."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from pathlib import Path
+from typing import Sequence
+
+from md_generator.codeflow.models.ir import BusinessRule
+
+
+def _md_cell(s: str, max_len: int = 400) -> str:
+    t = " ".join(s.splitlines()).strip()
+    t = t.replace("|", "\\|")
+    if len(t) > max_len:
+        return t[: max_len - 3] + "..."
+    return t
+
+
+def write_business_rules_markdown(path: Path, rules: Sequence[BusinessRule], *, entry_hint: str | None = None) -> None:
+    lines: list[str] = ["# Business rules", ""]
+    if entry_hint:
+        lines.append(f"*Entry scope:* `{entry_hint}`")
+        lines.append("")
+    if not rules:
+        lines.append("*No business rules were extracted for this slice (or optional SQL scan found nothing).*")
+        lines.append("")
+        path.write_text("\n".join(lines), encoding="utf-8")
+        return
+
+    by_source: dict[str, list[BusinessRule]] = defaultdict(list)
+    order = ("predicate", "branch", "validation", "sql_trigger")
+    for r in rules:
+        by_source[r.source].append(r)
+
+    lines.append("Summary tables group rules by origin. Confidence: **high** / *medium* / low.")
+    lines.append("")
+
+    for src in order:
+        bucket = by_source.get(src)
+        if not bucket:
+            continue
+        title = {
+            "predicate": "Predicates and branch conditions (from call graph)",
+            "branch": "Branch points (parser)",
+            "validation": "Validation-style hints (assert, raise, decorators)",
+            "sql_trigger": "SQL triggers (workspace scan)",
+        }.get(src, src)
+        lines.append(f"## {title}")
+        lines.append("")
+        lines.append("| Line | Symbol | Title | Detail | Conf. |")
+        lines.append("| --- | --- | --- | --- | --- |")
+        for r in sorted(bucket, key=lambda x: (x.file_path, x.line, x.title)):
+            sym = _md_cell(r.symbol_id or "—", 80)
+            lines.append(
+                f"| {r.line} | `{sym}` | {_md_cell(r.title, 120)} | {_md_cell(r.detail, 200)} | {r.confidence} |",
+            )
+        lines.append("")
+
+    path.write_text("\n".join(lines), encoding="utf-8")
+
+
+def write_combined_entry_markdown(entry_path: Path, rules_path: Path, combined_path: Path) -> None:
+    """Concatenate main entry doc and business rules for a single exportable file."""
+    entry_body = entry_path.read_text(encoding="utf-8").rstrip()
+    rules_body = rules_path.read_text(encoding="utf-8").strip()
+    combined = entry_body + "\n\n---\n\n" + rules_body + "\n"
+    combined_path.write_text(combined, encoding="utf-8")

--- a/src/md_generator/codeflow/generators/cytoscape_enrich.py
+++ b/src/md_generator/codeflow/generators/cytoscape_enrich.py
@@ -1,0 +1,97 @@
+"""Enrich serialized graph JSON for Cytoscape (layers, preset positions, compound clusters)."""
+
+from __future__ import annotations
+
+import re
+from collections import defaultdict
+
+import networkx as nx
+
+
+def _cluster_key(node: dict) -> str:
+    fp = (node.get("file_path") or "").strip().replace("\\", "/")
+    if not fp:
+        return "unscoped"
+    parts = fp.rsplit("/", 1)
+    return parts[0] if len(parts) > 1 else "root"
+
+
+def _safe_cluster_id(cluster_key: str) -> str:
+    s = re.sub(r"[^a-zA-Z0-9_]+", "_", cluster_key)[:80].strip("_") or "grp"
+    return f"__grp__{s}"
+
+
+def enrich_graph_for_views(graph: dict, entry_id: str) -> dict:
+    """Return a copy of ``graph`` with ``cy_depth``, preset positions, and compound parent metadata.
+
+    Does not mutate the original dict (safe for JSON already written to disk).
+    """
+    nodes_in = list(graph.get("nodes") or [])
+    edges_in = list(graph.get("edges") or [])
+    G = nx.DiGraph()
+    for n in nodes_in:
+        nid = n.get("id")
+        if nid:
+            G.add_node(nid)
+    for e in edges_in:
+        u, v = e.get("source"), e.get("target")
+        if u and v and G.has_node(u) and G.has_node(v):
+            G.add_edge(u, v)
+
+    if entry_id in G:
+        lengths: dict[str, int] = dict(nx.single_source_shortest_path_length(G, entry_id))
+    else:
+        lengths = {n: 0 for n in G.nodes()}
+
+    rank_bucket: dict[int, list[str]] = defaultdict(list)
+    for nid in G.nodes():
+        rank_bucket[lengths.get(nid, 0)].append(nid)
+
+    rank_positions: dict[str, tuple[float, float]] = {}
+    for r in sorted(rank_bucket.keys()):
+        ids = sorted(rank_bucket[r])
+        for i, nid in enumerate(ids):
+            rank_positions[nid] = (float(r) * 280.0, float(i) * 88.0)
+
+    cluster_keys: dict[str, str] = {}
+    for n in nodes_in:
+        nid = n.get("id")
+        if not nid:
+            continue
+        ck = _cluster_key(n)
+        cluster_keys.setdefault(ck, _safe_cluster_id(ck))
+
+    compound_parents = [{"id": cluster_keys[ck], "label": ck} for ck in sorted(cluster_keys.keys())]
+
+    nodes_out: list[dict] = []
+    for n in nodes_in:
+        nid = n.get("id")
+        if not nid:
+            continue
+        row = {**n}
+        row["cy_depth"] = int(lengths.get(nid, 0))
+        px, py = rank_positions.get(nid, (0.0, 0.0))
+        row["cy_preset_x"] = px
+        row["cy_preset_y"] = py
+        ck = _cluster_key(n)
+        row["cy_cluster_id"] = cluster_keys[ck]
+        row["cy_label_short"] = _short_label(n, nid)
+        nodes_out.append(row)
+
+    return {
+        "nodes": nodes_out,
+        "edges": edges_in,
+        "entry_id": entry_id,
+        "compound_parents": compound_parents,
+    }
+
+
+def _short_label(node: dict, nid: str) -> str:
+    cn = node.get("class_name")
+    mn = node.get("method_name")
+    if cn and mn:
+        return f"{cn}.{mn}"
+    if mn:
+        return str(mn)
+    tail = nid.split("::", 1)[-1] if "::" in nid else nid
+    return tail if len(tail) < 48 else tail[:45] + "…"

--- a/src/md_generator/codeflow/generators/entry_markdown.py
+++ b/src/md_generator/codeflow/generators/entry_markdown.py
@@ -1,0 +1,198 @@
+"""Structured per-entry Markdown (Execution Flow Documentation)."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from pathlib import Path
+
+import networkx as nx
+
+from md_generator.codeflow.analyzers.flow_analyzer import FlowSlice
+from md_generator.codeflow.generators.flow_summary import format_flow_description, format_method_summary_lines
+from md_generator.codeflow.models.ir import BusinessRule, EntryKind, EntryRecord
+
+
+def _md_escape(s: str) -> str:
+    return s.replace("|", "\\|")
+
+
+def type_label_for_kind(kind: str | None) -> str:
+    if not kind:
+        return "Other"
+    mapping = {
+        EntryKind.API_REST.value: "API",
+        EntryKind.KAFKA.value: "Event",
+        EntryKind.QUEUE.value: "Event",
+        EntryKind.SCHEDULER.value: "Scheduler",
+        EntryKind.MAIN.value: "Main",
+        EntryKind.CLI.value: "CLI",
+        EntryKind.UNKNOWN.value: "Other",
+    }
+    return mapping.get(kind, "Other")
+
+
+def _subtitle(entry_id: str, entry_record: EntryRecord | None, g: nx.DiGraph) -> str | None:
+    if entry_record and entry_record.label.strip():
+        lab = entry_record.label.strip()
+        up = lab.upper()
+        if any(m in up for m in ("GET ", "POST ", "PUT ", "DELETE ", "PATCH ")) or "`/" in lab or "/" in lab:
+            return lab
+    if entry_id in g:
+        el = g.nodes[entry_id].get("entry_label")
+        if el and str(el).strip():
+            s = str(el).strip()
+            if "/" in s or any(m in s.upper() for m in ("GET ", "POST ", "PUT ")):
+                return s
+    tail = entry_id.split("::", 1)[-1] if "::" in entry_id else entry_id
+    return tail.replace("_", " ") if tail else None
+
+
+def pretty_start_method(g: nx.DiGraph, entry_id: str) -> str:
+    if entry_id not in g:
+        tail = entry_id.split("::")[-1] if "::" in entry_id else entry_id
+        if "." in tail:
+            c, m = tail.rsplit(".", 1)
+            return f"{c}.{m}()"
+        return f"{tail}()"
+    d = g.nodes[entry_id]
+    cn = d.get("class_name")
+    mn = d.get("method_name")
+    if mn and cn:
+        return f"{cn}.{mn}()"
+    if mn:
+        return f"{mn}()"
+    tail = entry_id.split("::")[-1]
+    return tail if tail.endswith(")") else f"{tail}()"
+
+
+def _async_event_lines(sl: FlowSlice, g: nx.DiGraph) -> list[str]:
+    lines: list[str] = []
+    for _u, v, ed in sl.edges:
+        if ed.get("async_") or ed.get("type") == "async":
+            lines.append(f"- Async call to `{v}`")
+        if v in g:
+            ek = g.nodes[v].get("entry_kind")
+            if ek in (EntryKind.KAFKA.value, EntryKind.QUEUE.value):
+                lab = g.nodes[v].get("entry_label") or v
+                lines.append(f"- Event-style target (`{ek}`): {lab}")
+    return lines
+
+
+def _decision_bullets(sl: FlowSlice) -> list[str]:
+    out: list[str] = []
+    seen: set[str] = set()
+    for u, v, ed in sl.edges:
+        cond = ed.get("condition") or ""
+        labs = ed.get("labels") or []
+        lab = (labs[-1] if labs else None) or cond
+        if not lab:
+            continue
+        key = (u, v, str(lab))
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append(f"- `{u}` → `{v}` — *{lab}*")
+    return out
+
+
+def write_entry_markdown(
+    path: Path,
+    entry_id: str,
+    sl: FlowSlice,
+    g: nx.DiGraph,
+    entry_record: EntryRecord | None,
+    rules: Sequence[BusinessRule] | None = None,
+) -> None:
+    lines: list[str] = []
+    lines.append("# Execution Flow Documentation")
+    lines.append("")
+    sub = _subtitle(entry_id, entry_record, g)
+    if sub:
+        lines.append(f"*{sub}*")
+        lines.append("")
+    lines.append("## Entry Point")
+    lines.append("")
+    lines.append(f"- {pretty_start_method(g, entry_id)}")
+    lines.append("")
+    if entry_record is not None:
+        kind = entry_record.kind.value
+    elif entry_id in g:
+        kind = g.nodes[entry_id].get("entry_kind")
+    else:
+        kind = None
+    lines.append("## Type")
+    lines.append("")
+    lines.append(type_label_for_kind(kind))
+    lines.append("")
+    lines.append("## Flow Description")
+    lines.append("")
+    lines.extend(format_flow_description(sl, g))
+    lines.append("")
+    lines.append("## Method Summary")
+    lines.append("")
+    lines.extend(format_method_summary_lines(sl, g, entry_id))
+    lines.append("")
+
+    async_lines = _async_event_lines(sl, g)
+    lines.append("## Async / Event Flow")
+    lines.append("")
+    if async_lines:
+        lines.extend(async_lines)
+    else:
+        lines.append("*None detected in this slice.*")
+    lines.append("")
+
+    dec = _decision_bullets(sl)
+    if dec:
+        lines.append("## Decision Points")
+        lines.append("")
+        lines.extend(dec)
+        lines.append("")
+
+    if rules is not None:
+        lines.append("## Business rules")
+        lines.append("")
+        if rules:
+            for r in list(rules)[:4]:
+                d = " ".join(r.detail.splitlines())[:140]
+                lines.append(f"- **{_md_escape(r.title)}** (`{r.source}`, line {r.line}) — {_md_escape(d)}")
+            if len(rules) > 4:
+                lines.append(f"- *…and {len(rules) - 4} more in the full rules file.*")
+        else:
+            lines.append("*No detailed rules extracted for this slice.*")
+        lines.append("")
+        lines.append("[Full business rules](./business_rules.md)")
+        lines.append("")
+
+    lines.append("## Call graph (detail)")
+    lines.append("")
+    lines.append("See `flow.md` in this directory for the flat edge list.")
+    lines.append("")
+    path.write_text("\n".join(lines), encoding="utf-8")
+
+
+def write_system_overview(
+    path: Path,
+    rows: list[tuple[str, str, str, str, str]],
+    *,
+    project_hint: str | None = None,
+) -> None:
+    """Write root overview. Each row: ``(slug, type_label, start_method, link_line, one_line)``.
+
+    ``link_line`` is typically ``[entry](./slug/entry.md)``.
+    """
+    lines: list[str] = []
+    lines.append("# System overview")
+    lines.append("")
+    if project_hint:
+        lines.append(project_hint)
+        lines.append("")
+    lines.append("Entries are listed in **priority order** (API, event, scheduler, main, …).")
+    lines.append("")
+    lines.append("| Type | Start method | Doc | Summary |")
+    lines.append("| --- | --- | --- | --- |")
+    for slug, typ, start_m, link, summary in rows:
+        safe = summary.replace("|", "\\|")
+        lines.append(f"| {typ} | `{start_m}` | {link} | {safe} |")
+    lines.append("")
+    path.write_text("\n".join(lines), encoding="utf-8")

--- a/src/md_generator/codeflow/generators/flow_summary.py
+++ b/src/md_generator/codeflow/generators/flow_summary.py
@@ -1,0 +1,262 @@
+"""High-level flow narrative and method roles from a ``FlowSlice``."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+
+import networkx as nx
+
+from md_generator.codeflow.analyzers.flow_analyzer import FlowSlice
+
+
+def _edge_condition(ed: dict) -> str | None:
+    c = ed.get("condition")
+    if c:
+        return str(c)
+    labs = ed.get("labels") or []
+    for lab in reversed(labs):
+        if lab:
+            return str(lab)
+    return None
+
+
+def _pretty_method(g: nx.DiGraph, nid: str) -> str:
+    if nid not in g:
+        tail = nid.split("::")[-1] if "::" in nid else nid
+        if "." in tail:
+            cls, meth = tail.rsplit(".", 1)
+            return f"{cls}.{meth}()"
+        return f"{tail}()"
+    d = g.nodes[nid]
+    cn = d.get("class_name")
+    mn = d.get("method_name")
+    if not mn:
+        tail = nid.split("::")[-1] if "::" in nid else nid
+        if "." in tail:
+            cls, meth = tail.rsplit(".", 1)
+            return f"{cls}.{meth}()"
+        return f"{tail}()"
+    if cn:
+        return f"{cn}.{mn}()"
+    return f"{mn}()"
+
+
+def _class_method_from_id(g: nx.DiGraph, nid: str) -> tuple[str | None, str]:
+    if nid in g:
+        d = g.nodes[nid]
+        return d.get("class_name"), d.get("method_name") or nid.split("::")[-1].split(".")[-1]
+    tail = nid.split("::")[-1] if "::" in nid else nid
+    if "." in tail:
+        cls, meth = tail.rsplit(".", 1)
+        return cls, meth
+    return None, tail
+
+
+def _build_adjacency(sl: FlowSlice) -> dict[str, list[tuple[str, dict]]]:
+    adj: dict[str, list[tuple[str, dict]]] = defaultdict(list)
+    seen_pairs: set[tuple[str, str]] = set()
+    for u, v, ed in sl.edges:
+        key = (u, v)
+        if key in seen_pairs:
+            continue
+        seen_pairs.add(key)
+        adj[u].append((v, dict(ed)))
+    return adj
+
+
+def _partition_edges(
+    outs: list[tuple[str, dict]],
+) -> tuple[list[tuple[str, dict]], list[tuple[str, str, dict]]]:
+    uncond: list[tuple[str, dict]] = []
+    cond: list[tuple[str, str, dict]] = []
+    for v, ed in outs:
+        lbl = _edge_condition(ed)
+        if lbl:
+            cond.append((lbl, v, ed))
+        else:
+            uncond.append((v, ed))
+    return uncond, cond
+
+
+def _role_token(method_name: str, class_name: str | None) -> str | None:
+    hay = f"{class_name or ''}.{method_name}".lower()
+    for token, label in (
+        ("controller", "controller layer"),
+        ("service", "service layer"),
+        ("repository", "repository / persistence"),
+        ("repo", "repository / persistence"),
+        ("handler", "handler"),
+        ("consumer", "consumer"),
+        ("producer", "producer"),
+        ("listener", "event listener"),
+    ):
+        if token in hay:
+            return label
+    return None
+
+
+def method_roles(
+    sl: FlowSlice,
+    g: nx.DiGraph,
+    entry_id: str,
+) -> dict[str, str]:
+    """Map node id → short role phrase for Method Summary."""
+    adj = _build_adjacency(sl)
+
+    def out_degree_cond(u: str) -> int:
+        _, cond = _partition_edges(adj.get(u, []))
+        return len(cond)
+
+    roles: dict[str, str] = {}
+    for nid in sl.nodes:
+        cls, meth = _class_method_from_id(g, nid)
+        if nid == entry_id:
+            roles[nid] = "start method"
+            continue
+        outs_n = adj.get(nid, [])
+        if out_degree_cond(nid) >= 1:
+            roles[nid] = "decision logic"
+            continue
+        tok = _role_token(meth, cls)
+        if tok:
+            roles[nid] = tok
+            continue
+        succ = [v for v, _ in outs_n]
+        if not succ:
+            roles[nid] = "leaf / terminal"
+        else:
+            roles[nid] = "processing method"
+    return roles
+
+
+def _async_suffix(ed: dict) -> str:
+    return " [async]" if ed.get("async_") or ed.get("type") == "async" else ""
+
+
+def format_flow_description(sl: FlowSlice, g: nx.DiGraph) -> list[str]:
+    """Numbered flow with optional ``if`` / ``else`` nesting from edge conditions."""
+    lines: list[str] = []
+    adj = _build_adjacency(sl)
+    entry = sl.entry_id
+    if entry not in sl.nodes:
+        lines.append("*Entry not in slice.*")
+        return lines
+
+    step_of: dict[str, int] = {}
+    counter = [0]
+    described: set[str] = set()
+
+    def next_step(nid: str) -> int:
+        if nid not in step_of:
+            counter[0] += 1
+            step_of[nid] = counter[0]
+        return step_of[nid]
+
+    def callee_line(indent: str, v: str, ed: dict) -> None:
+        if v in described and v in step_of:
+            lines.append(
+                f"{indent}→ calls {_pretty_method(g, v)}{_async_suffix(ed)} (see step {step_of[v]})",
+            )
+        else:
+            lines.append(f"{indent}→ calls {_pretty_method(g, v)}{_async_suffix(ed)}")
+
+    def emit_conditional_chain(
+        conds: list[tuple[str, str, dict]],
+        unconds: list[tuple[str, dict]],
+        indent: str,
+    ) -> None:
+        if not conds:
+            return
+        c0, v0, ed0 = conds[0]
+        lines.append(f"{indent}→ if ({c0})")
+        callee_line(f"{indent}   ", v0, ed0)
+        if len(conds) == 1:
+            if unconds:
+                lines.append(f"{indent}→ else")
+                for v, ed in unconds:
+                    callee_line(f"{indent}   ", v, ed)
+            return
+        lines.append(f"{indent}→ else")
+        inner = indent + "   "
+        emit_conditional_chain(conds[1:], unconds, inner)
+
+    def emit_outgoing_block(u: str, indent: str) -> None:
+        outs = adj.get(u, [])
+        if not outs:
+            return
+        unconds, conds = _partition_edges(outs)
+        for v, ed in unconds:
+            callee_line(indent, v, ed)
+        if conds:
+            emit_conditional_chain(conds, [], indent)
+
+    def walk(u: str, stack: set[str]) -> None:
+        if u in described:
+            return
+        if u in stack:
+            lines.append("   → (cycle)")
+            return
+        stack = set(stack)
+        stack.add(u)
+        n = next_step(u)
+        described.add(u)
+        lines.append("")
+        lines.append(f"{n}. {_pretty_method(g, u)}")
+        if sl.truncated and u == entry:
+            lines.append("")
+            lines.append("*Truncated by depth limit.*")
+        if sl.cycle_nodes and u in sl.cycle_nodes:
+            lines.append("")
+            lines.append(f"*Possible cycles or revisits near:* `{u}`")
+        emit_outgoing_block(u, "")
+        outs = adj.get(u, [])
+        unconds, conds = _partition_edges(outs)
+        raw_children = [v for v, _ in unconds] + [v for _, v, _ in conds]
+        seen: set[str] = set()
+        child_order: list[str] = []
+        for v in sorted(raw_children):
+            if v not in sl.nodes or v in seen:
+                continue
+            seen.add(v)
+            child_order.append(v)
+        for v in child_order:
+            walk(v, stack)
+        stack.discard(u)
+
+    walk(entry, set())
+    if lines and lines[0] == "":
+        lines.pop(0)
+    return lines
+
+
+def format_method_summary_lines(sl: FlowSlice, g: nx.DiGraph, entry_id: str) -> list[str]:
+    """``### Class`` sections with ``- method() → role`` bullets."""
+    roles = method_roles(sl, g, entry_id)
+    by_class: dict[str, list[tuple[str, str]]] = defaultdict(list)
+    for nid in sorted(sl.nodes):
+        cls, meth = _class_method_from_id(g, nid)
+        key = cls or "(file scope)"
+        by_class[key].append((meth, roles.get(nid, "processing method")))
+    lines: list[str] = []
+    for cls in sorted(by_class.keys()):
+        lines.append(f"### {cls}")
+        for meth, role in sorted(by_class[cls], key=lambda x: x[0]):
+            lines.append(f"- {meth}() → {role}")
+        lines.append("")
+    if lines and lines[-1] == "":
+        lines.pop()
+    return lines
+
+
+def one_line_summary(sl: FlowSlice, g: nx.DiGraph, max_chars: int = 120) -> str:
+    """First hop or two for overview table."""
+    adj = _build_adjacency(sl)
+    e = sl.entry_id
+    outs = adj.get(e, [])
+    if not outs:
+        return _pretty_method(g, e)
+    parts = [_pretty_method(g, e)]
+    for v, ed in outs[:2]:
+        parts.append(f"→ {_pretty_method(g, v)}")
+    s = " ".join(parts)
+    return s if len(s) <= max_chars else s[: max_chars - 3] + "..."

--- a/src/md_generator/codeflow/generators/html.py
+++ b/src/md_generator/codeflow/generators/html.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import html
+import json
+from pathlib import Path
+
+from md_generator.codeflow.analyzers.flow_analyzer import FlowSlice
+
+
+def write_html_bundle(out: Path, entry_id: str, sl: FlowSlice, graph_json: dict) -> None:
+    payload = json.dumps(graph_json, ensure_ascii=False)
+    title = html.escape(entry_id)
+    nodes_text = html.escape("\n".join(sorted(sl.nodes)))
+    body = f"""<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+  <title>{title}</title>
+  <script src="https://unpkg.com/cytoscape@3.26.0/dist/cytoscape.min.js"></script>
+  <style>
+    body {{ font-family: system-ui, sans-serif; margin: 0; display: flex; height: 100vh; }}
+    #side {{ width: 280px; border-right: 1px solid #ccc; padding: 8px; overflow: auto; }}
+    #cy {{ flex: 1; min-height: 400px; }}
+    pre {{ white-space: pre-wrap; font-size: 12px; }}
+  </style>
+</head>
+<body>
+  <div id="side">
+    <h3>Entry</h3>
+    <pre>{html.escape(entry_id)}</pre>
+    <h4>Nodes</h4>
+    <pre>{nodes_text}</pre>
+  </div>
+  <div id="cy"></div>
+  <script>
+    const data = {payload};
+    const els = [];
+    for (const n of data.nodes || []) {{
+      els.push({{ data: {{ id: n.id, label: n.id }}}});
+    }}
+    for (const e of data.edges || []) {{
+      els.push({{ data: {{ id: e.source + "->" + e.target, source: e.source, target: e.target }}}});
+    }}
+    cytoscape({{
+      container: document.getElementById('cy'),
+      elements: els,
+      style: [
+        {{ selector: 'node', style: {{ 'label': 'data(label)', 'font-size': 10 }}}}, 
+        {{ selector: 'edge', style: {{ 'curve-style': 'bezier', 'target-arrow-shape': 'triangle', 'width': 2 }}}}, 
+      ],
+      layout: {{ name: 'breadthfirst', directed: true }},
+    }});
+  </script>
+</body>
+</html>
+"""
+    out.write_text(body, encoding="utf-8")

--- a/src/md_generator/codeflow/generators/html.py
+++ b/src/md_generator/codeflow/generators/html.py
@@ -1,3 +1,5 @@
+"""Cytoscape-based HTML bundles: tabbed ``index.html`` plus standalone view files."""
+
 from __future__ import annotations
 
 import html
@@ -5,53 +7,355 @@ import json
 from pathlib import Path
 
 from md_generator.codeflow.analyzers.flow_analyzer import FlowSlice
+from md_generator.codeflow.generators.cytoscape_enrich import enrich_graph_for_views
+
+
+def _payload(graph_json: dict, entry_id: str) -> str:
+    return json.dumps(enrich_graph_for_views(graph_json, entry_id), ensure_ascii=False)
+
+
+def _shared_css() -> str:
+    return """
+    * { box-sizing: border-box; }
+    body { font-family: system-ui, sans-serif; margin: 0; display: flex; flex-direction: column; height: 100vh; }
+    header { border-bottom: 1px solid #ccc; padding: 8px 12px; display: flex; flex-wrap: wrap; align-items: center; gap: 8px; }
+    header h1 { font-size: 1rem; margin: 0; flex: 1; min-width: 200px; }
+    .tabs { display: flex; gap: 4px; flex-wrap: wrap; }
+    .tabs button {
+      padding: 6px 12px; border: 1px solid #bbb; background: #f4f4f4; cursor: pointer; border-radius: 4px; font-size: 13px;
+    }
+    .tabs button.active { background: #1a5fb4; color: #fff; border-color: #1a5fb4; }
+    .toolbar { display: flex; align-items: center; gap: 8px; margin-left: auto; }
+    .toolbar input { padding: 6px 8px; min-width: 180px; border: 1px solid #ccc; border-radius: 4px; }
+    main { flex: 1; display: flex; min-height: 0; }
+    #side { width: 260px; border-right: 1px solid #ccc; padding: 8px; overflow: auto; font-size: 12px; }
+    .cy-wrap { flex: 1; min-width: 0; position: relative; display: none; }
+    .cy-wrap.active { display: block; }
+    .cy { width: 100%; height: 100%; min-height: 360px; }
+    pre { white-space: pre-wrap; margin: 0; }
+    """
+
+
+def _shared_js_core() -> str:
+    """Cytoscape helpers: elements builder, styles, filter. Uses global DATA and ENTRY."""
+    return r"""
+    function buildElements(data, withCompound) {
+      const els = [];
+      if (withCompound && data.compound_parents) {
+        for (const p of data.compound_parents) {
+          els.push({ data: { id: p.id, label: p.label }, classes: 'cluster' });
+        }
+      }
+      for (const n of data.nodes || []) {
+        const d = { id: n.id, label: n.cy_label_short || n.id };
+        if (withCompound && n.cy_cluster_id) d.parent = n.cy_cluster_id;
+        const cls = (n.type === 'entry' ? 'entry ' : '') + (n.unresolved ? 'unresolved' : '');
+        els.push({ data: d, classes: cls.trim() });
+      }
+      for (const e of data.edges || []) {
+        if (!e.source || !e.target) continue;
+        els.push({
+          data: {
+            id: e.source + '->' + e.target,
+            source: e.source,
+            target: e.target,
+          },
+        });
+      }
+      return els;
+    }
+
+    function baseStyles() {
+      return [
+        {
+          selector: 'node',
+          style: {
+            label: 'data(label)',
+            'font-size': 10,
+            'text-wrap': 'wrap',
+            'text-max-width': '120px',
+            width: 'label',
+            height: 'label',
+            padding: '8px',
+            'background-color': '#ddd',
+            'border-width': 1,
+            'border-color': '#888',
+          },
+        },
+        { selector: 'node.dim', style: { opacity: 0.14, 'text-opacity': 0.2 } },
+        { selector: 'node.entry', style: { 'background-color': '#8fd', 'border-color': '#063', 'font-weight': 'bold' } },
+        { selector: 'node.unresolved', style: { 'background-color': '#fdd' } },
+        { selector: 'node:parent', style: {
+            'background-opacity': 0.12,
+            'border-width': 1,
+            'border-color': '#999',
+            'border-style': 'dashed',
+            label: 'data(label)',
+            'font-size': 11,
+            'text-valign': 'top',
+            'text-halign': 'center',
+            'text-margin-y': '-6px',
+            padding: '14px',
+          },
+        },
+        { selector: 'node.cluster', style: { 'background-color': '#e8eef5' } },
+        {
+          selector: 'edge',
+          style: {
+            'curve-style': 'bezier',
+            'target-arrow-shape': 'triangle',
+            width: 2,
+            'line-color': '#555',
+            'target-arrow-color': '#555',
+          },
+        },
+      ];
+    }
+
+    function applyFilter(cy, q) {
+      const needle = (q || '').trim().toLowerCase();
+      cy.batch(() => {
+        cy.elements().removeClass('dim');
+        if (!needle) return;
+        cy.nodes().forEach((n) => {
+          const lab = (n.data('label') || n.id() || '').toLowerCase();
+          if (!lab.includes(needle)) n.addClass('dim');
+        });
+      });
+    }
+
+    function wireFilter(cy, inputId) {
+      const inp = document.getElementById(inputId);
+      if (!inp) return;
+      inp.addEventListener('input', () => applyFilter(cy, inp.value));
+    }
+
+    window.__codeflowCyInstances = window.__codeflowCyInstances || [];
+    function registerCy(cy) {
+      window.__codeflowCyInstances.push(cy);
+    }
+    function wireFilterAll(inputId) {
+      const inp = document.getElementById(inputId);
+      if (!inp) return;
+      inp.addEventListener('input', () => {
+        const q = inp.value;
+        (window.__codeflowCyInstances || []).forEach((cy) => applyFilter(cy, q));
+      });
+    }
+    """
+
+
+def _init_cytoscape_flow(containerId: str, *, register: bool, filter_input_id: str) -> str:
+    tail = "registerCy(cy);" if register else f"wireFilter(cy, '{filter_input_id}');"
+    return rf"""
+    (function() {{
+      const els = buildElements(DATA, false);
+      const cy = cytoscape({{
+        container: document.getElementById('{containerId}'),
+        elements: els,
+        style: baseStyles(),
+        layout: {{ name: 'breadthfirst', directed: true, roots: ENTRY ? [ENTRY] : undefined, spacingFactor: 1.2 }},
+        wheelSensitivity: 0.35,
+      }});
+      {tail}
+    }})();
+    """
+
+
+def _init_cytoscape_layered(containerId: str, *, register: bool, filter_input_id: str) -> str:
+    tail = "registerCy(cy);" if register else f"wireFilter(cy, '{filter_input_id}');"
+    return rf"""
+    (function() {{
+      const nodeById = new Map((DATA.nodes || []).map((n) => [n.id, n]));
+      const els = buildElements(DATA, false).map((el) => {{
+        if (!el.data || el.data.source) return el;
+        const row = nodeById.get(el.data.id);
+        if (row && typeof row.cy_preset_x === 'number') {{
+          return {{ ...el, position: {{ x: row.cy_preset_x, y: row.cy_preset_y }} }};
+        }}
+        return el;
+      }});
+      const cy = cytoscape({{
+        container: document.getElementById('{containerId}'),
+        elements: els,
+        style: baseStyles(),
+        layout: {{ name: 'preset' }},
+        wheelSensitivity: 0.35,
+      }});
+      {tail}
+    }})();
+    """
+
+
+def _init_cytoscape_clustered(containerId: str, *, register: bool, filter_input_id: str) -> str:
+    tail = "registerCy(cy);" if register else f"wireFilter(cy, '{filter_input_id}');"
+    return rf"""
+    (function() {{
+      const els = buildElements(DATA, true);
+      const cy = cytoscape({{
+        container: document.getElementById('{containerId}'),
+        elements: els,
+        style: baseStyles(),
+        layout: {{ name: 'cose', animate: false, nodeRepulsion: 8000, idealEdgeLength: 100, componentSpacing: 40 }},
+        wheelSensitivity: 0.35,
+      }});
+      {tail}
+    }})();
+    """
 
 
 def write_html_bundle(out: Path, entry_id: str, sl: FlowSlice, graph_json: dict) -> None:
-    payload = json.dumps(graph_json, ensure_ascii=False)
+    """Write tabbed ``index.html`` and standalone ``graph-view-*.html`` files in the same directory."""
+    payload = _payload(graph_json, entry_id)
     title = html.escape(entry_id)
     nodes_text = html.escape("\n".join(sorted(sl.nodes)))
-    body = f"""<!DOCTYPE html>
+    entry_json = json.dumps(entry_id, ensure_ascii=False)
+
+    side_block = f"""
+    <div id="side">
+      <h3>Entry</h3>
+      <pre>{html.escape(entry_id)}</pre>
+      <h4>Nodes ({len(sl.nodes)})</h4>
+      <pre>{nodes_text}</pre>
+      <p style="margin-top:12px;color:#555;font-size:11px;">Flow: breadth-first from entry. Layered: BFS rank positions (NetworkX). Clustered: package/dir compound groups + COSE.</p>
+    </div>"""
+
+    # Tabbed index.html
+    index_body = f"""<!DOCTYPE html>
 <html lang="en">
 <head>
   <meta charset="utf-8"/>
   <title>{title}</title>
   <script src="https://unpkg.com/cytoscape@3.26.0/dist/cytoscape.min.js"></script>
-  <style>
-    body {{ font-family: system-ui, sans-serif; margin: 0; display: flex; height: 100vh; }}
-    #side {{ width: 280px; border-right: 1px solid #ccc; padding: 8px; overflow: auto; }}
-    #cy {{ flex: 1; min-height: 400px; }}
-    pre {{ white-space: pre-wrap; font-size: 12px; }}
-  </style>
+  <style>{_shared_css()}</style>
 </head>
 <body>
-  <div id="side">
-    <h3>Entry</h3>
-    <pre>{html.escape(entry_id)}</pre>
-    <h4>Nodes</h4>
-    <pre>{nodes_text}</pre>
-  </div>
-  <div id="cy"></div>
+  <header>
+    <h1>Codeflow: {title}</h1>
+    <div class="tabs" id="tabbar">
+      <button type="button" class="active" data-tab="flow">Flow</button>
+      <button type="button" data-tab="layered">Layered</button>
+      <button type="button" data-tab="clustered">Clustered</button>
+    </div>
+    <div class="toolbar">
+      <label for="flt">Filter</label>
+      <input type="search" id="flt" placeholder="id / label substring…" autocomplete="off"/>
+    </div>
+  </header>
+  <main>
+    {side_block}
+    <div style="flex:1;display:flex;flex-direction:column;min-width:0;">
+      <div class="cy-wrap active" data-tab="flow"><div id="cy-flow" class="cy"></div></div>
+      <div class="cy-wrap" data-tab="layered"><div id="cy-layered" class="cy"></div></div>
+      <div class="cy-wrap" data-tab="clustered"><div id="cy-clustered" class="cy"></div></div>
+    </div>
+  </main>
   <script>
-    const data = {payload};
-    const els = [];
-    for (const n of data.nodes || []) {{
-      els.push({{ data: {{ id: n.id, label: n.id }}}});
-    }}
-    for (const e of data.edges || []) {{
-      els.push({{ data: {{ id: e.source + "->" + e.target, source: e.source, target: e.target }}}});
-    }}
-    cytoscape({{
-      container: document.getElementById('cy'),
-      elements: els,
-      style: [
-        {{ selector: 'node', style: {{ 'label': 'data(label)', 'font-size': 10 }}}}, 
-        {{ selector: 'edge', style: {{ 'curve-style': 'bezier', 'target-arrow-shape': 'triangle', 'width': 2 }}}}, 
-      ],
-      layout: {{ name: 'breadthfirst', directed: true }},
+    const DATA = {payload};
+    const ENTRY = {entry_json};
+    {_shared_js_core()}
+    window.__codeflowCyInstances = [];
+    {_init_cytoscape_flow("cy-flow", register=True, filter_input_id="flt")}
+    {_init_cytoscape_layered("cy-layered", register=True, filter_input_id="flt")}
+    {_init_cytoscape_clustered("cy-clustered", register=True, filter_input_id="flt")}
+    wireFilterAll('flt');
+    document.querySelectorAll('#tabbar button').forEach((btn) => {{
+      btn.addEventListener('click', () => {{
+        document.querySelectorAll('#tabbar button').forEach((b) => b.classList.remove('active'));
+        btn.classList.add('active');
+        const tab = btn.getAttribute('data-tab');
+        document.querySelectorAll('.cy-wrap').forEach((w) => {{
+          w.classList.toggle('active', w.getAttribute('data-tab') === tab);
+        }});
+        window.dispatchEvent(new Event('resize'));
+      }});
     }});
   </script>
 </body>
 </html>
 """
-    out.write_text(body, encoding="utf-8")
+    out.write_text(index_body, encoding="utf-8")
+
+    base = out.parent
+    _write_standalone_view(
+        base / "graph-view-flow.html",
+        title + " — flow",
+        payload,
+        "flow",
+        entry_id,
+        nodes_text,
+    )
+    _write_standalone_view(
+        base / "graph-view-layered.html",
+        title + " — layered",
+        payload,
+        "layered",
+        entry_id,
+        nodes_text,
+    )
+    _write_standalone_view(
+        base / "graph-view-clustered.html",
+        title + " — clustered",
+        payload,
+        "clustered",
+        entry_id,
+        nodes_text,
+    )
+
+
+def _write_standalone_view(
+    path: Path,
+    page_title: str,
+    payload: str,
+    mode: str,
+    entry_id: str,
+    nodes_text: str,
+) -> None:
+    esc_title = html.escape(page_title)
+    entry_json = json.dumps(entry_id, ensure_ascii=False)
+    if mode == "flow":
+        init = _init_cytoscape_flow("cy-main", register=False, filter_input_id="flt")
+    elif mode == "layered":
+        init = _init_cytoscape_layered("cy-main", register=False, filter_input_id="flt")
+    else:
+        init = _init_cytoscape_clustered("cy-main", register=False, filter_input_id="flt")
+
+    body = f"""<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+  <title>{esc_title}</title>
+  <script src="https://unpkg.com/cytoscape@3.26.0/dist/cytoscape.min.js"></script>
+  <style>
+    {_shared_css()}
+    main {{ flex-direction: column; }}
+    #side {{ width: 100%; max-height: 140px; border-right: none; border-bottom: 1px solid #ccc; }}
+    .cy-wrap.active {{ flex: 1; }}
+  </style>
+</head>
+<body>
+  <header>
+    <h1>{esc_title}</h1>
+    <div class="toolbar">
+      <a href="index.html" style="font-size:13px;margin-right:8px;">Tabbed bundle</a>
+      <label for="flt">Filter</label>
+      <input type="search" id="flt" placeholder="id / label…" autocomplete="off"/>
+    </div>
+  </header>
+  <main>
+    <div id="side">
+      <h4 style="margin:0 0 4px 0;">Nodes</h4>
+      <pre style="max-height:100px;overflow:auto;">{nodes_text}</pre>
+    </div>
+    <div class="cy-wrap active" style="display:block;"><div id="cy-main" class="cy"></div></div>
+  </main>
+  <script>
+    const DATA = {payload};
+    const ENTRY = {entry_json};
+    {_shared_js_core()}
+    {init}
+  </script>
+</body>
+</html>
+"""
+    path.write_text(body, encoding="utf-8")

--- a/src/md_generator/codeflow/generators/markdown.py
+++ b/src/md_generator/codeflow/generators/markdown.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from md_generator.codeflow.analyzers.flow_analyzer import FlowSlice
+
+
+def write_flow_markdown(out: Path, entry_id: str, sl: FlowSlice, full_graph: object) -> None:
+    lines: list[str] = []
+    lines.append(f"# Entry: `{entry_id}`")
+    lines.append("")
+    lines.append("## Flow")
+    lines.append("")
+    if sl.truncated:
+        lines.append("*Truncated by depth limit.*")
+        lines.append("")
+    if sl.cycle_nodes:
+        lines.append(f"*Possible cycles or revisits near:* `{', '.join(sorted(sl.cycle_nodes))}`")
+        lines.append("")
+    for u, v, ed in sl.edges:
+        cond = ed.get("condition") or ""
+        labs = ed.get("labels") or []
+        lab = labs[-1] if labs else cond
+        et = ed.get("type", "sync")
+        tail = f" ({lab})" if lab else ""
+        async_note = " [async]" if ed.get("async_") or et == "async" else ""
+        lines.append(f"- `{u}` → `{v}`{tail}{async_note}")
+    lines.append("")
+    out.write_text("\n".join(lines), encoding="utf-8")

--- a/src/md_generator/codeflow/generators/markdown.py
+++ b/src/md_generator/codeflow/generators/markdown.py
@@ -24,6 +24,12 @@ def write_flow_markdown(out: Path, entry_id: str, sl: FlowSlice, full_graph: obj
         et = ed.get("type", "sync")
         tail = f" ({lab})" if lab else ""
         async_note = " [async]" if ed.get("async_") or et == "async" else ""
-        lines.append(f"- `{u}` → `{v}`{tail}{async_note}")
+        flags: list[str] = []
+        if ed.get("recursive"):
+            flags.append("recursive")
+        if ed.get("unknown_call"):
+            flags.append("unknown_call")
+        flag_note = f" [{', '.join(flags)}]" if flags else ""
+        lines.append(f"- `{u}` → `{v}`{tail}{async_note}{flag_note}")
     lines.append("")
     out.write_text("\n".join(lines), encoding="utf-8")

--- a/src/md_generator/codeflow/generators/mermaid.py
+++ b/src/md_generator/codeflow/generators/mermaid.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from md_generator.codeflow.analyzers.flow_analyzer import FlowSlice
+
+
+def _nid(idx: int) -> str:
+    return f"n{idx}"
+
+
+def write_flow_mermaid(out: Path, entry_id: str, sl: FlowSlice) -> None:
+    lines: list[str] = ["flowchart TD"]
+    idx = 0
+    node_ids: dict[str, str] = {}
+
+    def nid_for(label: str) -> str:
+        nonlocal idx
+        if label not in node_ids:
+            node_ids[label] = _nid(idx)
+            idx += 1
+            esc = label.replace('"', "'")
+            lines.append(f'  {node_ids[label]}["{esc}"]')
+        return node_ids[label]
+
+    for u, v, ed in sl.edges:
+        a = nid_for(u)
+        b = nid_for(v)
+        labs = ed.get("labels") or []
+        lab = labs[-1] if labs else ed.get("condition") or ""
+        if lab:
+            esc = str(lab).replace('"', "'")[:120]
+            lines.append(f"  {a} -->|{esc}| {b}")
+        else:
+            lines.append(f"  {a} --> {b}")
+
+    lines.append("")
+    out.write_text("\n".join(lines), encoding="utf-8")

--- a/src/md_generator/codeflow/generators/mermaid.py
+++ b/src/md_generator/codeflow/generators/mermaid.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import re
 from pathlib import Path
 
 from md_generator.codeflow.analyzers.flow_analyzer import FlowSlice
@@ -29,6 +28,13 @@ def write_flow_mermaid(out: Path, entry_id: str, sl: FlowSlice) -> None:
         b = nid_for(v)
         labs = ed.get("labels") or []
         lab = labs[-1] if labs else ed.get("condition") or ""
+        meta: list[str] = []
+        if ed.get("recursive"):
+            meta.append("recursive")
+        if ed.get("unknown_call"):
+            meta.append("unknown_call")
+        if meta:
+            lab = f"{lab}|{','.join(meta)}" if lab else ",".join(meta)
         if lab:
             esc = str(lab).replace('"', "'")[:120]
             lines.append(f"  {a} -->|{esc}| {b}")

--- a/src/md_generator/codeflow/generators/sequence.py
+++ b/src/md_generator/codeflow/generators/sequence.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from md_generator.codeflow.analyzers.flow_analyzer import FlowSlice
+
+
+def write_sequence_mermaid(out: Path, entry_id: str, sl: FlowSlice) -> None:
+    lines: list[str] = ["sequenceDiagram", f"  participant E as {entry_id[:200]}"]
+    for u, v, ed in sl.edges:
+        ul = _safe(u)
+        vl = _safe(v)
+        lab = ""
+        if ed.get("labels"):
+            lab = str(ed["labels"][-1])[:80]
+        elif ed.get("condition"):
+            lab = str(ed["condition"])[:80]
+        arrow = f"  {ul}->>{vl}: {lab}" if lab else f"  {ul}->>{vl}: call"
+        lines.append(arrow)
+    lines.append("")
+    out.write_text("\n".join(lines), encoding="utf-8")
+
+
+def _safe(s: str) -> str:
+    return "".join(c if c.isalnum() else "_" for c in s)[:48]

--- a/src/md_generator/codeflow/generators/sequence.py
+++ b/src/md_generator/codeflow/generators/sequence.py
@@ -15,6 +15,14 @@ def write_sequence_mermaid(out: Path, entry_id: str, sl: FlowSlice) -> None:
             lab = str(ed["labels"][-1])[:80]
         elif ed.get("condition"):
             lab = str(ed["condition"])[:80]
+        meta: list[str] = []
+        if ed.get("recursive"):
+            meta.append("recursive")
+        if ed.get("unknown_call"):
+            meta.append("unknown_call")
+        if meta:
+            suf = ",".join(meta)
+            lab = f"{lab} [{suf}]" if lab else suf
         arrow = f"  {ul}->>{vl}: {lab}" if lab else f"  {ul}->>{vl}: call"
         lines.append(arrow)
     lines.append("")

--- a/src/md_generator/codeflow/graph/__init__.py
+++ b/src/md_generator/codeflow/graph/__init__.py
@@ -1,0 +1,5 @@
+from __future__ import annotations
+
+from md_generator.codeflow.graph.builder import GraphBuildResult, build_graph
+
+__all__ = ["GraphBuildResult", "build_graph"]

--- a/src/md_generator/codeflow/graph/builder.py
+++ b/src/md_generator/codeflow/graph/builder.py
@@ -5,7 +5,21 @@ from pathlib import Path
 
 import networkx as nx
 
-from md_generator.codeflow.models.ir import FileParseResult
+from md_generator.codeflow.models.ir import CallSite, FileParseResult
+
+
+def _edge_unknown_call(call: CallSite, callee_id: str) -> bool:
+    """True when the callee is not a confidently resolved static target (dynamic, unknown, proxy-style)."""
+    if call.resolution in ("unknown", "dynamic"):
+        return True
+    if str(callee_id).startswith("unknown::"):
+        return True
+    return False
+
+
+def _edge_recursive(caller_id: str, callee_id: str) -> bool:
+    """True for direct self-calls (same symbol id as caller and callee)."""
+    return caller_id == callee_id
 
 
 @dataclass(slots=True)
@@ -84,6 +98,8 @@ def build_graph(parse_results: list[FileParseResult], project_root: Path) -> Gra
 
             edge_type = "async" if call.is_async else "sync"
             cond = call.condition_label
+            unknown_call = _edge_unknown_call(call, callee_id)
+            recursive = _edge_recursive(call.caller_id, callee_id)
             if g.has_edge(call.caller_id, callee_id):
                 labs = list(g.edges[call.caller_id, callee_id].get("labels") or [])
                 if cond and cond not in labs:
@@ -91,6 +107,9 @@ def build_graph(parse_results: list[FileParseResult], project_root: Path) -> Gra
                 g.edges[call.caller_id, callee_id]["labels"] = labs
                 if cond:
                     g.edges[call.caller_id, callee_id]["condition"] = cond
+                ed = g.edges[call.caller_id, callee_id]
+                ed["unknown_call"] = bool(ed.get("unknown_call")) or unknown_call
+                ed["recursive"] = bool(ed.get("recursive")) or recursive
             else:
                 g.add_edge(
                     call.caller_id,
@@ -100,6 +119,8 @@ def build_graph(parse_results: list[FileParseResult], project_root: Path) -> Gra
                     condition=cond,
                     labels=[cond] if cond else [],
                     async_=call.is_async,
+                    unknown_call=unknown_call,
+                    recursive=recursive,
                 )
 
     return GraphBuildResult(graph=g, project_root=root)

--- a/src/md_generator/codeflow/graph/builder.py
+++ b/src/md_generator/codeflow/graph/builder.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+import networkx as nx
+
+from md_generator.codeflow.models.ir import FileParseResult
+
+
+@dataclass(slots=True)
+class GraphBuildResult:
+    graph: nx.DiGraph
+    project_root: Path
+
+
+def build_graph(parse_results: list[FileParseResult], project_root: Path) -> GraphBuildResult:
+    """Merge file-level parse results into one DiGraph with node/edge attributes."""
+    g = nx.DiGraph()
+    root = project_root.resolve()
+
+    for fr in parse_results:
+        rel_file = _safe_rel(fr.path, root)
+        for sid in fr.symbol_ids:
+            if not g.has_node(sid):
+                g.add_node(
+                    sid,
+                    id=sid,
+                    type="method",
+                    class_name=_class_from_symbol_id(sid),
+                    method_name=_method_from_symbol_id(sid),
+                    file_path=rel_file,
+                    language=fr.language,
+                )
+            else:
+                g.nodes[sid]["language"] = fr.language
+
+        for e in fr.entries:
+            fp = _safe_rel(Path(e.file_path), root) if e.file_path else rel_file
+            if g.has_node(e.symbol_id):
+                g.nodes[e.symbol_id]["entry_kind"] = e.kind.value
+                g.nodes[e.symbol_id]["entry_label"] = e.label
+                g.nodes[e.symbol_id]["type"] = "entry"
+                if fp:
+                    g.nodes[e.symbol_id]["file_path"] = fp
+            else:
+                g.add_node(
+                    e.symbol_id,
+                    id=e.symbol_id,
+                    type="entry",
+                    class_name=_class_from_symbol_id(e.symbol_id),
+                    method_name=_method_from_symbol_id(e.symbol_id),
+                    file_path=fp,
+                    language=fr.language,
+                    entry_kind=e.kind.value,
+                    entry_label=e.label,
+                )
+
+        for call in fr.calls:
+            callee_id = call.callee_hint
+            if not g.has_node(callee_id):
+                unresolved = call.resolution == "unknown" or callee_id.startswith("unknown::")
+                g.add_node(
+                    callee_id,
+                    id=callee_id,
+                    type="unknown" if unresolved else "method",
+                    class_name=_class_from_unknown_id(callee_id),
+                    method_name=_method_tail(callee_id),
+                    file_path="",
+                    language=fr.language,
+                    unresolved=unresolved,
+                )
+
+            if not g.has_node(call.caller_id):
+                g.add_node(
+                    call.caller_id,
+                    id=call.caller_id,
+                    type="method",
+                    class_name=_class_from_symbol_id(call.caller_id),
+                    method_name=_method_from_symbol_id(call.caller_id),
+                    file_path=rel_file,
+                    language=fr.language,
+                )
+
+            edge_type = "async" if call.is_async else "sync"
+            cond = call.condition_label
+            if g.has_edge(call.caller_id, callee_id):
+                labs = list(g.edges[call.caller_id, callee_id].get("labels") or [])
+                if cond and cond not in labs:
+                    labs.append(cond)
+                g.edges[call.caller_id, callee_id]["labels"] = labs
+                if cond:
+                    g.edges[call.caller_id, callee_id]["condition"] = cond
+            else:
+                g.add_edge(
+                    call.caller_id,
+                    callee_id,
+                    type=edge_type,
+                    resolution=call.resolution,
+                    condition=cond,
+                    labels=[cond] if cond else [],
+                    async_=call.is_async,
+                )
+
+    return GraphBuildResult(graph=g, project_root=root)
+
+
+def _safe_rel(path: Path, root: Path) -> str:
+    try:
+        return path.resolve().relative_to(root).as_posix()
+    except ValueError:
+        return path.as_posix()
+
+
+def _class_from_symbol_id(sid: str) -> str | None:
+    if "::" not in sid:
+        return None
+    tail = sid.split("::", 1)[1]
+    if "." in tail:
+        return tail.rsplit(".", 1)[0]
+    return None
+
+
+def _method_from_symbol_id(sid: str) -> str:
+    if "::" not in sid:
+        return sid
+    tail = sid.split("::", 1)[1]
+    if "." in tail:
+        return tail.rsplit(".", 1)[1]
+    return tail
+
+
+def _class_from_unknown_id(cid: str) -> str | None:
+    if cid.startswith("unknown::"):
+        return None
+    tail = cid.split("::")[-1] if "::" in cid else cid
+    if "." in tail:
+        return tail.rsplit(".", 1)[0]
+    return None
+
+
+def _method_tail(cid: str) -> str:
+    tail = cid.split("::")[-1] if "::" in cid else cid
+    if "." in tail:
+        return tail.rsplit(".", 1)[1]
+    return tail
+
+
+def graph_to_serializable(g: nx.DiGraph) -> dict:
+    nodes = []
+    for n, attr in g.nodes(data=True):
+        nodes.append({"id": n, **{k: v for k, v in attr.items() if k != "id"}})
+    edges = []
+    for u, v, attr in g.edges(data=True):
+        edges.append({"source": u, "target": v, **attr})
+    return {"nodes": nodes, "edges": edges}
+
+
+def export_node_link_json(g: nx.DiGraph) -> dict:
+    return nx.node_link_data(g)

--- a/src/md_generator/codeflow/ingestion/__init__.py
+++ b/src/md_generator/codeflow/ingestion/__init__.py
@@ -1,5 +1,10 @@
 from __future__ import annotations
 
-from md_generator.codeflow.ingestion.loader import LoadedWorkspace, collect_source_files, load_workspace
+from md_generator.codeflow.ingestion.loader import (
+    LoadedWorkspace,
+    collect_source_files,
+    load_workspace,
+    source_file_extensions,
+)
 
-__all__ = ["LoadedWorkspace", "collect_source_files", "load_workspace"]
+__all__ = ["LoadedWorkspace", "collect_source_files", "load_workspace", "source_file_extensions"]

--- a/src/md_generator/codeflow/ingestion/__init__.py
+++ b/src/md_generator/codeflow/ingestion/__init__.py
@@ -1,0 +1,5 @@
+from __future__ import annotations
+
+from md_generator.codeflow.ingestion.loader import LoadedWorkspace, collect_source_files, load_workspace
+
+__all__ = ["LoadedWorkspace", "collect_source_files", "load_workspace"]

--- a/src/md_generator/codeflow/ingestion/loader.py
+++ b/src/md_generator/codeflow/ingestion/loader.py
@@ -6,6 +6,12 @@ import zipfile
 from dataclasses import dataclass
 from pathlib import Path
 
+from md_generator.codeflow.lang_dispatch import (
+    MIXED_LANG_KEYS,
+    extensions_for_languages,
+    normalize_language_filter,
+)
+
 
 @dataclass(frozen=True, slots=True)
 class LoadedWorkspace:
@@ -39,17 +45,22 @@ def load_workspace(
 
 
 def collect_source_files(root: Path, languages: str) -> list[Path]:
-    exts: set[str] = set()
-    if languages in ("mixed", "python"):
-        exts.add(".py")
-    if languages in ("mixed", "java"):
-        exts.add(".java")
+    allowed = normalize_language_filter(languages)
+    exts = extensions_for_languages(allowed)
     if not exts:
-        exts = {".py", ".java"}
+        exts = extensions_for_languages(MIXED_LANG_KEYS)
     out: list[Path] = []
     for p in root.rglob("*"):
-        if p.is_file() and p.suffix.lower() in exts:
-            if "node_modules" in p.parts or ".git" in p.parts:
-                continue
-            out.append(p)
+        if not p.is_file():
+            continue
+        if p.suffix.lower() not in exts:
+            continue
+        if "node_modules" in p.parts or ".git" in p.parts or "vendor" in p.parts:
+            continue
+        out.append(p)
     return sorted(out)
+
+
+def source_file_extensions() -> frozenset[str]:
+    """All extensions the tool may treat as source when ``languages=mixed``."""
+    return frozenset(extensions_for_languages(MIXED_LANG_KEYS))

--- a/src/md_generator/codeflow/ingestion/loader.py
+++ b/src/md_generator/codeflow/ingestion/loader.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import shutil
+import tempfile
+import zipfile
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True, slots=True)
+class LoadedWorkspace:
+    root: Path
+    cleanup_dir: Path | None = None
+
+    def close(self) -> None:
+        if self.cleanup_dir and self.cleanup_dir.exists():
+            shutil.rmtree(self.cleanup_dir, ignore_errors=True)
+
+
+def _extract_zip(zip_path: Path) -> Path:
+    td = Path(tempfile.mkdtemp(prefix="codeflow-zip-"))
+    with zipfile.ZipFile(zip_path, "r") as zf:
+        zf.extractall(td)
+    return td
+
+
+def load_workspace(
+    *,
+    path: Path,
+) -> LoadedWorkspace:
+    """Return a project root. If ``path`` is a ``.zip``, extract to a temp directory."""
+    p = path.expanduser().resolve()
+    if p.is_file() and p.suffix.lower() == ".zip":
+        td = _extract_zip(p)
+        return LoadedWorkspace(root=td, cleanup_dir=td)
+    if p.is_file():
+        return LoadedWorkspace(root=p.parent, cleanup_dir=None)
+    return LoadedWorkspace(root=p, cleanup_dir=None)
+
+
+def collect_source_files(root: Path, languages: str) -> list[Path]:
+    exts: set[str] = set()
+    if languages in ("mixed", "python"):
+        exts.add(".py")
+    if languages in ("mixed", "java"):
+        exts.add(".java")
+    if not exts:
+        exts = {".py", ".java"}
+    out: list[Path] = []
+    for p in root.rglob("*"):
+        if p.is_file() and p.suffix.lower() in exts:
+            if "node_modules" in p.parts or ".git" in p.parts:
+                continue
+            out.append(p)
+    return sorted(out)

--- a/src/md_generator/codeflow/lang_dispatch.py
+++ b/src/md_generator/codeflow/lang_dispatch.py
@@ -1,0 +1,64 @@
+"""Map file extensions to parser language keys and interpret ``ScanConfig.languages``."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+# language key -> extensions scanned for that backend
+LANG_EXTENSIONS: dict[str, frozenset[str]] = {
+    "python": frozenset({".py"}),
+    "java": frozenset({".java"}),
+    "javascript": frozenset({".js", ".jsx", ".mjs", ".cjs"}),
+    "typescript": frozenset({".ts", ".mts", ".cts"}),
+    "tsx": frozenset({".tsx"}),
+    "cpp": frozenset({".c", ".h", ".cc", ".cpp", ".cxx", ".hpp", ".hh", ".hxx"}),
+    "go": frozenset({".go"}),
+    "php": frozenset({".php"}),
+}
+
+# All keys used when ``languages`` is ``mixed``
+MIXED_LANG_KEYS: frozenset[str] = frozenset(LANG_EXTENSIONS.keys())
+
+
+def normalize_language_filter(languages: str) -> frozenset[str]:
+    """Return allowed parser language keys for a scan."""
+    s = (languages or "mixed").strip().lower()
+    if s == "mixed":
+        return MIXED_LANG_KEYS
+    parts: list[str] = []
+    for p in s.split(","):
+        p = p.strip().lower()
+        if not p:
+            continue
+        if p in ("js", "javascript"):
+            parts.append("javascript")
+        elif p in ("ts", "typescript"):
+            parts.append("typescript")
+        elif p == "tsx":
+            parts.append("tsx")
+        elif p in ("c", "c++", "cxx", "cpp", "cplusplus"):
+            parts.append("cpp")
+        else:
+            parts.append(p)
+    return frozenset(parts) if parts else MIXED_LANG_KEYS
+
+
+def extensions_for_languages(allowed: frozenset[str]) -> set[str]:
+    exts: set[str] = set()
+    for lang in allowed:
+        exts |= set(LANG_EXTENSIONS.get(lang, frozenset()))
+    return exts
+
+
+def lang_for_path(path: Path) -> str:
+    suf = path.suffix.lower()
+    for lang, exts in LANG_EXTENSIONS.items():
+        if suf in exts:
+            return lang
+    return "unknown"
+
+
+def should_parse_file_lang(file_lang: str, allowed: frozenset[str]) -> bool:
+    if file_lang == "unknown":
+        return False
+    return file_lang in allowed

--- a/src/md_generator/codeflow/mcp/__init__.py
+++ b/src/md_generator/codeflow/mcp/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import annotations

--- a/src/md_generator/codeflow/mcp/server.py
+++ b/src/md_generator/codeflow/mcp/server.py
@@ -1,0 +1,42 @@
+"""Optional MCP tools (requires ``mdengine[mcp]``). Celery/Redis replacement: document only — jobs use SQLite."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from mcp.server.fastmcp import FastMCP
+
+from md_generator.codeflow.core.extractor import build_output_zip
+from md_generator.codeflow.core.run_config import ScanConfig
+
+
+def build_mcp_stack(*, mount_under_fastapi: bool = False) -> tuple[FastMCP, object]:
+    path = "/" if mount_under_fastapi else "/mcp"
+    mcp = FastMCP(
+        "codeflow-to-md",
+        instructions="Analyze Python/Java source archives into execution-flow Markdown and graphs.",
+        streamable_http_path=path,
+    )
+
+    @mcp.tool()
+    def codeflow_analyze_zip_base64(zip_base64: str, formats: str = "md,mermaid,json") -> str:
+        import base64
+        import tempfile
+
+        raw = base64.b64decode(zip_base64)
+        td = Path(tempfile.mkdtemp(prefix="codeflow-mcp-"))
+        src = td / "src"
+        src.mkdir(parents=True, exist_ok=True)
+        zpath = td / "in.zip"
+        zpath.write_bytes(raw)
+        import zipfile
+
+        with zipfile.ZipFile(zpath, "r") as zf:
+            zf.extractall(src)
+        fmts = tuple(x.strip() for x in formats.split(",") if x.strip())
+        cfg = ScanConfig(project_root=src, output_path=td / "out", formats=fmts)
+        data = build_output_zip(cfg, workspace_root=src)
+        return base64.b64encode(data).decode("ascii")
+
+    sub = mcp.streamable_http_app()
+    return mcp, sub

--- a/src/md_generator/codeflow/models/__init__.py
+++ b/src/md_generator/codeflow/models/__init__.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from md_generator.codeflow.models.ir import (
     BranchPoint,
+    BusinessRule,
     CallSite,
     EntryKind,
     EntryRecord,
@@ -11,6 +12,7 @@ from md_generator.codeflow.models.ir import (
 
 __all__ = [
     "BranchPoint",
+    "BusinessRule",
     "CallSite",
     "EntryKind",
     "EntryRecord",

--- a/src/md_generator/codeflow/models/__init__.py
+++ b/src/md_generator/codeflow/models/__init__.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from md_generator.codeflow.models.ir import (
+    BranchPoint,
+    CallSite,
+    EntryKind,
+    EntryRecord,
+    FileParseResult,
+    SymbolRef,
+)
+
+__all__ = [
+    "BranchPoint",
+    "CallSite",
+    "EntryKind",
+    "EntryRecord",
+    "FileParseResult",
+    "SymbolRef",
+]

--- a/src/md_generator/codeflow/models/ir.py
+++ b/src/md_generator/codeflow/models/ir.py
@@ -6,6 +6,23 @@ from pathlib import Path
 from typing import Literal
 
 
+RuleSource = Literal["branch", "validation", "sql_trigger", "predicate"]
+RuleConfidence = Literal["high", "medium", "low"]
+
+
+@dataclass(frozen=True, slots=True)
+class BusinessRule:
+    """Extracted business-oriented rule for documentation (not evaluated at runtime)."""
+
+    source: RuleSource
+    symbol_id: str | None
+    file_path: str
+    line: int
+    title: str
+    detail: str
+    confidence: RuleConfidence = "medium"
+
+
 class EntryKind(str, Enum):
     API_REST = "api_rest"
     MAIN = "main"
@@ -77,3 +94,4 @@ class FileParseResult:
     calls: list[CallSite] = field(default_factory=list)
     branches: list[BranchPoint] = field(default_factory=list)
     entries: list[EntryRecord] = field(default_factory=list)
+    rules: list[BusinessRule] = field(default_factory=list)

--- a/src/md_generator/codeflow/models/ir.py
+++ b/src/md_generator/codeflow/models/ir.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from pathlib import Path
+from typing import Literal
+
+
+class EntryKind(str, Enum):
+    API_REST = "api_rest"
+    MAIN = "main"
+    CLI = "cli"
+    SCHEDULER = "scheduler"
+    KAFKA = "kafka"
+    QUEUE = "queue"
+    UNKNOWN = "unknown"
+
+
+CallResolution = Literal["static", "dynamic", "unknown"]
+
+
+@dataclass(frozen=True, slots=True)
+class SymbolRef:
+    """Language-agnostic reference to a callable."""
+
+    module_path: str
+    class_name: str | None
+    method_name: str
+    file_path: str
+    language: str
+
+    def stable_id(self, project_root: Path) -> str:
+        try:
+            rel = Path(self.file_path).resolve().relative_to(project_root.resolve())
+            key = rel.as_posix()
+        except ValueError:
+            key = Path(self.file_path).as_posix()
+        if self.class_name:
+            return f"{key}::{self.class_name}.{self.method_name}"
+        return f"{key}::{self.method_name}"
+
+
+@dataclass(slots=True)
+class CallSite:
+    caller_id: str
+    callee_hint: str
+    resolution: CallResolution
+    is_async: bool
+    line: int
+    condition_label: str | None = None
+
+
+@dataclass(slots=True)
+class BranchPoint:
+    caller_id: str
+    kind: Literal["if", "else", "elif", "switch", "loop"]
+    label: str | None
+    line: int
+
+
+@dataclass(slots=True)
+class EntryRecord:
+    """Detected entry point (API handler, main, etc.)."""
+
+    symbol_id: str
+    kind: EntryKind
+    label: str
+    file_path: str
+    line: int
+
+
+@dataclass
+class FileParseResult:
+    path: Path
+    language: str
+    symbol_ids: list[str] = field(default_factory=list)
+    calls: list[CallSite] = field(default_factory=list)
+    branches: list[BranchPoint] = field(default_factory=list)
+    entries: list[EntryRecord] = field(default_factory=list)

--- a/src/md_generator/codeflow/parsers/__init__.py
+++ b/src/md_generator/codeflow/parsers/__init__.py
@@ -1,7 +1,18 @@
 from __future__ import annotations
 
 from md_generator.codeflow.parsers.base import ParserRegistry, register_defaults
+from md_generator.codeflow.parsers.cpp_parser import CppParser
+from md_generator.codeflow.parsers.go_parser import GoParser
 from md_generator.codeflow.parsers.java_parser import JavaParser
+from md_generator.codeflow.parsers.php_parser import PhpParser
 from md_generator.codeflow.parsers.python_parser import PythonParser
 
-__all__ = ["ParserRegistry", "register_defaults", "JavaParser", "PythonParser"]
+__all__ = [
+    "ParserRegistry",
+    "register_defaults",
+    "CppParser",
+    "GoParser",
+    "JavaParser",
+    "PhpParser",
+    "PythonParser",
+]

--- a/src/md_generator/codeflow/parsers/__init__.py
+++ b/src/md_generator/codeflow/parsers/__init__.py
@@ -1,0 +1,7 @@
+from __future__ import annotations
+
+from md_generator.codeflow.parsers.base import ParserRegistry, register_defaults
+from md_generator.codeflow.parsers.java_parser import JavaParser
+from md_generator.codeflow.parsers.python_parser import PythonParser
+
+__all__ = ["ParserRegistry", "register_defaults", "JavaParser", "PythonParser"]

--- a/src/md_generator/codeflow/parsers/base.py
+++ b/src/md_generator/codeflow/parsers/base.py
@@ -31,8 +31,27 @@ class ParserRegistry:
 
 
 def register_defaults(reg: ParserRegistry) -> None:
+    from md_generator.codeflow.parsers.cpp_parser import CppParser
+    from md_generator.codeflow.parsers.go_parser import GoParser
     from md_generator.codeflow.parsers.java_parser import JavaParser
+    from md_generator.codeflow.parsers.php_parser import PhpParser
     from md_generator.codeflow.parsers.python_parser import PythonParser
 
     reg.register(PythonParser())
     reg.register(JavaParser())
+    reg.register(CppParser())
+    reg.register(GoParser())
+    reg.register(PhpParser())
+    try:
+        from tree_sitter import Language
+
+        import tree_sitter_javascript as tsjs
+        import tree_sitter_typescript as tsts
+
+        from md_generator.codeflow.parsers.treesitter_js_ts_parser import TreesitterJsTsParser
+
+        reg.register(TreesitterJsTsParser("javascript", Language(tsjs.language())))
+        reg.register(TreesitterJsTsParser("typescript", Language(tsts.language_typescript())))
+        reg.register(TreesitterJsTsParser("tsx", Language(tsts.language_tsx())))
+    except ImportError:
+        pass

--- a/src/md_generator/codeflow/parsers/base.py
+++ b/src/md_generator/codeflow/parsers/base.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Protocol
+
+from md_generator.codeflow.models.ir import FileParseResult
+
+
+class LanguageParser(Protocol):
+    language: str
+
+    def parse_file(self, path: Path, project_root: Path) -> FileParseResult:
+        ...
+
+
+class ParserRegistry:
+    def __init__(self) -> None:
+        self._by_lang: dict[str, LanguageParser] = {}
+
+    def register(self, parser: LanguageParser) -> None:
+        self._by_lang[parser.language] = parser
+
+    def get(self, lang: str) -> LanguageParser | None:
+        return self._by_lang.get(lang)
+
+    def parse_file(self, path: Path, project_root: Path, lang: str) -> FileParseResult | None:
+        p = self.get(lang)
+        if not p:
+            return None
+        return p.parse_file(path, project_root)
+
+
+def register_defaults(reg: ParserRegistry) -> None:
+    from md_generator.codeflow.parsers.java_parser import JavaParser
+    from md_generator.codeflow.parsers.python_parser import PythonParser
+
+    reg.register(PythonParser())
+    reg.register(JavaParser())

--- a/src/md_generator/codeflow/parsers/cpp_parser.py
+++ b/src/md_generator/codeflow/parsers/cpp_parser.py
@@ -1,0 +1,155 @@
+"""C/C++ parsing: prefer libclang; fall back to Tree-sitter C/C++ when clang is unavailable."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+from md_generator.codeflow.models.ir import CallSite, FileParseResult
+
+logger = logging.getLogger(__name__)
+
+
+def _rel_key(path: Path, root: Path) -> str:
+    try:
+        return path.resolve().relative_to(root.resolve()).as_posix()
+    except ValueError:
+        return path.as_posix()
+
+
+def _sid(key: str, name: str) -> str:
+    return f"{key}::{name}"
+
+
+class CppParser:
+    language = "cpp"
+
+    def parse_file(self, path: Path, project_root: Path) -> FileParseResult:
+        fr = FileParseResult(path=path.resolve(), language=self.language)
+        key = _rel_key(path, project_root)
+        if self._parse_clang(path, key, fr):
+            return fr
+        if self._parse_treesitter_cpp(path, key, fr):
+            return fr
+        return fr
+
+    def _parse_clang(self, path: Path, key: str, fr: FileParseResult) -> bool:
+        try:
+            import clang.cindex as ci  # type: ignore[import-not-found]
+        except Exception as e:
+            logger.debug("clang not available: %s", e)
+            return False
+        try:
+            index = ci.Index.create()
+            if path.suffix.lower() == ".c":
+                args = ["-x", "c"]
+            else:
+                args = ["-x", "c++"]
+            tu = index.parse(str(path), args=args)
+        except Exception as e:
+            logger.debug("clang parse failed %s: %s", path, e)
+            return False
+
+        def collect_calls(body: object, caller_id: str) -> None:
+            stack = list(body.get_children())
+            while stack:
+                cur = stack.pop()
+                if cur.kind == ci.CursorKind.CALL_EXPR:
+                    callee = cur.spelling or cur.displayname or "unknown"
+                    line = int(cur.location.line) if cur.location and cur.location.file else 0
+                    fr.calls.append(
+                        CallSite(
+                            caller_id=caller_id,
+                            callee_hint=callee,
+                            resolution="dynamic",
+                            is_async=False,
+                            line=line,
+                            condition_label=None,
+                        )
+                    )
+                stack.extend(cur.get_children())
+
+        def visit(cur: object) -> None:
+            if cur.kind == ci.CursorKind.FUNCTION_DECL and cur.is_definition():
+                name = cur.spelling or "<anonymous>"
+                fid = _sid(key, name)
+                if fid not in fr.symbol_ids:
+                    fr.symbol_ids.append(fid)
+                for ch in cur.get_children():
+                    if ch.kind == ci.CursorKind.COMPOUND_STMT:
+                        collect_calls(ch, fid)
+                        break
+                return
+            for ch in cur.get_children():
+                visit(ch)
+
+        try:
+            visit(tu.cursor)
+        except Exception as e:
+            logger.debug("clang walk failed %s: %s", path, e)
+            return False
+        return bool(fr.symbol_ids or fr.calls)
+
+    def _parse_treesitter_cpp(self, path: Path, key: str, fr: FileParseResult) -> bool:
+        try:
+            import tree_sitter_cpp as tscpp
+            from tree_sitter import Language, Parser
+        except Exception as e:
+            logger.debug("tree-sitter-cpp not available: %s", e)
+            return False
+        try:
+            lang = Language(tscpp.language())
+            parser = Parser(lang)
+            source = path.read_bytes()
+            tree = parser.parse(source)
+        except Exception as e:
+            logger.debug("tree-sitter cpp parse failed %s: %s", path, e)
+            return False
+
+        def text(node: object) -> str:
+            return source[node.start_byte : node.end_byte].decode("utf-8", errors="replace")
+
+        def walk(node: object, class_name: str | None, cur_fn: str | None) -> None:
+            t = node.type
+            if t == "class_specifier":
+                nm_node = node.child_by_field_name("name")
+                nm = text(nm_node).strip() if nm_node else None
+                body = node.child_by_field_name("body")
+                if body:
+                    for ch in body.children:
+                        walk(ch, nm, cur_fn)
+                return
+            if t == "function_definition":
+                decl = node.child_by_field_name("declarator")
+                fn_name = "<fn>"
+                if decl:
+                    raw = text(decl).strip()
+                    if "(" in raw:
+                        head = raw.split("(", 1)[0].strip()
+                        fn_name = head.split()[-1] if head else fn_name
+                fid = _sid(key, f"{class_name}.{fn_name}" if class_name else fn_name)
+                if fid not in fr.symbol_ids:
+                    fr.symbol_ids.append(fid)
+                body = node.child_by_field_name("body")
+                if body:
+                    for ch in body.children:
+                        walk(ch, class_name, fid)
+                return
+            if t == "call_expression" and cur_fn:
+                fn = node.child_by_field_name("function")
+                callee = text(fn).strip() if fn else "unknown"
+                fr.calls.append(
+                    CallSite(
+                        caller_id=cur_fn,
+                        callee_hint=callee or "unknown::call",
+                        resolution="dynamic",
+                        is_async=False,
+                        line=node.start_point[0] + 1,
+                        condition_label=None,
+                    )
+                )
+            for c in node.children:
+                walk(c, class_name, cur_fn)
+
+        walk(tree.root_node, None, None)
+        return bool(fr.symbol_ids or fr.calls)

--- a/src/md_generator/codeflow/parsers/go_parser.py
+++ b/src/md_generator/codeflow/parsers/go_parser.py
@@ -1,0 +1,82 @@
+"""Go parsing via ``go/parser`` (JSON bridge in ``tools/codeflow_go_dump``)."""
+
+from __future__ import annotations
+
+import json
+import logging
+import shutil
+import subprocess
+from pathlib import Path
+
+from md_generator.codeflow.models.ir import CallSite, CallResolution, FileParseResult
+from md_generator.codeflow.utils.tools_root import find_tools_dir
+
+logger = logging.getLogger(__name__)
+
+
+def _rel_key(path: Path, root: Path) -> str:
+    try:
+        return path.resolve().relative_to(root.resolve()).as_posix()
+    except ValueError:
+        return path.as_posix()
+
+
+class GoParser:
+    language = "go"
+
+    def parse_file(self, path: Path, project_root: Path) -> FileParseResult:
+        fr = FileParseResult(path=path.resolve(), language=self.language)
+        tool = find_tools_dir("codeflow_go_dump")
+        if not tool or not (tool / "main.go").is_file():
+            logger.debug("codeflow_go_dump tool missing; skip %s", path)
+            return fr
+        if shutil.which("go") is None:
+            logger.debug("go not on PATH; skip %s", path)
+            return fr
+        rel = _rel_key(path, project_root)
+        try:
+            proc = subprocess.run(
+                ["go", "run", ".", str(path.resolve()), rel],
+                cwd=str(tool),
+                capture_output=True,
+                text=True,
+                timeout=120,
+                check=False,
+            )
+        except Exception as e:
+            logger.debug("go dump failed for %s: %s", path, e)
+            return fr
+        if proc.returncode != 0:
+            logger.debug("go dump stderr: %s", proc.stderr[:500] if proc.stderr else "")
+            return fr
+        try:
+            data = json.loads(proc.stdout)
+        except json.JSONDecodeError:
+            return fr
+        if isinstance(data, dict) and data.get("error"):
+            return fr
+        for fn in data.get("funcs", []) or []:
+            fid = fn.get("id")
+            if fid and fid not in fr.symbol_ids:
+                fr.symbol_ids.append(fid)
+            raw_calls = fn.get("calls") or []
+            if not isinstance(raw_calls, list):
+                raw_calls = []
+            for c in raw_calls:
+                callee = str(c.get("Callee") or c.get("callee") or "")
+                caller = str(c.get("Caller") or c.get("caller") or fid or "")
+                line = int(c.get("Line") or c.get("line") or 0)
+                res: CallResolution = "dynamic"
+                if "." not in callee and callee.isidentifier():
+                    res = "static"
+                fr.calls.append(
+                    CallSite(
+                        caller_id=caller,
+                        callee_hint=callee or "unknown::call",
+                        resolution=res,
+                        is_async=False,
+                        line=line,
+                        condition_label=None,
+                    )
+                )
+        return fr

--- a/src/md_generator/codeflow/parsers/java_parser.py
+++ b/src/md_generator/codeflow/parsers/java_parser.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import javalang.tree
+
+from md_generator.codeflow.models.ir import CallSite, CallResolution, EntryKind, EntryRecord, FileParseResult
+
+
+def _rel_key(path: Path, root: Path) -> str:
+    try:
+        return path.resolve().relative_to(root.resolve()).as_posix()
+    except ValueError:
+        return path.as_posix()
+
+
+def _sid(key: str, cls: str, method: str) -> str:
+    return f"{key}::{cls}.{method}"
+
+
+def _iter_javalang_tree(node: object):
+    """Depth-first iteration over javalang.tree nodes reachable from a statement/expression."""
+    stack: list[object] = [node]
+    seen: set[int] = set()
+    while stack:
+        n = stack.pop()
+        i = id(n)
+        if i in seen:
+            continue
+        seen.add(i)
+        yield n
+        attrs = getattr(n, "attrs", None)
+        if not attrs:
+            continue
+        for name in attrs:
+            val = getattr(n, name, None)
+            if val is None:
+                continue
+            if isinstance(val, list):
+                for x in val:
+                    if x is not None and getattr(type(x), "__module__", "") == javalang.tree.__name__:
+                        stack.append(x)
+            elif getattr(type(val), "__module__", "") == javalang.tree.__name__:
+                stack.append(val)
+
+
+class JavaParser:
+    language = "java"
+
+    def parse_file(self, path: Path, project_root: Path) -> FileParseResult:
+        import javalang
+        from javalang.tree import MethodDeclaration, MethodInvocation
+
+        root = project_root.resolve()
+        key = _rel_key(path, root)
+        text = path.read_text(encoding="utf-8", errors="replace")
+        fr = FileParseResult(path=path.resolve(), language=self.language)
+
+        try:
+            tree = javalang.parse.parse(text)
+        except Exception:
+            return fr
+
+        for t in tree.types or []:
+            cls_name = getattr(t, "name", None)
+            if not cls_name:
+                continue
+            for m in getattr(t, "methods", None) or []:
+                if not isinstance(m, MethodDeclaration):
+                    continue
+                caller = _sid(key, cls_name, m.name)
+                fr.symbol_ids.append(caller)
+                body = m.body or []
+                for node in body:
+                    for sub in _iter_javalang_tree(node):
+                        if isinstance(sub, MethodInvocation):
+                            callee = self._format_invocation(sub)
+                            pos = getattr(sub, "position", None)
+                            line = int(getattr(pos, "line", 0) or 0) if pos else 0
+                            fr.calls.append(
+                                CallSite(
+                                    caller_id=caller,
+                                    callee_hint=callee,
+                                    resolution=self._resolution_for_invocation(sub),
+                                    is_async=False,
+                                    line=line,
+                                    condition_label=None,
+                                )
+                            )
+
+                ann_text = " ".join(str(getattr(a, "name", a)) for a in (getattr(m, "annotations", None) or []))
+                if "KafkaListener" in ann_text or "kafka" in ann_text.lower():
+                    pos = getattr(m, "position", None)
+                    line = int(getattr(pos, "line", 0) or 0) if pos else 0
+                    fr.entries.append(
+                        EntryRecord(
+                            symbol_id=caller,
+                            kind=EntryKind.KAFKA,
+                            label="Kafka listener",
+                            file_path=str(path.resolve()),
+                            line=line,
+                        )
+                    )
+
+        return fr
+
+    def _format_invocation(self, expr: object) -> str:
+        qual = getattr(expr, "qualifier", None) or ""
+        member = getattr(expr, "member", "") or ""
+        if qual:
+            return f"{qual}.{member}"
+        return member or "unknown"
+
+    def _resolution_for_invocation(self, expr: object) -> CallResolution:
+        qual = getattr(expr, "qualifier", None) or ""
+        return "static" if qual else "dynamic"

--- a/src/md_generator/codeflow/parsers/php_parser.py
+++ b/src/md_generator/codeflow/parsers/php_parser.py
@@ -1,0 +1,79 @@
+"""PHP parsing via nikic/php-parser (JSON bridge in ``tools/codeflow_php_dump``)."""
+
+from __future__ import annotations
+
+import json
+import logging
+import shutil
+import subprocess
+from pathlib import Path
+
+from md_generator.codeflow.models.ir import CallSite, CallResolution, FileParseResult
+from md_generator.codeflow.utils.tools_root import find_tools_dir
+
+logger = logging.getLogger(__name__)
+
+
+def _rel_key(path: Path, root: Path) -> str:
+    try:
+        return path.resolve().relative_to(root.resolve()).as_posix()
+    except ValueError:
+        return path.as_posix()
+
+
+class PhpParser:
+    language = "php"
+
+    def parse_file(self, path: Path, project_root: Path) -> FileParseResult:
+        fr = FileParseResult(path=path.resolve(), language=self.language)
+        tool = find_tools_dir("codeflow_php_dump")
+        if not tool or not (tool / "dump.php").is_file():
+            logger.debug("codeflow_php_dump missing; skip %s", path)
+            return fr
+        php = shutil.which("php")
+        if php is None:
+            logger.debug("php not on PATH; skip %s", path)
+            return fr
+        rel = _rel_key(path, project_root)
+        script = tool / "dump.php"
+        try:
+            proc = subprocess.run(
+                [php, str(script), str(path.resolve()), rel],
+                cwd=str(tool),
+                capture_output=True,
+                text=True,
+                timeout=120,
+                check=False,
+            )
+        except Exception as e:
+            logger.debug("php dump failed for %s: %s", path, e)
+            return fr
+        if proc.returncode != 0:
+            logger.debug("php dump stderr: %s", (proc.stderr or "")[:500])
+            return fr
+        try:
+            data = json.loads(proc.stdout)
+        except json.JSONDecodeError:
+            return fr
+        if isinstance(data, dict) and data.get("error"):
+            return fr
+        for fn in data.get("funcs", []) or []:
+            fid = fn.get("id")
+            if fid and fid not in fr.symbol_ids:
+                fr.symbol_ids.append(fid)
+            for c in fn.get("calls", []) or []:
+                callee = str(c.get("callee") or "")
+                caller = str(c.get("caller") or fid or "")
+                line = int(c.get("line") or 0)
+                res: CallResolution = "static" if callee.isidentifier() else "dynamic"
+                fr.calls.append(
+                    CallSite(
+                        caller_id=caller,
+                        callee_hint=callee or "unknown::call",
+                        resolution=res,
+                        is_async=False,
+                        line=line,
+                        condition_label=None,
+                    )
+                )
+        return fr

--- a/src/md_generator/codeflow/parsers/python_parser.py
+++ b/src/md_generator/codeflow/parsers/python_parser.py
@@ -1,0 +1,295 @@
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+from md_generator.codeflow.models.ir import CallSite, CallResolution, EntryKind, EntryRecord, FileParseResult
+
+
+def _rel_key(path: Path, root: Path) -> str:
+    try:
+        return path.resolve().relative_to(root.resolve()).as_posix()
+    except ValueError:
+        return path.as_posix()
+
+
+def _sid(key: str, cls: str | None, name: str) -> str:
+    if cls:
+        return f"{key}::{cls}.{name}"
+    return f"{key}::{name}"
+
+
+def _collect_defined_functions(tree: ast.Module) -> set[tuple[str | None, str]]:
+    found: set[tuple[str | None, str]] = set()
+
+    def from_class(cls: ast.ClassDef) -> None:
+        for n in cls.body:
+            if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                found.add((cls.name, n.name))
+
+    for node in tree.body:
+        if isinstance(node, ast.ClassDef):
+            from_class(node)
+        elif isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            found.add((None, node.name))
+    return found
+
+
+class PythonParser:
+    language = "python"
+
+    def parse_file(self, path: Path, project_root: Path) -> FileParseResult:
+        root = project_root.resolve()
+        key = _rel_key(path, root)
+        text = path.read_text(encoding="utf-8", errors="replace")
+        tree = ast.parse(text, filename=str(path))
+        fr = FileParseResult(path=path.resolve(), language=self.language)
+
+        imports: dict[str, str] = {}
+        self._gather_imports(tree, imports)
+        defined = _collect_defined_functions(tree)
+
+        visitor = _MethodVisitor(
+            file_key=key,
+            imports=imports,
+            defined=defined,
+            fr=fr,
+            path=str(path.resolve()),
+        )
+        visitor.walk_module(tree)
+
+        fr.entries.extend(self._detect_main_guard(tree, key, path))
+        fr.entries.extend(self._detect_cli(tree, key, path))
+
+        return fr
+
+    def _gather_imports(self, tree: ast.AST, imports: dict[str, str]) -> None:
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                for alias in node.names:
+                    imports[alias.asname or alias.name.split(".")[0]] = alias.name
+            elif isinstance(node, ast.ImportFrom):
+                mod = node.module or ""
+                for alias in node.names:
+                    nm = alias.name
+                    imports[alias.asname or nm] = f"{mod}.{nm}" if mod else nm
+
+    def _is_main_guard(self, node: ast.If) -> bool:
+        try:
+            g = ast.unparse(node.test)
+        except Exception:
+            return False
+        return g.replace(" ", "") in (
+            '__name__=="__main__"',
+            "__name__=='__main__'",
+        )
+
+    def _detect_main_guard(self, tree: ast.Module, key: str, path: Path) -> list[EntryRecord]:
+        out: list[EntryRecord] = []
+        for node in tree.body:
+            if isinstance(node, ast.If) and self._is_main_guard(node):
+                out.append(
+                    EntryRecord(
+                        symbol_id=_sid(key, None, "__main__"),
+                        kind=EntryKind.MAIN,
+                        label="Python __main__ guard",
+                        file_path=str(path.resolve()),
+                        line=node.lineno,
+                    )
+                )
+                break
+        return out
+
+    def _detect_cli(self, tree: ast.Module, key: str, path: Path) -> list[EntryRecord]:
+        hits: list[EntryRecord] = []
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Call):
+                func = node.func
+                name = ""
+                if isinstance(func, ast.Name):
+                    name = func.id
+                elif isinstance(func, ast.Attribute):
+                    name = func.attr
+                if name == "ArgumentParser":
+                    hits.append(
+                        EntryRecord(
+                            symbol_id=_sid(key, None, "cli"),
+                            kind=EntryKind.CLI,
+                            label="argparse CLI",
+                            file_path=str(path.resolve()),
+                            line=node.lineno,
+                        )
+                    )
+                    break
+        return hits
+
+
+class _MethodVisitor:
+    def __init__(
+        self,
+        *,
+        file_key: str,
+        imports: dict[str, str],
+        defined: set[tuple[str | None, str]],
+        fr: FileParseResult,
+        path: str,
+    ) -> None:
+        self.file_key = file_key
+        self.imports = imports
+        self.defined = defined
+        self.fr = fr
+        self.path = path
+        self.class_stack: list[str] = []
+        self.branch_stack: list[str | None] = []
+
+    def walk_module(self, tree: ast.Module) -> None:
+        for node in tree.body:
+            if isinstance(node, ast.ClassDef):
+                self._visit_class(node)
+            elif isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                self._visit_function(node, None)
+
+    def _visit_class(self, cls: ast.ClassDef) -> None:
+        self.class_stack.append(cls.name)
+        for node in cls.body:
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                self._visit_function(node, cls.name)
+            elif isinstance(node, ast.ClassDef):
+                self._visit_class(node)
+        self.class_stack.pop()
+
+    def _visit_function(self, fn: ast.FunctionDef | ast.AsyncFunctionDef, outer_class: str | None) -> None:
+        cls = outer_class if outer_class is not None else (self.class_stack[-1] if self.class_stack else None)
+        name = fn.name
+        caller = _sid(self.file_key, cls, name)
+        if caller not in self.fr.symbol_ids:
+            self.fr.symbol_ids.append(caller)
+
+        is_async = isinstance(fn, ast.AsyncFunctionDef)
+        self._walk_body(fn.body, caller, is_async)
+
+    def _walk_body(self, nodes: list[ast.stmt], caller: str, is_async_fn: bool) -> None:
+        for st in nodes:
+            self._walk_stmt(st, caller, is_async_fn)
+
+    def _walk_stmt(self, st: ast.stmt, caller: str, is_async_fn: bool) -> None:
+        if isinstance(st, ast.If):
+            lbl = self._if_label(st)
+            self.branch_stack.append(lbl)
+            for sub in st.body:
+                self._walk_stmt(sub, caller, is_async_fn)
+            self.branch_stack.pop()
+            self.branch_stack.append(f"else(L{st.lineno})")
+            for sub in st.orelse:
+                self._walk_stmt(sub, caller, is_async_fn)
+            self.branch_stack.pop()
+            return
+        if isinstance(st, (ast.For, ast.While)):
+            self.branch_stack.append(f"loop(L{st.lineno})")
+            for sub in st.body:
+                self._walk_stmt(sub, caller, is_async_fn)
+            self.branch_stack.pop()
+            return
+        if isinstance(st, ast.Try):
+            for sub in st.body:
+                self._walk_stmt(sub, caller, is_async_fn)
+            for h in st.handlers:
+                self.branch_stack.append(f"except(L{h.lineno})")
+                for sub in h.body:
+                    self._walk_stmt(sub, caller, is_async_fn)
+                self.branch_stack.pop()
+            for sub in st.finalbody:
+                self._walk_stmt(sub, caller, is_async_fn)
+            return
+        if isinstance(st, ast.With):
+            for sub in st.body:
+                self._walk_stmt(sub, caller, is_async_fn)
+            return
+        if isinstance(st, (ast.Assign, ast.AnnAssign, ast.AugAssign)):
+            value = getattr(st, "value", None)
+            if isinstance(value, ast.expr):
+                self._visit_expr(value, caller, is_async_fn)
+            return
+        if isinstance(st, ast.Expr):
+            self._visit_expr(st.value, caller, is_async_fn)
+            return
+        if isinstance(st, ast.Return) and st.value:
+            self._visit_expr(st.value, caller, is_async_fn)
+            return
+        if isinstance(st, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            cls = self.class_stack[-1] if self.class_stack else None
+            self._visit_function(st, cls)
+            return
+        if isinstance(st, ast.ClassDef):
+            self._visit_class(st)
+            return
+
+    def _visit_expr(self, expr: ast.expr, caller: str, is_async_fn: bool) -> None:
+        if isinstance(expr, ast.Call):
+            self._visit_call(expr, caller, is_async_fn)
+            for a in expr.args:
+                self._visit_expr(a, caller, is_async_fn)
+            for kw in expr.keywords:
+                if kw.value:
+                    self._visit_expr(kw.value, caller, is_async_fn)
+            return
+        if isinstance(expr, ast.Await):
+            if isinstance(expr.value, ast.Call):
+                self._visit_call(expr.value, caller, True)
+            else:
+                self._visit_expr(expr.value, caller, is_async_fn)
+            return
+        if isinstance(expr, ast.Lambda):
+            self._visit_expr(expr.body, caller, is_async_fn)
+            return
+        for sub in ast.iter_child_nodes(expr):
+            if isinstance(sub, ast.expr):
+                self._visit_expr(sub, caller, is_async_fn)
+
+    def _if_label(self, node: ast.If) -> str:
+        try:
+            t = ast.unparse(node.test)
+            t = t.replace("\n", " ")
+            if len(t) > 80:
+                t = t[:77] + "..."
+            return f"if({t})"
+        except Exception:
+            return f"if(L{node.lineno})"
+
+    def _visit_call(self, node: ast.Call, caller: str, is_async_fn: bool) -> None:
+        callee, res = self._resolve_callee(node.func)
+        cond = self.branch_stack[-1] if self.branch_stack else None
+        line = getattr(node, "lineno", 0) or 0
+        self.fr.calls.append(
+            CallSite(
+                caller_id=caller,
+                callee_hint=callee,
+                resolution=res if res in ("static", "dynamic", "unknown") else "unknown",
+                is_async=is_async_fn,
+                line=line,
+                condition_label=cond,
+            )
+        )
+
+    def _resolve_callee(self, func: ast.expr) -> tuple[str, CallResolution]:
+        if isinstance(func, ast.Name):
+            hint = func.id
+            cls = self.class_stack[-1] if self.class_stack else None
+            if (cls, hint) in self.defined:
+                return _sid(self.file_key, cls, hint), "static"
+            if (None, hint) in self.defined:
+                return _sid(self.file_key, None, hint), "static"
+            return f"unknown::{hint}", "unknown"
+        if isinstance(func, ast.Attribute):
+            attr = func.attr
+            base = func.value
+            if isinstance(base, ast.Name) and base.id == "self" and self.class_stack:
+                return _sid(self.file_key, self.class_stack[-1], attr), "static"
+            try:
+                return ast.unparse(func).replace(" ", ""), "dynamic"
+            except Exception:
+                return f"unknown::{attr}", "unknown"
+        try:
+            return ast.unparse(func), "dynamic"
+        except Exception:
+            return "unknown::expr", "unknown"

--- a/src/md_generator/codeflow/parsers/treesitter_js_ts_parser.py
+++ b/src/md_generator/codeflow/parsers/treesitter_js_ts_parser.py
@@ -1,0 +1,119 @@
+"""JavaScript / TypeScript / TSX parsing via Tree-sitter."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+from tree_sitter import Language, Node, Parser
+
+from md_generator.codeflow.models.ir import CallSite, CallResolution, FileParseResult
+
+logger = logging.getLogger(__name__)
+
+
+def _rel_key(path: Path, root: Path) -> str:
+    try:
+        return path.resolve().relative_to(root.resolve()).as_posix()
+    except ValueError:
+        return path.as_posix()
+
+
+def _text(source: bytes, node: Node | None) -> str:
+    if node is None:
+        return ""
+    return source[node.start_byte : node.end_byte].decode("utf-8", errors="replace")
+
+
+def _sid(key: str, cls: str | None, name: str) -> str:
+    if cls:
+        return f"{key}::{cls}.{name}"
+    return f"{key}::{name}"
+
+
+def _call_resolution(callee: str) -> CallResolution:
+    c = callee.strip().replace(" ", "")
+    if c.isidentifier():
+        return "static"
+    if "." in c and all(part.isidentifier() for part in c.split(".") if part):
+        return "static"
+    return "dynamic"
+
+
+class TreesitterJsTsParser:
+    """Parses ``.js``/``.jsx``/``.mjs`` or ``.ts``/``.mts`` or ``.tsx`` using Tree-sitter."""
+
+    def __init__(self, language_key: str, language: Language) -> None:
+        self.language = language_key
+        self._language = language
+
+    def parse_file(self, path: Path, project_root: Path) -> FileParseResult:
+        fr = FileParseResult(path=path.resolve(), language=self.language)
+        source = path.read_bytes()
+        parser = Parser(self._language)
+        tree = parser.parse(source)
+        if tree.root_node.has_error:
+            logger.debug("tree-sitter parse has errors: %s", path)
+        key = _rel_key(path, project_root)
+        self._walk(tree.root_node, source, key, fr, class_name=None, current_fn=None)
+        return fr
+
+    def _walk(
+        self,
+        node: Node,
+        source: bytes,
+        file_key: str,
+        fr: FileParseResult,
+        *,
+        class_name: str | None,
+        current_fn: str | None,
+    ) -> None:
+        t = node.type
+        if t == "class_declaration":
+            nm = _text(source, node.child_by_field_name("name")).strip() or "anon"
+            body = node.child_by_field_name("body")
+            if body:
+                for ch in body.children:
+                    self._walk(ch, source, file_key, fr, class_name=nm, current_fn=current_fn)
+            return
+        if t in ("function_declaration", "method_definition", "generator_function_declaration"):
+            name_node = node.child_by_field_name("name")
+            raw_name = _text(source, name_node).strip() if name_node else ""
+            nm = raw_name or "<anonymous>"
+            fid = _sid(file_key, class_name, nm)
+            if fid not in fr.symbol_ids:
+                fr.symbol_ids.append(fid)
+            body = node.child_by_field_name("body")
+            if body:
+                for ch in body.children:
+                    self._walk(ch, source, file_key, fr, class_name=class_name, current_fn=fid)
+            return
+        if t == "arrow_function":
+            fid = _sid(file_key, class_name, "<arrow>")
+            if fid not in fr.symbol_ids:
+                fr.symbol_ids.append(fid)
+            body = node.child_by_field_name("body")
+            if body and body.type == "statement_block":
+                for ch in body.children:
+                    self._walk(ch, source, file_key, fr, class_name=class_name, current_fn=fid)
+            elif body:
+                self._walk(body, source, file_key, fr, class_name=class_name, current_fn=fid)
+            return
+        if t == "call_expression" and current_fn:
+            fn = node.child_by_field_name("function")
+            callee = _text(source, fn).strip().replace("\n", " ")
+            if len(callee) > 200:
+                callee = callee[:197] + "..."
+            line = node.start_point[0] + 1
+            fr.calls.append(
+                CallSite(
+                    caller_id=current_fn,
+                    callee_hint=callee if callee else "unknown::call",
+                    resolution=_call_resolution(callee) if callee else "unknown",
+                    is_async=False,
+                    line=line,
+                    condition_label=None,
+                )
+            )
+        for c in node.children:
+            self._walk(c, source, file_key, fr, class_name=class_name, current_fn=current_fn)

--- a/src/md_generator/codeflow/rules/__init__.py
+++ b/src/md_generator/codeflow/rules/__init__.py
@@ -1,0 +1,5 @@
+"""Business-rule extraction for codeflow documentation."""
+
+from md_generator.codeflow.rules.collector import collect_business_rules
+
+__all__ = ["collect_business_rules"]

--- a/src/md_generator/codeflow/rules/collector.py
+++ b/src/md_generator/codeflow/rules/collector.py
@@ -1,0 +1,284 @@
+"""Collect ``BusinessRule`` rows from slice edges, Python AST, optional SQL, and parser-emitted rules."""
+
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+
+import networkx as nx
+
+from md_generator.codeflow.analyzers.flow_analyzer import FlowSlice
+from md_generator.codeflow.core.run_config import ScanConfig
+from md_generator.codeflow.models.ir import BusinessRule, FileParseResult
+from md_generator.codeflow.parsers.python_parser import _rel_key
+
+
+def _sid_py(file_key: str, class_name: str | None, method_name: str) -> str:
+    if class_name:
+        return f"{file_key}::{class_name}.{method_name}"
+    return f"{file_key}::{method_name}"
+
+
+def _dedupe_key(r: BusinessRule) -> tuple:
+    return (r.source, r.file_path, r.line, r.title, r.detail[:120])
+
+
+def dedupe_rules(rules: list[BusinessRule]) -> list[BusinessRule]:
+    seen: set[tuple] = set()
+    out: list[BusinessRule] = []
+    for r in rules:
+        k = _dedupe_key(r)
+        if k in seen:
+            continue
+        seen.add(k)
+        out.append(r)
+    return out
+
+
+def _rules_from_slice_edges(sl: FlowSlice, g: nx.DiGraph) -> list[BusinessRule]:
+    rules: list[BusinessRule] = []
+    seen: set[tuple[str, str, str]] = set()
+    for u, v, ed in sl.edges:
+        cond = ed.get("condition") or ""
+        labs = ed.get("labels") or []
+        lab = (labs[-1] if labs else None) or cond
+        if not lab:
+            continue
+        key = (u, v, str(lab))
+        if key in seen:
+            continue
+        seen.add(key)
+        fp_u = g.nodes[u].get("file_path", "") if u in g else ""
+        ln = int(ed.get("line", 0) or g.nodes[u].get("line", 0) or 0) or 1
+        title = f"Branch predicate: `{u}` → `{v}`"
+        rules.append(
+            BusinessRule(
+                source="predicate",
+                symbol_id=u,
+                file_path=str(fp_u or ""),
+                line=ln,
+                title=title,
+                detail=str(lab),
+                confidence="high",
+            ),
+        )
+    return rules
+
+
+def _decorator_name(d: ast.expr) -> str | None:
+    if isinstance(d, ast.Name):
+        return d.id
+    if isinstance(d, ast.Attribute):
+        return d.attr
+    if isinstance(d, ast.Call):
+        return _decorator_name(d.func)
+    return None
+
+
+_VALIDATION_DECORATORS = frozenset(
+    {
+        "validator",
+        "field_validator",
+        "root_validator",
+        "model_validator",
+        "validate",
+    },
+)
+
+
+def _extract_python_method_rules(
+    path: Path,
+    project_root: Path,
+    target_sids: set[str],
+) -> list[BusinessRule]:
+    rules: list[BusinessRule] = []
+    key = _rel_key(path, project_root)
+    text = path.read_text(encoding="utf-8", errors="replace")
+    try:
+        tree = ast.parse(text, filename=str(path))
+    except SyntaxError:
+        return rules
+
+    def handle_function(
+        node: ast.FunctionDef | ast.AsyncFunctionDef,
+        class_name: str | None,
+    ) -> None:
+        sid = _sid_py(key, class_name, node.name)
+        if sid not in target_sids:
+            return
+        fp = str(path.resolve())
+        for dec in node.decorator_list:
+            nm = _decorator_name(dec)
+            if nm and nm in _VALIDATION_DECORATORS:
+                try:
+                    snippet = ast.unparse(dec)[:200]
+                except Exception:
+                    snippet = nm
+                rules.append(
+                    BusinessRule(
+                        source="validation",
+                        symbol_id=sid,
+                        file_path=fp,
+                        line=node.lineno,
+                        title=f"Validation decorator `{nm}`",
+                        detail=snippet,
+                        confidence="medium",
+                    ),
+                )
+        for child in ast.walk(node):
+            if isinstance(child, ast.Assert) and child.lineno:
+                try:
+                    det = ast.unparse(child.test)[:300]
+                except Exception:
+                    det = "assert …"
+                rules.append(
+                    BusinessRule(
+                        source="validation",
+                        symbol_id=sid,
+                        file_path=fp,
+                        line=child.lineno,
+                        title="Assert",
+                        detail=det,
+                        confidence="low",
+                    ),
+                )
+            if isinstance(child, ast.Raise) and child.lineno:
+                try:
+                    det = ast.unparse(child.exc)[:300] if child.exc else "raise"
+                except Exception:
+                    det = "raise …"
+                exc_name = ""
+                if child.exc and isinstance(child.exc, ast.Call) and isinstance(child.exc.func, ast.Name):
+                    exc_name = child.exc.func.id
+                if exc_name in ("ValueError", "TypeError", "RuntimeError", "KeyError", "AttributeError"):
+                    rules.append(
+                        BusinessRule(
+                            source="validation",
+                            symbol_id=sid,
+                            file_path=fp,
+                            line=child.lineno,
+                            title=f"Raise {exc_name}",
+                            detail=det,
+                            confidence="low",
+                        ),
+                    )
+
+    for mod_child in tree.body:
+        if isinstance(mod_child, ast.ClassDef):
+            for body in mod_child.body:
+                if isinstance(body, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                    handle_function(body, mod_child.name)
+        elif isinstance(mod_child, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            handle_function(mod_child, None)
+    return rules
+
+
+_CREATE_TRIGGER_RE = re.compile(r"\bCREATE\s+TRIGGER\b", re.IGNORECASE)
+
+
+def _extract_sql_trigger_lines(path: Path) -> list[BusinessRule]:
+    rules: list[BusinessRule] = []
+    text = path.read_text(encoding="utf-8", errors="replace")
+    fp = str(path.resolve())
+    for i, line in enumerate(text.splitlines(), start=1):
+        if _CREATE_TRIGGER_RE.search(line):
+            title = "SQL trigger"
+            stripped = line.strip()[:500]
+            rules.append(
+                BusinessRule(
+                    source="sql_trigger",
+                    symbol_id=None,
+                    file_path=fp,
+                    line=i,
+                    title=title,
+                    detail=stripped,
+                    confidence="medium",
+                ),
+            )
+    return rules
+
+
+def _slice_nodes_by_file(sl: FlowSlice, g: nx.DiGraph) -> dict[str, set[str]]:
+    by_file: dict[str, set[str]] = {}
+    for sid in sl.nodes:
+        if sid not in g:
+            continue
+        fp = g.nodes[sid].get("file_path")
+        if not fp:
+            continue
+        by_file.setdefault(str(fp), set()).add(sid)
+    return by_file
+
+
+def _iter_sql_paths(project_root: Path, paths_override: list[Path] | None) -> list[Path]:
+    root = project_root.resolve()
+    paths: list[Path] = []
+    if paths_override:
+        bases = {p.resolve().parent if p.is_file() else p.resolve() for p in paths_override}
+        for b in bases:
+            if b.exists():
+                paths.extend(b.rglob("*.sql"))
+    else:
+        paths.extend(root.rglob("*.sql"))
+    # cap for safety
+    uniq: dict[str, Path] = {}
+    for p in paths:
+        try:
+            uniq[p.resolve().as_posix()] = p
+        except OSError:
+            continue
+    return list(uniq.values())[:300]
+
+
+def collect_business_rules(
+    _entry_id: str,
+    sl: FlowSlice,
+    g: nx.DiGraph,
+    parse_results: list[FileParseResult],
+    cfg: ScanConfig,
+    *,
+    project_root: Path,
+) -> list[BusinessRule]:
+    """Gather rules scoped to the flow slice (plus optional workspace SQL when enabled)."""
+    if not cfg.business_rules:
+        return []
+
+    rules: list[BusinessRule] = []
+
+    for fr in parse_results:
+        rules.extend(fr.rules)
+
+    rules.extend(_rules_from_slice_edges(sl, g))
+
+    by_file = _slice_nodes_by_file(sl, g)
+    pr_by_key = {_rel_key(fr.path, project_root): fr for fr in parse_results}
+
+    for rel_fp, sids in by_file.items():
+        fr = pr_by_key.get(rel_fp)
+        if not fr or fr.language != "python":
+            continue
+        rules.extend(_extract_python_method_rules(fr.path, project_root, sids))
+
+    for bp in (b for fr in parse_results for b in fr.branches):
+        if bp.caller_id not in sl.nodes:
+            continue
+        fp = g.nodes[bp.caller_id].get("file_path", "") if bp.caller_id in g else ""
+        lab = bp.label or bp.kind
+        rules.append(
+            BusinessRule(
+                source="branch",
+                symbol_id=bp.caller_id,
+                file_path=str(fp or ""),
+                line=bp.line,
+                title=f"Branch ({bp.kind})",
+                detail=str(lab),
+                confidence="medium",
+            ),
+        )
+
+    if cfg.business_rules_sql:
+        for sql_path in _iter_sql_paths(project_root, cfg.paths_override):
+            rules.extend(_extract_sql_trigger_lines(sql_path))
+
+    return dedupe_rules(rules)

--- a/src/md_generator/codeflow/runtime/__init__.py
+++ b/src/md_generator/codeflow/runtime/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import annotations

--- a/src/md_generator/codeflow/runtime/tracer.py
+++ b/src/md_generator/codeflow/runtime/tracer.py
@@ -1,0 +1,14 @@
+"""Optional runtime tracing (Python ``sys.settrace``). Future: Java agent, Node async_hooks."""
+
+from __future__ import annotations
+
+from typing import Callable
+
+
+def trace_python_calls(
+    target: Callable[..., object],
+    *args: object,
+    **kwargs: object,
+) -> None:
+    """Placeholder: execute ``target`` without tracing until explicitly implemented."""
+    target(*args, **kwargs)

--- a/src/md_generator/codeflow/utils/__init__.py
+++ b/src/md_generator/codeflow/utils/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import annotations

--- a/src/md_generator/codeflow/utils/tools_root.py
+++ b/src/md_generator/codeflow/utils/tools_root.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def find_tools_dir(name: str) -> Path | None:
+    """Locate ``tools/<name>/`` by walking up from this package."""
+    here = Path(__file__).resolve()
+    for anc in here.parents:
+        cand = anc / "tools" / name
+        if cand.is_dir():
+            return cand
+    return None

--- a/src/md_generator/engine_cli.py
+++ b/src/md_generator/engine_cli.py
@@ -7,7 +7,7 @@ def main(argv: list[str] | None = None) -> int:
     argv = list(sys.argv[1:] if argv is None else argv)
     if len(argv) < 1:
         print(
-            "Usage: mdengine db-to-md ... | mdengine graph-to-md ... | mdengine openapi-to-md generate ...",
+            "Usage: mdengine db-to-md ... | mdengine graph-to-md ... | mdengine openapi-to-md generate ... | mdengine codeflow-to-md scan ...",
             file=sys.stderr,
         )
         return 2
@@ -23,8 +23,12 @@ def main(argv: list[str] | None = None) -> int:
         from md_generator.openapi.cli.main import main as openapi_main
 
         return openapi_main(argv[1:])
+    if argv[0] == "codeflow-to-md":
+        from md_generator.codeflow.cli.main import main as cf_main
+
+        return cf_main(argv[1:])
     print(
-        "Usage: mdengine db-to-md ... | mdengine graph-to-md ... | mdengine openapi-to-md generate ...",
+        "Usage: mdengine db-to-md ... | mdengine graph-to-md ... | mdengine openapi-to-md generate ... | mdengine codeflow-to-md scan ...",
         file=sys.stderr,
     )
     return 2


### PR DESCRIPTION
## Summary

Adds **codeflow-to-md**: analyze **multi-language** sources and emit **Markdown** documentation plus **diagrams** (execution / control-flow views) using **AST**-based parsing and **runtime**-oriented flow extraction where applicable. Surfaces the feature through **`md-codeflow`**, **`md-codeflow-api`**, and **`md-codeflow-mcp`** (and alias console script **`codeflow`**), consistent with other **mdengine** modules.

Closes #18

## What’s included

- **Library:** `md_generator.codeflow.*` — pipeline from source → structured docs (Markdown, Mermaid / graph artifacts, JSON summaries as implemented in this branch).
- **Optional extras (from `pyproject.toml`):**
  - **`codeflow`** — `networkx`, `javalang` (baseline stack).
  - **`codeflow-treesitter`** — Tree-sitter grammars for JS/TS/C++-style parsing.
  - **`codeflow-clang`** — `clang` bindings for C/C++ AST paths when enabled.
- **CLI:** `md-codeflow` / `codeflow` → `md_generator.codeflow.cli.main:main`
- **HTTP API:** `md-codeflow-api` → `md_generator.codeflow.api.run:main`
- **MCP:** `md-codeflow-mcp` → `md_generator.codeflow.api.mcp_server:main`
- **Tests:** `codeflow-to-md/tests/` (pytest `testpaths`).

## Install (local / dev)

```bash
pip install -e ".[codeflow]"
# Optional parsers:
pip install -e ".[codeflow-treesitter]"
pip install -e ".[codeflow-clang]"
```
From PyPI after release:

```bash
pip install "mdengine[codeflow]"
```
How to verify

```bash
md-codeflow --help
# Run against a small fixture or sample repo path per README
```
