### PR TITLE
docs: MkDocs Material site, CI, and optional docs extra

### DIFF
--- a/.github/workflows/docs-pr-preview.yml
+++ b/.github/workflows/docs-pr-preview.yml
@@ -1,0 +1,34 @@
+name: Documentation Preview
+
+on:
+  pull_request:
+    paths:
+      - "docs/**"
+      - "mkdocs.yml"
+      - "pyproject.toml"
+      - ".github/workflows/docs*.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  build-preview:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install documentation dependencies
+        run: |
+          python -m pip install -U pip
+          pip install -e ".[docs]"
+      - name: Build documentation
+        run: mkdocs build --strict --site-dir site-preview
+      - name: Upload preview artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: docs-preview
+          path: site-preview

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,45 @@
+name: Documentation
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install documentation dependencies
+        run: |
+          python -m pip install -U pip
+          pip install -e ".[docs]"
+      - name: Build documentation
+        run: mkdocs build --strict
+      - uses: actions/configure-pages@v5
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/docs/ai-ml/datasets.md
+++ b/docs/ai-ml/datasets.md
@@ -1,0 +1,3 @@
+# Datasets
+
+No checked-in training dataset contract was detected. Inputs are user-provided files, URLs, logs, database metadata, graph sources, OpenAPI specs, and source trees.

--- a/docs/ai-ml/embeddings.md
+++ b/docs/ai-ml/embeddings.md
@@ -1,0 +1,3 @@
+# Embeddings
+
+Embedding-related extras exist for codeflow and log semantic workflows through `sentence-transformers`, `numpy`, and `scikit-learn`.

--- a/docs/ai-ml/inference-flow.md
+++ b/docs/ai-ml/inference-flow.md
@@ -1,0 +1,3 @@
+# Inference Flow
+
+Inference-oriented flows load user input, invoke an installed model or semantic library, and render Markdown. Keep model selection, hardware expectations, and cache locations explicit in deployment docs.

--- a/docs/ai-ml/models.md
+++ b/docs/ai-ml/models.md
@@ -1,0 +1,3 @@
+# Models
+
+The repository uses AI/ML dependencies for conversion tasks such as Whisper transcription and optional semantic clustering. No model training pipeline was detected.

--- a/docs/ai-ml/pipelines.md
+++ b/docs/ai-ml/pipelines.md
@@ -1,0 +1,3 @@
+# Pipelines
+
+Detected pipelines are inference and documentation generation pipelines: audio/video transcription, log semantic clustering, codeflow semantic clustering, and assistant skill context assembly.

--- a/docs/ai-ml/vector-database.md
+++ b/docs/ai-ml/vector-database.md
@@ -1,0 +1,3 @@
+# Vector Database
+
+Optional Chroma support is exposed through the `skill-rag-chroma` extra for assistant RAG over skill markdown. No always-on vector database service was detected.

--- a/docs/api/authentication.md
+++ b/docs/api/authentication.md
@@ -1,0 +1,14 @@
+# Authentication
+
+No repository-level authentication middleware, OAuth flow, API key dependency, or Django/Flask authentication layer was detected in the FastAPI applications.
+
+## Deployment Guidance
+
+For production deployments, put authentication at the platform edge:
+
+- API gateway or reverse proxy authentication.
+- OAuth2/OIDC through an ingress controller or identity-aware proxy.
+- Network allowlists for internal conversion services.
+- Short-lived signed URLs or authenticated storage for generated artifacts.
+
+Do not expose conversion APIs directly to the internet without upload limits, authentication, malware scanning controls, and rate limiting.

--- a/docs/api/endpoints.md
+++ b/docs/api/endpoints.md
@@ -1,0 +1,42 @@
+# Endpoints
+
+## Converter Pattern
+
+Most converter APIs expose:
+
+- `POST /convert/sync`: run conversion immediately and return the generated result or bundle.
+- `POST /convert/jobs`: create an asynchronous conversion job.
+- `GET /convert/jobs/{job_id}`: inspect job status.
+- `GET /convert/jobs/{job_id}/download`: download output.
+
+## Domain APIs
+
+- `db-to-md`: `/db-to-md/run`, `/db-to-md/run/sqlite`, `/db-to-md/job`, `/db-to-md/job/sqlite`, event and stream endpoints.
+- `graph-to-md`: `/graph-to-md/run`, `/graph-to-md/job`, event and stream endpoints.
+- `log-to-md`: sync, upload, async job, event, and stream endpoints.
+- `codeflow-to-md`: `/analyze`, `/analyze/sync`, status, result, and events endpoints.
+- `openapi-to-md`: `/openapi-to-md/generate` plus `/health`.
+
+## Full Detected Route Summary
+
+| Service | Endpoints |
+|---------|-----------|
+| pdf-to-md | `/convert/sync, /convert/jobs, /convert/jobs/{job_id}, /convert/jobs/{job_id}/download` |
+| word-to-md | `/convert/sync, /convert/jobs, /convert/jobs/{job_id}, /convert/jobs/{job_id}/download` |
+| ppt-to-md | `/convert/sync, /convert/jobs, /convert/jobs/{job_id}, /convert/jobs/{job_id}/download` |
+| xlsx-to-md | `/convert/sync, /convert/jobs, /convert/jobs/{job_id}, /convert/jobs/{job_id}/download` |
+| image-to-md | `/convert/sync, /convert/jobs, /convert/jobs/{job_id}, /convert/jobs/{job_id}/download` |
+| txt-json-xml-to-md | `/convert/sync, /convert/jobs, /convert/jobs/{job_id}, /convert/jobs/{job_id}/download` |
+| zip-to-md | `/convert/sync, /convert/jobs, /convert/jobs/{job_id}, /convert/jobs/{job_id}/download` |
+| url-to-md | `/convert/sync, /convert/jobs, /convert/jobs/{job_id}, /convert/jobs/{job_id}/download` |
+| audio-to-md | `/convert/sync, /convert/jobs, /convert/jobs/{job_id}, /convert/jobs/{job_id}/download` |
+| video-to-md | `/convert/sync, /convert/jobs, /convert/jobs/{job_id}, /convert/jobs/{job_id}/download` |
+| youtube-to-md | `/convert/sync, /convert/jobs, /convert/jobs/{job_id}, /convert/jobs/{job_id}/download` |
+| playwright-to-md | `/convert/sync, /convert/jobs, /convert/jobs/{job_id}, /convert/jobs/{job_id}/download` |
+| db-to-md | `/health, /db-to-md/run, /db-to-md/run/sqlite, /db-to-md/job, /db-to-md/job/sqlite, /db-to-md/job/{job_id}, /download, /events, /stream` |
+| graph-to-md | `/health, /graph-to-md/run, /graph-to-md/job, /graph-to-md/job/{job_id}, /download, /events, /stream` |
+| openapi-to-md | `/health, /openapi-to-md/generate, /mcp` |
+| codeflow-to-md | `/health, /analyze, /analyze/sync, /status/{job_id}, /result/{job_id}, /analyze/job/{job_id}/events` |
+| log-to-md | `/health, /log-to-md/run, /log-to-md/run/upload, /log-to-md/job, /log-to-md/job/upload, /log-to-md/job/{job_id}, /download, /events, /stream` |
+| No FastAPI app detected | `No HTTP API route set was detected for this module.` |
+| No FastAPI app detected | `No HTTP API route set was detected for this module.` |

--- a/docs/api/error-handling.md
+++ b/docs/api/error-handling.md
@@ -1,0 +1,16 @@
+# Error Handling
+
+## Expected Error Classes
+
+- Validation errors for missing files, unsupported options, malformed JSON/YAML, or invalid URLs.
+- Dependency errors when an optional extra is not installed.
+- Runtime errors from external tools such as Graphviz, browser binaries, OCR engines, or ffmpeg.
+- Upload and output size errors for API routes with bounded workspaces.
+
+## API Behavior
+
+FastAPI services should return structured HTTP errors and preserve enough detail for operators to diagnose the failing input, dependency, or configuration.
+
+## CLI Behavior
+
+CLI commands should return non-zero exit codes on failure and write actionable messages to stderr.

--- a/docs/api/examples.md
+++ b/docs/api/examples.md
@@ -1,0 +1,18 @@
+# API Examples
+
+## Run The Docker Gateway
+
+```bash
+docker compose -f deploy/docker-compose.yml up --build
+```
+
+Open `http://localhost:8080/` to see the gateway index. Swagger UI paths include `/pdf-to-md/docs`, `/word-to-md/docs`, `/ppt-to-md/docs`, `/image-to-md/docs`, `/txt-json-xml-to-md/docs`, `/zip-to-md/docs`, and `/xlsx-to-md/docs`.
+
+## Direct Uvicorn Example
+
+```bash
+pip install -e ".[pdf,api]"
+uvicorn md_generator.pdf.api.main:app --host 0.0.0.0 --port 8000
+```
+
+Then open `http://localhost:8000/docs`.

--- a/docs/api/overview.md
+++ b/docs/api/overview.md
@@ -1,0 +1,27 @@
+# API Overview
+
+FastAPI services are detected under `src/md_generator/**/api`. Most file converters expose a consistent conversion contract, while richer domains expose job-specific APIs.
+
+| Service | Source | CLI | Endpoints |
+|---------|--------|-----|-----------|
+| pdf-to-md | `src/md_generator/pdf` | `md-pdf` | `/convert/sync, /convert/jobs, /convert/jobs/{job_id}, /convert/jobs/{job_id}/download` |
+| word-to-md | `src/md_generator/word` | `md-word` | `/convert/sync, /convert/jobs, /convert/jobs/{job_id}, /convert/jobs/{job_id}/download` |
+| ppt-to-md | `src/md_generator/ppt` | `md-ppt` | `/convert/sync, /convert/jobs, /convert/jobs/{job_id}, /convert/jobs/{job_id}/download` |
+| xlsx-to-md | `src/md_generator/xlsx` | `md-xlsx` | `/convert/sync, /convert/jobs, /convert/jobs/{job_id}, /convert/jobs/{job_id}/download` |
+| image-to-md | `src/md_generator/image` | `md-image` | `/convert/sync, /convert/jobs, /convert/jobs/{job_id}, /convert/jobs/{job_id}/download` |
+| txt-json-xml-to-md | `src/md_generator/text` | `md-text` | `/convert/sync, /convert/jobs, /convert/jobs/{job_id}, /convert/jobs/{job_id}/download` |
+| zip-to-md | `src/md_generator/archive` | `md-zip` | `/convert/sync, /convert/jobs, /convert/jobs/{job_id}, /convert/jobs/{job_id}/download` |
+| url-to-md | `src/md_generator/url` | `md-url` | `/convert/sync, /convert/jobs, /convert/jobs/{job_id}, /convert/jobs/{job_id}/download` |
+| audio-to-md | `src/md_generator/media/audio` | `md-audio` | `/convert/sync, /convert/jobs, /convert/jobs/{job_id}, /convert/jobs/{job_id}/download` |
+| video-to-md | `src/md_generator/media/video` | `md-video` | `/convert/sync, /convert/jobs, /convert/jobs/{job_id}, /convert/jobs/{job_id}/download` |
+| youtube-to-md | `src/md_generator/media/youtube` | `md-youtube` | `/convert/sync, /convert/jobs, /convert/jobs/{job_id}, /convert/jobs/{job_id}/download` |
+| playwright-to-md | `src/md_generator/playwright` | `md-playwright` | `/convert/sync, /convert/jobs, /convert/jobs/{job_id}, /convert/jobs/{job_id}/download` |
+| db-to-md | `src/md_generator/db` | `md-db` | `/health, /db-to-md/run, /db-to-md/run/sqlite, /db-to-md/job, /db-to-md/job/sqlite, /db-to-md/job/{job_id}, /download, /events, /stream` |
+| graph-to-md | `src/md_generator/graph` | `md-graph` | `/health, /graph-to-md/run, /graph-to-md/job, /graph-to-md/job/{job_id}, /download, /events, /stream` |
+| openapi-to-md | `src/md_generator/openapi` | `md-openapi` | `/health, /openapi-to-md/generate, /mcp` |
+| codeflow-to-md | `src/md_generator/codeflow` | `md-codeflow or codeflow` | `/health, /analyze, /analyze/sync, /status/{job_id}, /result/{job_id}, /analyze/job/{job_id}/events` |
+| log-to-md | `src/md_generator/log` | `md-log` | `/health, /log-to-md/run, /log-to-md/run/upload, /log-to-md/job, /log-to-md/job/upload, /log-to-md/job/{job_id}, /download, /events, /stream` |
+| No FastAPI app detected | `src/md_generator/tools/assistant` | `mdengine ai assist / mdengine ai export` | `No HTTP API route set was detected for this module.` |
+| No FastAPI app detected | `src/md_generator/tools/skill_builder` | `mdengine skill build` | `No HTTP API route set was detected for this module.` |
+
+Each FastAPI app also serves OpenAPI JSON and Swagger UI through FastAPI defaults when running without a custom gateway path.

--- a/docs/api/request-response.md
+++ b/docs/api/request-response.md
@@ -1,0 +1,21 @@
+# Request And Response Patterns
+
+## Sync Conversion
+
+```bash
+curl -X POST http://localhost:8000/convert/sync   -F "file=@input.pdf"
+```
+
+A sync endpoint returns the generated artifact immediately when the output is small enough and the conversion completes inside request limits.
+
+## Async Conversion
+
+```bash
+curl -X POST http://localhost:8000/convert/jobs   -F "file=@input.pdf"
+```
+
+The response includes a `job_id`. Poll the status endpoint and then call the download endpoint when complete.
+
+## Domain Configuration Request
+
+Database, graph, OpenAPI, codeflow, and log endpoints accept structured JSON or multipart payloads depending on the operation. These payloads mirror each domain CLI/YAML configuration rather than a single global schema.

--- a/docs/architecture/data-flow.md
+++ b/docs/architecture/data-flow.md
@@ -1,0 +1,13 @@
+# Data Flow
+
+```mermaid
+flowchart TD
+    Source[Input_source] --> Reader[Reader_or_adapter]
+    Reader --> Parsed[Parsed_content_or_metadata]
+    Parsed --> Generator[Markdown_generator]
+    Generator --> Markdown[Markdown_files]
+    Generator --> Diagrams[Mermaid_or_Graphviz_assets]
+    Generator --> Zip[ZIP_download_when_API]
+```
+
+Data generally flows one way: from input source to generated documentation artifacts. The repository does not define persistent application data stores for the converter services; database and graph modules introspect external systems and write documentation output.

--- a/docs/architecture/deployment-architecture.md
+++ b/docs/architecture/deployment-architecture.md
@@ -1,0 +1,21 @@
+# Deployment Architecture
+
+The checked-in deployment stack is Docker Compose plus nginx. The compose file currently runs the gateway and selected converter APIs: ZIP, image, text, Word, PDF, PPT, and XLSX.
+
+```mermaid
+flowchart LR
+    Browser[Browser_or_HTTP_client] --> Nginx[Nginx_on_8080]
+    Nginx --> Zip[zip_to_md_API]
+    Nginx --> Image[image_to_md_API]
+    Nginx --> Text[text_json_xml_API]
+    Nginx --> Word[word_to_md_API]
+    Nginx --> Pdf[pdf_to_md_API]
+    Nginx --> Ppt[ppt_to_md_API]
+    Nginx --> Xlsx[xlsx_to_md_API]
+```
+
+Run it from the repository root:
+
+```bash
+docker compose -f deploy/docker-compose.yml up --build
+```

--- a/docs/architecture/hld.md
+++ b/docs/architecture/hld.md
@@ -1,0 +1,30 @@
+# High-Level Design
+
+## System Boundaries
+
+The system boundary is the `mdengine` distribution. Inputs are files, URLs, database metadata sources, graph sources, OpenAPI specifications, source repositories, logs, and skill markdown bundles. Outputs are Markdown files, ZIP bundles, diagrams, JSON sidecars, and API download artifacts.
+
+## Major Components
+
+- CLI layer: console scripts defined in `pyproject.toml`.
+- API layer: FastAPI applications in `src/md_generator/**/api`.
+- MCP layer: optional tool servers for automation clients.
+- Core converter layer: package-specific conversion and generation logic.
+- Deployment layer: Docker Compose plus nginx gateway for selected services.
+
+## Runtime Communication
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant FastAPI
+    participant JobStore
+    participant Converter
+    participant Output
+    Client->>FastAPI: POST conversion request
+    FastAPI->>JobStore: create job or workspace
+    FastAPI->>Converter: run converter with options
+    Converter->>Output: write Markdown and assets
+    Output-->>FastAPI: result path or ZIP bytes
+    FastAPI-->>Client: response, status, or download
+```

--- a/docs/architecture/lld.md
+++ b/docs/architecture/lld.md
@@ -1,0 +1,26 @@
+# Low-Level Design
+
+## Shared Converter Shape
+
+Most converter modules follow a small set of conventions:
+
+- `converter.py` provides the CLI entry point or conversion wrapper.
+- `api/main.py` provides a FastAPI app where the module supports HTTP.
+- Job-enabled APIs write results into temporary workspaces and expose download endpoints.
+- Heavy dependencies are isolated behind optional extras.
+
+## Internal Flow
+
+```mermaid
+flowchart TD
+    Args[CLI_or_API_options] --> Validate[Validate_input_and_options]
+    Validate --> Load[Load_source]
+    Load --> Convert[Convert_to_intermediate_content]
+    Convert --> Render[Render_Markdown]
+    Render --> Assets[Write_assets]
+    Assets --> Result[Return_path_or_zip]
+```
+
+## Error Handling
+
+FastAPI modules convert validation and processing failures into HTTP errors. CLI modules return process exit codes and write errors to the terminal. Domain modules should keep exceptions meaningful at the boundary so API and CLI layers can present actionable messages.

--- a/docs/architecture/module-interactions.md
+++ b/docs/architecture/module-interactions.md
@@ -1,0 +1,30 @@
+# Module Interactions
+
+## Interface To Core Mapping
+
+| `md-pdf` | `md_generator.pdf` | `pdf` | PDF documents |
+| `md-word` | `md_generator.word` | `word` | DOCX documents |
+| `md-ppt` | `md_generator.ppt` | `ppt` | PPTX slide decks |
+| `md-xlsx` | `md_generator.xlsx` | `xlsx` | XLSX, XLSM, and CSV files |
+| `md-image` | `md_generator.image` | `image or image-ocr` | Image files or directories |
+| `md-text` | `md_generator.text` | `text` | Plain text, JSON, and XML files |
+| `md-zip` | `md_generator.archive` | `archive plus nested format extras` | ZIP archives |
+| `md-url` | `md_generator.url` | `url or url-full` | HTTP and HTTPS web pages |
+| `md-audio` | `md_generator.media.audio` | `audio` | Audio files |
+| `md-video` | `md_generator.media.video` | `video` | Video files |
+| `md-youtube` | `md_generator.media.youtube` | `youtube` | YouTube URLs |
+| `md-playwright` | `md_generator.playwright` | `playwright` | Rendered web pages and SPAs |
+| `md-db` | `md_generator.db` | `db` | Postgres, MySQL, Oracle, SQLite, and Mongo metadata sources |
+| `md-graph` | `md_generator.graph` | `graph` | Neo4j and NetworkX graph sources |
+| `md-openapi` | `md_generator.openapi` | `openapi` | OpenAPI 3.x or Swagger 2.0 specifications |
+| `md-codeflow or codeflow` | `md_generator.codeflow` | `codeflow` | Source repositories and code trees |
+| `md-log` | `md_generator.log` | `log` | Log files and uploaded log content |
+| `mdengine ai assist / mdengine ai export` | `md_generator.tools.assistant` | `skill-openai or skill-rag-chroma for optional providers` | Skill markdown bundles and prompts |
+| `mdengine skill build` | `md_generator.tools.skill_builder` | `base package` | Project metadata and skill sources |
+
+## Cross-Module Relationships
+
+- `archive` can call nested converters when the relevant extras are installed.
+- `url-full` combines URL fetching with document conversion stacks.
+- API and MCP modules delegate to the same core conversion logic used by CLIs.
+- `db`, `graph`, `openapi`, `codeflow`, and `log` use packaged YAML/configuration patterns for richer generation workflows.

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -1,0 +1,32 @@
+# Architecture Overview
+
+`mdengine` is a modular Python monorepo with one installable distribution and many optional runtime surfaces.
+
+```mermaid
+flowchart TB
+    subgraph packageLayer[Python_distribution]
+        Engine[mdengine_package]
+        Modules[md_generator_modules]
+        Extras[optional_dependency_extras]
+    end
+    subgraph interfaceLayer[Interfaces]
+        CLI[CLI_entry_points]
+        API[FastAPI_apps]
+        MCP[MCP_servers]
+    end
+    subgraph runtimeLayer[Runtime_targets]
+        Local[Local_terminal]
+        Docker[Docker_compose_gateway]
+        CI[GitHub_Actions]
+    end
+    CLI --> Modules
+    API --> Modules
+    MCP --> Modules
+    Engine --> Modules
+    Extras --> Modules
+    Local --> CLI
+    Docker --> API
+    CI --> Engine
+```
+
+The dominant pattern is a modular monolith. Feature areas share packaging, test configuration, and release cadence while keeping converter logic in separate modules.

--- a/docs/architecture/sequence-diagrams.md
+++ b/docs/architecture/sequence-diagrams.md
@@ -1,0 +1,37 @@
+# Sequence Diagrams
+
+## Async Conversion Job
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant API
+    participant WorkerThread
+    participant Converter
+    participant Storage
+    Client->>API: POST /convert/jobs
+    API->>Storage: allocate job workspace
+    API->>WorkerThread: start background conversion
+    API-->>Client: job_id
+    Client->>API: GET /convert/jobs/job_id
+    WorkerThread->>Converter: convert input
+    Converter->>Storage: write Markdown bundle
+    API-->>Client: status
+    Client->>API: GET /convert/jobs/job_id/download
+    API-->>Client: FileResponse
+```
+
+## Domain Job With Events
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant API
+    participant DomainJob
+    participant EventStream
+    Client->>API: POST domain job
+    API-->>Client: job_id
+    Client->>EventStream: GET events stream
+    DomainJob->>EventStream: progress updates
+    DomainJob->>EventStream: completion or failure
+```

--- a/docs/architecture/system-design.md
+++ b/docs/architecture/system-design.md
@@ -1,0 +1,12 @@
+# System Design
+
+## Design Goals
+
+- Keep default installs lightweight by using extras.
+- Reuse converter code across CLI, API, and MCP surfaces.
+- Make generated Markdown deterministic enough for version control and review.
+- Support both local developer workflows and containerized HTTP services.
+
+## Architectural Pattern
+
+The repository is not a microservice repository in packaging terms. It is a modular monolith with optional independently runnable FastAPI services. Docker Compose turns selected modules into service containers behind nginx, but the Python release remains unified.

--- a/docs/database/indexing.md
+++ b/docs/database/indexing.md
@@ -1,0 +1,11 @@
+# Database Indexing
+
+The DB exporter can document detected indexes from source databases. Use generated index pages to review uniqueness, coverage, naming consistency, and candidates for query optimization.
+
+```mermaid
+erDiagram
+    SOURCE_DATABASE ||--o{ SCHEMA : contains
+    SCHEMA ||--o{ TABLE : contains
+    TABLE ||--o{ COLUMN : defines
+    TABLE ||--o{ INDEX : has
+```

--- a/docs/database/migrations.md
+++ b/docs/database/migrations.md
@@ -1,0 +1,11 @@
+# Database Migrations
+
+No Alembic or Django migration tree was detected for application-owned persistence. For documented databases, migration history remains in the source database or the owning application repository.
+
+```mermaid
+erDiagram
+    SOURCE_DATABASE ||--o{ SCHEMA : contains
+    SCHEMA ||--o{ TABLE : contains
+    TABLE ||--o{ COLUMN : defines
+    TABLE ||--o{ INDEX : has
+```

--- a/docs/database/optimization.md
+++ b/docs/database/optimization.md
@@ -1,0 +1,11 @@
+# Database Optimization
+
+Optimization notes should be generated from observed schema shape: large tables, missing foreign keys, index duplication, and expensive graph sizes. Keep extraction limits configured for very large catalogs.
+
+```mermaid
+erDiagram
+    SOURCE_DATABASE ||--o{ SCHEMA : contains
+    SCHEMA ||--o{ TABLE : contains
+    TABLE ||--o{ COLUMN : defines
+    TABLE ||--o{ INDEX : has
+```

--- a/docs/database/schema.md
+++ b/docs/database/schema.md
@@ -1,0 +1,11 @@
+# Database Schema
+
+`mdengine` does not own application tables. The DB module documents external database schemas through adapters for Postgres, MySQL, Oracle, Mongo, and SQLite. Outputs can include tables, views, indexes, routines, triggers, Mongo collections, and ERD artifacts.
+
+```mermaid
+erDiagram
+    SOURCE_DATABASE ||--o{ SCHEMA : contains
+    SCHEMA ||--o{ TABLE : contains
+    TABLE ||--o{ COLUMN : defines
+    TABLE ||--o{ INDEX : has
+```

--- a/docs/deployment/ci-cd.md
+++ b/docs/deployment/ci-cd.md
@@ -1,0 +1,10 @@
+# CI/CD
+
+The existing CI workflow runs a Python matrix, installs selected extras, tests `db-to-md/tests`, and builds the distribution. Documentation deployment is handled by the dedicated docs workflows added with this site.
+
+## Documentation Pipeline
+
+- Install `.[docs]`.
+- Run `mkdocs build --strict` to validate nav, links, and plugin configuration.
+- Upload the generated site as a GitHub Pages artifact on main branch pushes.
+- Build PR documentation artifacts for review.

--- a/docs/deployment/docker.md
+++ b/docs/deployment/docker.md
@@ -1,0 +1,9 @@
+# Docker Deployment
+
+The checked-in Docker deployment is `deploy/docker-compose.yml`. It builds service images from per-module `Dockerfile.api` files and exposes them through nginx on port `8080`.
+
+```bash
+docker compose -f deploy/docker-compose.yml up --build
+```
+
+The gateway currently lists Swagger UI routes for ZIP, PDF, PPT, Word, image, text, and XLSX services.

--- a/docs/deployment/helm.md
+++ b/docs/deployment/helm.md
@@ -1,0 +1,3 @@
+# Helm
+
+No Helm chart was detected. If Helm is introduced, keep values grouped by converter service: image, resources, upload limits, root path, timeout, environment variables, and ingress path.

--- a/docs/deployment/kubernetes.md
+++ b/docs/deployment/kubernetes.md
@@ -1,0 +1,10 @@
+# Kubernetes Deployment
+
+No Kubernetes manifests were detected in the repository. A production Kubernetes deployment should translate each API container into a Deployment, expose services through an Ingress, and externalize upload limits, timeout settings, and workspace storage.
+
+## Recommended Baseline
+
+- One Deployment per converter API that must scale independently.
+- Readiness probes against `/health` where implemented or FastAPI docs/OpenAPI endpoints where safe.
+- Persistent or object storage for large asynchronous artifacts if pods are ephemeral.
+- Ingress authentication and upload limits.

--- a/docs/deployment/production-checklist.md
+++ b/docs/deployment/production-checklist.md
@@ -1,0 +1,10 @@
+# Production Checklist
+
+- Install only required extras in each runtime image.
+- Put authentication and rate limiting in front of FastAPI services.
+- Enforce request body, output ZIP, and workspace size limits.
+- Scan untrusted uploads before conversion where policy requires it.
+- Configure structured logs and central retention.
+- Run `mkdocs build --strict` before publishing docs.
+- Document every externally supplied environment variable.
+- Validate Graphviz, ffmpeg, OCR, Playwright, and database drivers during image build or startup.

--- a/docs/deployment/scaling.md
+++ b/docs/deployment/scaling.md
@@ -1,0 +1,10 @@
+# Scaling
+
+Scale API services by workload type. CPU-heavy OCR, Whisper, browser rendering, and source-code analysis should not share resource limits with lightweight text or OpenAPI conversion.
+
+## Guidance
+
+- Separate heavy services into dedicated containers or node pools.
+- Prefer async job endpoints for large inputs.
+- Put upload, processing, and output size limits at the API and gateway layers.
+- Use queue-backed workers for codeflow when `codeflow-worker` and Redis/Celery are intentionally deployed.

--- a/docs/development/coding-standards.md
+++ b/docs/development/coding-standards.md
@@ -1,0 +1,3 @@
+# Coding Standards
+
+Follow the existing module structure: keep converter logic in package modules, expose interfaces through CLI/API/MCP wrappers, and gate heavy dependencies with extras.

--- a/docs/development/debugging.md
+++ b/docs/development/debugging.md
@@ -1,0 +1,3 @@
+# Debugging
+
+Start with the CLI path for deterministic local failures, then reproduce through FastAPI if the problem involves uploads, jobs, or downloads.

--- a/docs/development/linting.md
+++ b/docs/development/linting.md
@@ -1,0 +1,3 @@
+# Linting
+
+No single repository linter configuration was detected. Keep formatting consistent with nearby code and add lint tooling deliberately if the project standardizes on one.

--- a/docs/development/project-structure.md
+++ b/docs/development/project-structure.md
@@ -1,0 +1,3 @@
+# Project Structure
+
+The package uses a `src` layout. Top-level `*-to-md` folders hold tests, Dockerfiles, requirement hints, shims, and per-format README files.

--- a/docs/development/release-process.md
+++ b/docs/development/release-process.md
@@ -1,0 +1,3 @@
+# Release Process
+
+Package releases use the existing PyPI publish workflow on GitHub release publication. Documentation deployment is separate and publishes from main branch documentation builds.

--- a/docs/development/testing-strategy.md
+++ b/docs/development/testing-strategy.md
@@ -1,0 +1,3 @@
+# Testing Strategy
+
+`pyproject.toml` configures many test directories. Existing CI runs a narrower DB subset, so local broad testing is important before cross-module changes.

--- a/docs/getting-started/environment-setup.md
+++ b/docs/getting-started/environment-setup.md
@@ -1,0 +1,14 @@
+# Environment Setup
+
+The repository does not include a single root `.env.example`. Runtime configuration is module-specific and exposed through CLI flags, YAML configuration, or service-specific environment variables.
+
+## Common Patterns
+
+- API ports use module-specific variables such as `DB_TO_MD_PORT`, `GRAPH_TO_MD_PORT`, or `OPENAPI_TO_MD_PORT` where implemented.
+- Upload and ZIP limits are enforced by API modules such as `db-to-md` through variables like `DB_TO_MD_MAX_SQLITE_UPLOAD_MB`.
+- Graphviz can be configured with `GRAPHVIZ_DOT` when `dot` is not on `PATH`.
+- Mermaid image rendering can use `MERMAID_INK_SERVER` for DB ERD generation when `mermaid-py` is used.
+
+## Recommended Local Practice
+
+Keep local secrets outside git, document service-specific variables in deployment manifests, and prefer YAML configs for database, graph, OpenAPI, and log workflows where the module provides packaged defaults.

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -1,0 +1,31 @@
+# Installation
+
+## From PyPI
+
+```bash
+pip install "mdengine[pdf,word]"
+pip install "mdengine[all]"
+```
+
+## From A Clone
+
+```bash
+git clone https://github.com/vishal7090/md-generator.git
+cd md-generator
+python -m venv .venv
+. .venv/bin/activate
+python -m pip install -U pip
+pip install -e ".[dev,docs]"
+```
+
+On Windows PowerShell, activate with:
+
+```powershell
+.\.venv\Scripts\Activate.ps1
+```
+
+## Optional Extras
+
+The repository uses optional dependency extras instead of installing every converter dependency by default. Detected extras include `pdf`, `word`, `ppt`, `xlsx`, `image`, `image-ocr`, `text`, `archive`, `url`, `url-full`, `audio`, `video`, `youtube`, `playwright`, `db`, `graph`, `openapi`, `codeflow`, `codeflow-worker`, `codeflow-treesitter`, `codeflow-clang`, `codeflow-semantic`, `log`, `log-cluster`, `log-semantic`, `log-pretty`, `api`, `mcp`, `skill-openai`, `skill-rag-chroma`, `dev`, `all`, and `docs`.
+
+Install the smallest set required for the workflow. For example, database exports need `db`; FastAPI services need `api`; MCP servers need `mcp`.

--- a/docs/getting-started/introduction.md
+++ b/docs/getting-started/introduction.md
@@ -1,0 +1,14 @@
+# Introduction
+
+`mdengine` converts heterogeneous technical inputs into Markdown and related assets. It is not a single web application; it is a Python distribution with many optional feature areas.
+
+## Primary Use Cases
+
+- Convert office, PDF, image, archive, URL, audio, video, and YouTube inputs to Markdown.
+- Generate database, graph, OpenAPI, source-code, and log documentation.
+- Run converters locally through CLI commands or expose them through FastAPI services.
+- Package Markdown output for downstream review, search, or static publishing.
+
+## Architectural Shape
+
+The repository is best described as a modular monolith: one package, many feature modules, optional dependencies, consistent CLI/API surfaces, and no separately versioned Python packages.

--- a/docs/getting-started/local-development.md
+++ b/docs/getting-started/local-development.md
@@ -1,0 +1,31 @@
+# Local Development
+
+## Editable Development Environment
+
+```bash
+python -m venv .venv
+. .venv/bin/activate
+python -m pip install -U pip
+pip install -e ".[dev,all,docs]"
+```
+
+## Test Commands
+
+Run the full configured test discovery:
+
+```bash
+python -m pytest
+```
+
+Run the CI-aligned subset currently used by the existing workflow:
+
+```bash
+python -m pytest db-to-md/tests -v -m "not integration"
+```
+
+## Package Build
+
+```bash
+python -m pip install build
+python -m build
+```

--- a/docs/getting-started/prerequisites.md
+++ b/docs/getting-started/prerequisites.md
@@ -1,0 +1,15 @@
+# Prerequisites
+
+## Required
+
+- Python 3.10 or newer.
+- `pip` and virtual environment support.
+- Git for editable installs and GitHub Actions workflows.
+
+## Optional System Tools
+
+- Graphviz `dot` for DB and graph rendered diagrams.
+- Tesseract for OCR paths that use the Tesseract engine.
+- Playwright browser binaries for rendered web capture: `playwright install chromium`.
+- ffmpeg or the bundled `imageio-ffmpeg` fallback for audio/video workflows.
+- Docker and Docker Compose for the API gateway stack.

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -1,0 +1,28 @@
+# Quick Start
+
+## Local Editable Install
+
+```bash
+python -m venv .venv
+# Windows PowerShell
+.\.venv\Scripts\Activate.ps1
+python -m pip install -U pip
+pip install -e ".[pdf,word,api]"
+```
+
+## Run A Converter
+
+```bash
+md-pdf report.pdf report.md
+md-word notes.docx notes.md
+md-url https://example.com ./page-out --artifact-layout
+```
+
+## Run The Documentation Site
+
+```bash
+pip install -e ".[docs]"
+mkdocs serve
+```
+
+Open `http://127.0.0.1:8000/`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,52 @@
+# mdengine Documentation
+
+`mdengine` is a Python 3.10+ documentation and conversion engine. The PyPI distribution is named `mdengine`; all runtime code imports from `md_generator` under `src/md_generator`.
+
+The repository is a modular monorepo. Each converter can be used as a command-line tool, many converters expose FastAPI services, and selected domains provide MCP servers for tool-based automation.
+
+## What This Site Covers
+
+- Installation, local development, and operating guidance for Windows, macOS, and Linux.
+- High-level and low-level architecture for the converter, API, MCP, database, graph, codeflow, log, and assistant modules.
+- API endpoint families detected in the repository.
+- Docker gateway deployment using `deploy/docker-compose.yml` and `deploy/nginx/default.conf`.
+- Python reference pages generated with `mkdocstrings` from the `md_generator` package.
+
+## Detected Modules
+
+- `pdf`: PDF (`md_generator.pdf`), CLI `md-pdf`, extra `pdf`.
+- `word`: Word (`md_generator.word`), CLI `md-word`, extra `word`.
+- `ppt`: PowerPoint (`md_generator.ppt`), CLI `md-ppt`, extra `ppt`.
+- `xlsx`: Excel and CSV (`md_generator.xlsx`), CLI `md-xlsx`, extra `xlsx`.
+- `image`: Image OCR (`md_generator.image`), CLI `md-image`, extra `image or image-ocr`.
+- `text`: Text JSON XML (`md_generator.text`), CLI `md-text`, extra `text`.
+- `archive`: ZIP Archive (`md_generator.archive`), CLI `md-zip`, extra `archive plus nested format extras`.
+- `url`: URL and Web (`md_generator.url`), CLI `md-url`, extra `url or url-full`.
+- `media-audio`: Audio (`md_generator.media.audio`), CLI `md-audio`, extra `audio`.
+- `media-video`: Video (`md_generator.media.video`), CLI `md-video`, extra `video`.
+- `media-youtube`: YouTube (`md_generator.media.youtube`), CLI `md-youtube`, extra `youtube`.
+- `playwright`: Playwright Web Capture (`md_generator.playwright`), CLI `md-playwright`, extra `playwright`.
+- `db`: Database Metadata (`md_generator.db`), CLI `md-db`, extra `db`.
+- `graph`: Graph Metadata (`md_generator.graph`), CLI `md-graph`, extra `graph`.
+- `openapi`: OpenAPI (`md_generator.openapi`), CLI `md-openapi`, extra `openapi`.
+- `codeflow`: Codeflow (`md_generator.codeflow`), CLI `md-codeflow or codeflow`, extra `codeflow`.
+- `log`: Log Analysis (`md_generator.log`), CLI `md-log`, extra `log`.
+- `tools-assistant`: AI Assistant Tools (`md_generator.tools.assistant`), CLI `mdengine ai assist / mdengine ai export`, extra `skill-openai or skill-rag-chroma for optional providers`.
+- `tools-skill-builder`: Skill Builder (`md_generator.tools.skill_builder`), CLI `mdengine skill build`, extra `base package`.
+
+## Core Flow
+
+```mermaid
+flowchart LR
+    User[User] --> CLI[mdengine_and_md_CLIs]
+    User --> Gateway[Nginx_gateway]
+    Gateway --> FastAPI[FastAPI_services]
+    CLI --> Core[md_generator_core_modules]
+    FastAPI --> Core
+    Core --> Integrations[Files_databases_APIs_media_tools]
+    Core --> Output[Markdown_outputs]
+```
+
+## Repository Source Of Truth
+
+The root `README.md`, `pyproject.toml`, per-converter README files, `codeflow-to-md/docs`, and `ai/` skill documentation remain authoritative sources for contributor-facing details. This MkDocs site organizes those facts into a deployable documentation platform.

--- a/docs/integrations/cloud-services.md
+++ b/docs/integrations/cloud-services.md
@@ -1,0 +1,3 @@
+# Cloud Services Integration
+
+No cloud-specific SDK deployment integration was detected. GitHub Actions is used for CI, package publishing, and the new documentation deployment workflow.

--- a/docs/integrations/elasticsearch.md
+++ b/docs/integrations/elasticsearch.md
@@ -1,0 +1,3 @@
+# Elasticsearch Integration
+
+No Elasticsearch integration was detected in the repository. Do not assume indexing or search cluster behavior beyond MkDocs client-side search.

--- a/docs/integrations/external-apis.md
+++ b/docs/integrations/external-apis.md
@@ -1,0 +1,3 @@
+# External Apis Integration
+
+External API interactions include URL fetching with `httpx`, YouTube transcript access, OpenAPI spec ingestion, and optional MCP surfaces. Production deployments should bound outbound network access.

--- a/docs/integrations/kafka.md
+++ b/docs/integrations/kafka.md
@@ -1,0 +1,3 @@
+# Kafka Integration
+
+No Kafka consumer or producer implementation was detected. If Kafka is added later, document topics, schemas, consumer groups, retry behavior, and dead-letter handling here.

--- a/docs/integrations/mongodb.md
+++ b/docs/integrations/mongodb.md
@@ -1,0 +1,3 @@
+# Mongodb Integration
+
+MongoDB is supported by the DB metadata module through `pymongo`. The exporter documents collections and metadata from external Mongo sources.

--- a/docs/integrations/postgres.md
+++ b/docs/integrations/postgres.md
@@ -1,0 +1,3 @@
+# Postgres Integration
+
+Postgres is supported by the DB metadata module through SQLAlchemy and `psycopg2-binary`. Use YAML/API config to provide connection details and schema scope.

--- a/docs/integrations/redis.md
+++ b/docs/integrations/redis.md
@@ -1,0 +1,3 @@
+# Redis Integration
+
+Redis appears as an optional dependency for `codeflow-worker` through Celery support. The default codeflow API path uses threads unless the worker extra and runtime are configured.

--- a/docs/modules/archive/api.md
+++ b/docs/modules/archive/api.md
@@ -1,0 +1,5 @@
+# ZIP Archive API
+
+FastAPI title: `zip-to-md`.
+
+Detected endpoints: `/convert/sync, /convert/jobs, /convert/jobs/{job_id}, /convert/jobs/{job_id}/download`.

--- a/docs/modules/archive/configuration.md
+++ b/docs/modules/archive/configuration.md
@@ -1,0 +1,11 @@
+# ZIP Archive Configuration
+
+Configuration is supplied through CLI flags, API request fields, packaged YAML where the module provides it, and environment variables for service runtime concerns.
+
+For this module, begin with:
+
+```bash
+md-zip --help
+```
+
+Source code lives in `src/md_generator/archive`.

--- a/docs/modules/archive/database.md
+++ b/docs/modules/archive/database.md
@@ -1,0 +1,3 @@
+# ZIP Archive Database Notes
+
+No repository database tables are owned by this module.

--- a/docs/modules/archive/deployment.md
+++ b/docs/modules/archive/deployment.md
@@ -1,0 +1,5 @@
+# ZIP Archive Deployment
+
+Deploy the API surface only when HTTP access is required. Install the smallest dependency extra set and add `api` for FastAPI runtime.
+
+For Dockerized services, follow the existing `Dockerfile.api` and Compose gateway pattern used by top-level converter folders.

--- a/docs/modules/archive/exceptions.md
+++ b/docs/modules/archive/exceptions.md
@@ -1,0 +1,5 @@
+# ZIP Archive Exceptions
+
+Expected failures include missing optional dependencies, invalid inputs, unsupported source formats, external tool failures, and output write errors.
+
+API callers should receive structured HTTP failures. CLI users should receive a non-zero exit code and actionable terminal output.

--- a/docs/modules/archive/installation.md
+++ b/docs/modules/archive/installation.md
@@ -1,0 +1,17 @@
+# ZIP Archive Installation
+
+```bash
+pip install "mdengine[archive]"
+```
+
+For local development from a clone:
+
+```bash
+pip install -e ".[archive,dev]"
+```
+
+If the module also runs as HTTP API, include `api`:
+
+```bash
+pip install -e ".[archive,api]"
+```

--- a/docs/modules/archive/lld.md
+++ b/docs/modules/archive/lld.md
@@ -1,0 +1,12 @@
+# ZIP Archive Low-Level Design
+
+```mermaid
+flowchart TD
+    Request[CLI_or_API_request] --> Options[Parse_options]
+    Options --> Validate[Validate_input]
+    Validate --> Convert[archive_conversion]
+    Convert --> Render[Render_Markdown]
+    Render --> Return[Return_or_download_result]
+```
+
+The module should keep parsing, conversion, rendering, and interface concerns separated enough that CLI and API paths can reuse the same core behavior.

--- a/docs/modules/archive/logging.md
+++ b/docs/modules/archive/logging.md
@@ -1,0 +1,3 @@
+# ZIP Archive Logging
+
+Log module name, input type, job ID when present, output location, and bounded error details. Do not log uploaded file contents, credentials, or database connection secrets.

--- a/docs/modules/archive/overview.md
+++ b/docs/modules/archive/overview.md
@@ -1,0 +1,15 @@
+# ZIP Archive Module Overview
+
+Package: `md_generator.archive`  
+Source: `src/md_generator/archive`  
+CLI: `md-zip`  
+Extra: `archive plus nested format extras`
+
+This module accepts ZIP archives and produces Directory-oriented Markdown bundle. It participates in the unified `mdengine` distribution and follows the repository pattern of keeping feature dependencies optional.
+
+```mermaid
+flowchart LR
+    Input[Input] --> Module[archive_module]
+    Module --> Markdown[Markdown_output]
+    Module --> Assets[Assets_when_enabled]
+```

--- a/docs/modules/archive/responsibilities.md
+++ b/docs/modules/archive/responsibilities.md
@@ -1,0 +1,5 @@
+# ZIP Archive Responsibilities
+
+- Unpack supported archive members safely.
+- Route nested supported formats through converters.
+- Produce a browsable Markdown layout.

--- a/docs/modules/archive/testing.md
+++ b/docs/modules/archive/testing.md
@@ -1,0 +1,7 @@
+# ZIP Archive Testing
+
+Tests for this feature area are expected under the matching top-level `*-to-md/tests` folder where present. Run targeted tests before changing the module and run broader `python -m pytest` before cross-module changes.
+
+```bash
+python -m pytest
+```

--- a/docs/modules/archive/workflows.md
+++ b/docs/modules/archive/workflows.md
@@ -1,0 +1,16 @@
+# ZIP Archive Workflows
+
+## CLI Workflow
+
+```bash
+md-zip --help
+```
+
+1. Install the required extra.
+2. Provide an input source: ZIP archives.
+3. Choose an output path.
+4. Review generated Markdown and assets.
+
+## API Workflow
+
+If an API is detected for this module, submit a sync request for small work or a job request for larger work. Download endpoints return generated artifacts after completion.

--- a/docs/modules/codeflow/api.md
+++ b/docs/modules/codeflow/api.md
@@ -1,0 +1,5 @@
+# Codeflow API
+
+FastAPI title: `codeflow-to-md`.
+
+Detected endpoints: `/health, /analyze, /analyze/sync, /status/{job_id}, /result/{job_id}, /analyze/job/{job_id}/events`.

--- a/docs/modules/codeflow/configuration.md
+++ b/docs/modules/codeflow/configuration.md
@@ -1,0 +1,11 @@
+# Codeflow Configuration
+
+Configuration is supplied through CLI flags, API request fields, packaged YAML where the module provides it, and environment variables for service runtime concerns.
+
+For this module, begin with:
+
+```bash
+md-codeflow --help
+```
+
+Source code lives in `src/md_generator/codeflow`.

--- a/docs/modules/codeflow/database.md
+++ b/docs/modules/codeflow/database.md
@@ -1,0 +1,3 @@
+# Codeflow Database Notes
+
+No repository database tables are owned by this module.

--- a/docs/modules/codeflow/deployment.md
+++ b/docs/modules/codeflow/deployment.md
@@ -1,0 +1,5 @@
+# Codeflow Deployment
+
+Deploy the API surface only when HTTP access is required. Install the smallest dependency extra set and add `api` for FastAPI runtime.
+
+For Dockerized services, follow the existing `Dockerfile.api` and Compose gateway pattern used by top-level converter folders.

--- a/docs/modules/codeflow/exceptions.md
+++ b/docs/modules/codeflow/exceptions.md
@@ -1,0 +1,5 @@
+# Codeflow Exceptions
+
+Expected failures include missing optional dependencies, invalid inputs, unsupported source formats, external tool failures, and output write errors.
+
+API callers should receive structured HTTP failures. CLI users should receive a non-zero exit code and actionable terminal output.

--- a/docs/modules/codeflow/installation.md
+++ b/docs/modules/codeflow/installation.md
@@ -1,0 +1,17 @@
+# Codeflow Installation
+
+```bash
+pip install "mdengine[codeflow]"
+```
+
+For local development from a clone:
+
+```bash
+pip install -e ".[codeflow,dev]"
+```
+
+If the module also runs as HTTP API, include `api`:
+
+```bash
+pip install -e ".[codeflow,api]"
+```

--- a/docs/modules/codeflow/lld.md
+++ b/docs/modules/codeflow/lld.md
@@ -1,0 +1,12 @@
+# Codeflow Low-Level Design
+
+```mermaid
+flowchart TD
+    Request[CLI_or_API_request] --> Options[Parse_options]
+    Options --> Validate[Validate_input]
+    Validate --> Convert[codeflow_conversion]
+    Convert --> Render[Render_Markdown]
+    Render --> Return[Return_or_download_result]
+```
+
+The module should keep parsing, conversion, rendering, and interface concerns separated enough that CLI and API paths can reuse the same core behavior.

--- a/docs/modules/codeflow/logging.md
+++ b/docs/modules/codeflow/logging.md
@@ -1,0 +1,3 @@
+# Codeflow Logging
+
+Log module name, input type, job ID when present, output location, and bounded error details. Do not log uploaded file contents, credentials, or database connection secrets.

--- a/docs/modules/codeflow/overview.md
+++ b/docs/modules/codeflow/overview.md
@@ -1,0 +1,15 @@
+# Codeflow Module Overview
+
+Package: `md_generator.codeflow`  
+Source: `src/md_generator/codeflow`  
+CLI: `md-codeflow or codeflow`  
+Extra: `codeflow`
+
+This module accepts Source repositories and code trees and produces Architecture Markdown, call graphs, flow docs, JSON, Mermaid, and optional HTML. It participates in the unified `mdengine` distribution and follows the repository pattern of keeping feature dependencies optional.
+
+```mermaid
+flowchart LR
+    Input[Input] --> Module[codeflow_module]
+    Module --> Markdown[Markdown_output]
+    Module --> Assets[Assets_when_enabled]
+```

--- a/docs/modules/codeflow/responsibilities.md
+++ b/docs/modules/codeflow/responsibilities.md
@@ -1,0 +1,5 @@
+# Codeflow Responsibilities
+
+- Parse source code into an intermediate graph.
+- Detect entries and relationships.
+- Generate system overview and per-entry documentation.

--- a/docs/modules/codeflow/testing.md
+++ b/docs/modules/codeflow/testing.md
@@ -1,0 +1,7 @@
+# Codeflow Testing
+
+Tests for this feature area are expected under the matching top-level `*-to-md/tests` folder where present. Run targeted tests before changing the module and run broader `python -m pytest` before cross-module changes.
+
+```bash
+python -m pytest
+```

--- a/docs/modules/codeflow/workflows.md
+++ b/docs/modules/codeflow/workflows.md
@@ -1,0 +1,16 @@
+# Codeflow Workflows
+
+## CLI Workflow
+
+```bash
+md-codeflow --help
+```
+
+1. Install the required extra.
+2. Provide an input source: Source repositories and code trees.
+3. Choose an output path.
+4. Review generated Markdown and assets.
+
+## API Workflow
+
+If an API is detected for this module, submit a sync request for small work or a job request for larger work. Download endpoints return generated artifacts after completion.

--- a/docs/modules/db/api.md
+++ b/docs/modules/db/api.md
@@ -1,0 +1,5 @@
+# Database Metadata API
+
+FastAPI title: `db-to-md`.
+
+Detected endpoints: `/health, /db-to-md/run, /db-to-md/run/sqlite, /db-to-md/job, /db-to-md/job/sqlite, /db-to-md/job/{job_id}, /download, /events, /stream`.

--- a/docs/modules/db/configuration.md
+++ b/docs/modules/db/configuration.md
@@ -1,0 +1,11 @@
+# Database Metadata Configuration
+
+Configuration is supplied through CLI flags, API request fields, packaged YAML where the module provides it, and environment variables for service runtime concerns.
+
+For this module, begin with:
+
+```bash
+md-db --help
+```
+
+Source code lives in `src/md_generator/db`.

--- a/docs/modules/db/database.md
+++ b/docs/modules/db/database.md
@@ -1,0 +1,3 @@
+# Database Metadata Database Notes
+
+This module documents external databases; it does not define application-owned ORM tables.

--- a/docs/modules/db/deployment.md
+++ b/docs/modules/db/deployment.md
@@ -1,0 +1,5 @@
+# Database Metadata Deployment
+
+Deploy the API surface only when HTTP access is required. Install the smallest dependency extra set and add `api` for FastAPI runtime.
+
+For Dockerized services, follow the existing `Dockerfile.api` and Compose gateway pattern used by top-level converter folders.

--- a/docs/modules/db/exceptions.md
+++ b/docs/modules/db/exceptions.md
@@ -1,0 +1,5 @@
+# Database Metadata Exceptions
+
+Expected failures include missing optional dependencies, invalid inputs, unsupported source formats, external tool failures, and output write errors.
+
+API callers should receive structured HTTP failures. CLI users should receive a non-zero exit code and actionable terminal output.

--- a/docs/modules/db/installation.md
+++ b/docs/modules/db/installation.md
@@ -1,0 +1,17 @@
+# Database Metadata Installation
+
+```bash
+pip install "mdengine[db]"
+```
+
+For local development from a clone:
+
+```bash
+pip install -e ".[db,dev]"
+```
+
+If the module also runs as HTTP API, include `api`:
+
+```bash
+pip install -e ".[db,api]"
+```

--- a/docs/modules/db/lld.md
+++ b/docs/modules/db/lld.md
@@ -1,0 +1,12 @@
+# Database Metadata Low-Level Design
+
+```mermaid
+flowchart TD
+    Request[CLI_or_API_request] --> Options[Parse_options]
+    Options --> Validate[Validate_input]
+    Validate --> Convert[db_conversion]
+    Convert --> Render[Render_Markdown]
+    Render --> Return[Return_or_download_result]
+```
+
+The module should keep parsing, conversion, rendering, and interface concerns separated enough that CLI and API paths can reuse the same core behavior.

--- a/docs/modules/db/logging.md
+++ b/docs/modules/db/logging.md
@@ -1,0 +1,3 @@
+# Database Metadata Logging
+
+Log module name, input type, job ID when present, output location, and bounded error details. Do not log uploaded file contents, credentials, or database connection secrets.

--- a/docs/modules/db/overview.md
+++ b/docs/modules/db/overview.md
@@ -1,0 +1,15 @@
+# Database Metadata Module Overview
+
+Package: `md_generator.db`  
+Source: `src/md_generator/db`  
+CLI: `md-db`  
+Extra: `db`
+
+This module accepts Postgres, MySQL, Oracle, SQLite, and Mongo metadata sources and produces Schema documentation, ERD assets, and Markdown bundles. It participates in the unified `mdengine` distribution and follows the repository pattern of keeping feature dependencies optional.
+
+```mermaid
+flowchart LR
+    Input[Input] --> Module[db_module]
+    Module --> Markdown[Markdown_output]
+    Module --> Assets[Assets_when_enabled]
+```

--- a/docs/modules/db/responsibilities.md
+++ b/docs/modules/db/responsibilities.md
@@ -1,0 +1,5 @@
+# Database Metadata Responsibilities
+
+- Create database adapters from YAML/API configuration.
+- Introspect schemas, routines, indexes, triggers, and Mongo collections.
+- Write Markdown and ERD outputs.

--- a/docs/modules/db/testing.md
+++ b/docs/modules/db/testing.md
@@ -1,0 +1,7 @@
+# Database Metadata Testing
+
+Tests for this feature area are expected under the matching top-level `*-to-md/tests` folder where present. Run targeted tests before changing the module and run broader `python -m pytest` before cross-module changes.
+
+```bash
+python -m pytest
+```

--- a/docs/modules/db/workflows.md
+++ b/docs/modules/db/workflows.md
@@ -1,0 +1,16 @@
+# Database Metadata Workflows
+
+## CLI Workflow
+
+```bash
+md-db --help
+```
+
+1. Install the required extra.
+2. Provide an input source: Postgres, MySQL, Oracle, SQLite, and Mongo metadata sources.
+3. Choose an output path.
+4. Review generated Markdown and assets.
+
+## API Workflow
+
+If an API is detected for this module, submit a sync request for small work or a job request for larger work. Download endpoints return generated artifacts after completion.

--- a/docs/modules/graph/api.md
+++ b/docs/modules/graph/api.md
@@ -1,0 +1,5 @@
+# Graph Metadata API
+
+FastAPI title: `graph-to-md`.
+
+Detected endpoints: `/health, /graph-to-md/run, /graph-to-md/job, /graph-to-md/job/{job_id}, /download, /events, /stream`.

--- a/docs/modules/graph/configuration.md
+++ b/docs/modules/graph/configuration.md
@@ -1,0 +1,11 @@
+# Graph Metadata Configuration
+
+Configuration is supplied through CLI flags, API request fields, packaged YAML where the module provides it, and environment variables for service runtime concerns.
+
+For this module, begin with:
+
+```bash
+md-graph --help
+```
+
+Source code lives in `src/md_generator/graph`.

--- a/docs/modules/graph/database.md
+++ b/docs/modules/graph/database.md
@@ -1,0 +1,3 @@
+# Graph Metadata Database Notes
+
+Uses external graph databases or graph files; no app-owned tables are defined.

--- a/docs/modules/graph/deployment.md
+++ b/docs/modules/graph/deployment.md
@@ -1,0 +1,5 @@
+# Graph Metadata Deployment
+
+Deploy the API surface only when HTTP access is required. Install the smallest dependency extra set and add `api` for FastAPI runtime.
+
+For Dockerized services, follow the existing `Dockerfile.api` and Compose gateway pattern used by top-level converter folders.

--- a/docs/modules/graph/exceptions.md
+++ b/docs/modules/graph/exceptions.md
@@ -1,0 +1,5 @@
+# Graph Metadata Exceptions
+
+Expected failures include missing optional dependencies, invalid inputs, unsupported source formats, external tool failures, and output write errors.
+
+API callers should receive structured HTTP failures. CLI users should receive a non-zero exit code and actionable terminal output.

--- a/docs/modules/graph/installation.md
+++ b/docs/modules/graph/installation.md
@@ -1,0 +1,17 @@
+# Graph Metadata Installation
+
+```bash
+pip install "mdengine[graph]"
+```
+
+For local development from a clone:
+
+```bash
+pip install -e ".[graph,dev]"
+```
+
+If the module also runs as HTTP API, include `api`:
+
+```bash
+pip install -e ".[graph,api]"
+```

--- a/docs/modules/graph/lld.md
+++ b/docs/modules/graph/lld.md
@@ -1,0 +1,12 @@
+# Graph Metadata Low-Level Design
+
+```mermaid
+flowchart TD
+    Request[CLI_or_API_request] --> Options[Parse_options]
+    Options --> Validate[Validate_input]
+    Validate --> Convert[graph_conversion]
+    Convert --> Render[Render_Markdown]
+    Render --> Return[Return_or_download_result]
+```
+
+The module should keep parsing, conversion, rendering, and interface concerns separated enough that CLI and API paths can reuse the same core behavior.

--- a/docs/modules/graph/logging.md
+++ b/docs/modules/graph/logging.md
@@ -1,0 +1,3 @@
+# Graph Metadata Logging
+
+Log module name, input type, job ID when present, output location, and bounded error details. Do not log uploaded file contents, credentials, or database connection secrets.

--- a/docs/modules/graph/overview.md
+++ b/docs/modules/graph/overview.md
@@ -1,0 +1,15 @@
+# Graph Metadata Module Overview
+
+Package: `md_generator.graph`  
+Source: `src/md_generator/graph`  
+CLI: `md-graph`  
+Extra: `graph`
+
+This module accepts Neo4j and NetworkX graph sources and produces Graph entity Markdown, summaries, Mermaid, and optional Graphviz artifacts. It participates in the unified `mdengine` distribution and follows the repository pattern of keeping feature dependencies optional.
+
+```mermaid
+flowchart LR
+    Input[Input] --> Module[graph_module]
+    Module --> Markdown[Markdown_output]
+    Module --> Assets[Assets_when_enabled]
+```

--- a/docs/modules/graph/responsibilities.md
+++ b/docs/modules/graph/responsibilities.md
@@ -1,0 +1,5 @@
+# Graph Metadata Responsibilities
+
+- Read graph sources through configured adapters.
+- Document nodes and relationships.
+- Emit visualization artifacts.

--- a/docs/modules/graph/testing.md
+++ b/docs/modules/graph/testing.md
@@ -1,0 +1,7 @@
+# Graph Metadata Testing
+
+Tests for this feature area are expected under the matching top-level `*-to-md/tests` folder where present. Run targeted tests before changing the module and run broader `python -m pytest` before cross-module changes.
+
+```bash
+python -m pytest
+```

--- a/docs/modules/graph/workflows.md
+++ b/docs/modules/graph/workflows.md
@@ -1,0 +1,16 @@
+# Graph Metadata Workflows
+
+## CLI Workflow
+
+```bash
+md-graph --help
+```
+
+1. Install the required extra.
+2. Provide an input source: Neo4j and NetworkX graph sources.
+3. Choose an output path.
+4. Review generated Markdown and assets.
+
+## API Workflow
+
+If an API is detected for this module, submit a sync request for small work or a job request for larger work. Download endpoints return generated artifacts after completion.

--- a/docs/modules/image/api.md
+++ b/docs/modules/image/api.md
@@ -1,0 +1,5 @@
+# Image OCR API
+
+FastAPI title: `image-to-md`.
+
+Detected endpoints: `/convert/sync, /convert/jobs, /convert/jobs/{job_id}, /convert/jobs/{job_id}/download`.

--- a/docs/modules/image/configuration.md
+++ b/docs/modules/image/configuration.md
@@ -1,0 +1,11 @@
+# Image OCR Configuration
+
+Configuration is supplied through CLI flags, API request fields, packaged YAML where the module provides it, and environment variables for service runtime concerns.
+
+For this module, begin with:
+
+```bash
+md-image --help
+```
+
+Source code lives in `src/md_generator/image`.

--- a/docs/modules/image/database.md
+++ b/docs/modules/image/database.md
@@ -1,0 +1,3 @@
+# Image OCR Database Notes
+
+No repository database tables are owned by this module.

--- a/docs/modules/image/deployment.md
+++ b/docs/modules/image/deployment.md
@@ -1,0 +1,5 @@
+# Image OCR Deployment
+
+Deploy the API surface only when HTTP access is required. Install the smallest dependency extra set and add `api` for FastAPI runtime.
+
+For Dockerized services, follow the existing `Dockerfile.api` and Compose gateway pattern used by top-level converter folders.

--- a/docs/modules/image/exceptions.md
+++ b/docs/modules/image/exceptions.md
@@ -1,0 +1,5 @@
+# Image OCR Exceptions
+
+Expected failures include missing optional dependencies, invalid inputs, unsupported source formats, external tool failures, and output write errors.
+
+API callers should receive structured HTTP failures. CLI users should receive a non-zero exit code and actionable terminal output.

--- a/docs/modules/image/installation.md
+++ b/docs/modules/image/installation.md
@@ -1,0 +1,17 @@
+# Image OCR Installation
+
+```bash
+pip install "mdengine[image]"
+```
+
+For local development from a clone:
+
+```bash
+pip install -e ".[image,dev]"
+```
+
+If the module also runs as HTTP API, include `api`:
+
+```bash
+pip install -e ".[image,api]"
+```

--- a/docs/modules/image/lld.md
+++ b/docs/modules/image/lld.md
@@ -1,0 +1,12 @@
+# Image OCR Low-Level Design
+
+```mermaid
+flowchart TD
+    Request[CLI_or_API_request] --> Options[Parse_options]
+    Options --> Validate[Validate_input]
+    Validate --> Convert[image_conversion]
+    Convert --> Render[Render_Markdown]
+    Render --> Return[Return_or_download_result]
+```
+
+The module should keep parsing, conversion, rendering, and interface concerns separated enough that CLI and API paths can reuse the same core behavior.

--- a/docs/modules/image/logging.md
+++ b/docs/modules/image/logging.md
@@ -1,0 +1,3 @@
+# Image OCR Logging
+
+Log module name, input type, job ID when present, output location, and bounded error details. Do not log uploaded file contents, credentials, or database connection secrets.

--- a/docs/modules/image/overview.md
+++ b/docs/modules/image/overview.md
@@ -1,0 +1,15 @@
+# Image OCR Module Overview
+
+Package: `md_generator.image`  
+Source: `src/md_generator/image`  
+CLI: `md-image`  
+Extra: `image or image-ocr`
+
+This module accepts Image files or directories and produces OCR text and image metadata as Markdown. It participates in the unified `mdengine` distribution and follows the repository pattern of keeping feature dependencies optional.
+
+```mermaid
+flowchart LR
+    Input[Input] --> Module[image_module]
+    Module --> Markdown[Markdown_output]
+    Module --> Assets[Assets_when_enabled]
+```

--- a/docs/modules/image/responsibilities.md
+++ b/docs/modules/image/responsibilities.md
@@ -1,0 +1,5 @@
+# Image OCR Responsibilities
+
+- Load image inputs.
+- Run configured OCR engines when installed.
+- Choose OCR strategy and emit Markdown summaries.

--- a/docs/modules/image/testing.md
+++ b/docs/modules/image/testing.md
@@ -1,0 +1,7 @@
+# Image OCR Testing
+
+Tests for this feature area are expected under the matching top-level `*-to-md/tests` folder where present. Run targeted tests before changing the module and run broader `python -m pytest` before cross-module changes.
+
+```bash
+python -m pytest
+```

--- a/docs/modules/image/workflows.md
+++ b/docs/modules/image/workflows.md
@@ -1,0 +1,16 @@
+# Image OCR Workflows
+
+## CLI Workflow
+
+```bash
+md-image --help
+```
+
+1. Install the required extra.
+2. Provide an input source: Image files or directories.
+3. Choose an output path.
+4. Review generated Markdown and assets.
+
+## API Workflow
+
+If an API is detected for this module, submit a sync request for small work or a job request for larger work. Download endpoints return generated artifacts after completion.

--- a/docs/modules/log/api.md
+++ b/docs/modules/log/api.md
@@ -1,0 +1,5 @@
+# Log Analysis API
+
+FastAPI title: `log-to-md`.
+
+Detected endpoints: `/health, /log-to-md/run, /log-to-md/run/upload, /log-to-md/job, /log-to-md/job/upload, /log-to-md/job/{job_id}, /download, /events, /stream`.

--- a/docs/modules/log/configuration.md
+++ b/docs/modules/log/configuration.md
@@ -1,0 +1,11 @@
+# Log Analysis Configuration
+
+Configuration is supplied through CLI flags, API request fields, packaged YAML where the module provides it, and environment variables for service runtime concerns.
+
+For this module, begin with:
+
+```bash
+md-log --help
+```
+
+Source code lives in `src/md_generator/log`.

--- a/docs/modules/log/database.md
+++ b/docs/modules/log/database.md
@@ -1,0 +1,3 @@
+# Log Analysis Database Notes
+
+No repository database tables are owned by this module.

--- a/docs/modules/log/deployment.md
+++ b/docs/modules/log/deployment.md
@@ -1,0 +1,5 @@
+# Log Analysis Deployment
+
+Deploy the API surface only when HTTP access is required. Install the smallest dependency extra set and add `api` for FastAPI runtime.
+
+For Dockerized services, follow the existing `Dockerfile.api` and Compose gateway pattern used by top-level converter folders.

--- a/docs/modules/log/exceptions.md
+++ b/docs/modules/log/exceptions.md
@@ -1,0 +1,5 @@
+# Log Analysis Exceptions
+
+Expected failures include missing optional dependencies, invalid inputs, unsupported source formats, external tool failures, and output write errors.
+
+API callers should receive structured HTTP failures. CLI users should receive a non-zero exit code and actionable terminal output.

--- a/docs/modules/log/installation.md
+++ b/docs/modules/log/installation.md
@@ -1,0 +1,17 @@
+# Log Analysis Installation
+
+```bash
+pip install "mdengine[log]"
+```
+
+For local development from a clone:
+
+```bash
+pip install -e ".[log,dev]"
+```
+
+If the module also runs as HTTP API, include `api`:
+
+```bash
+pip install -e ".[log,api]"
+```

--- a/docs/modules/log/lld.md
+++ b/docs/modules/log/lld.md
@@ -1,0 +1,12 @@
+# Log Analysis Low-Level Design
+
+```mermaid
+flowchart TD
+    Request[CLI_or_API_request] --> Options[Parse_options]
+    Options --> Validate[Validate_input]
+    Validate --> Convert[log_conversion]
+    Convert --> Render[Render_Markdown]
+    Render --> Return[Return_or_download_result]
+```
+
+The module should keep parsing, conversion, rendering, and interface concerns separated enough that CLI and API paths can reuse the same core behavior.

--- a/docs/modules/log/logging.md
+++ b/docs/modules/log/logging.md
@@ -1,0 +1,3 @@
+# Log Analysis Logging
+
+Log module name, input type, job ID when present, output location, and bounded error details. Do not log uploaded file contents, credentials, or database connection secrets.

--- a/docs/modules/log/overview.md
+++ b/docs/modules/log/overview.md
@@ -1,0 +1,15 @@
+# Log Analysis Module Overview
+
+Package: `md_generator.log`  
+Source: `src/md_generator/log`  
+CLI: `md-log`  
+Extra: `log`
+
+This module accepts Log files and uploaded log content and produces Markdown summaries, parsed events, and optional clustering output. It participates in the unified `mdengine` distribution and follows the repository pattern of keeping feature dependencies optional.
+
+```mermaid
+flowchart LR
+    Input[Input] --> Module[log_module]
+    Module --> Markdown[Markdown_output]
+    Module --> Assets[Assets_when_enabled]
+```

--- a/docs/modules/log/responsibilities.md
+++ b/docs/modules/log/responsibilities.md
@@ -1,0 +1,5 @@
+# Log Analysis Responsibilities
+
+- Parse logs with configured presets.
+- Summarize events and time ranges.
+- Expose sync, upload, and async job APIs.

--- a/docs/modules/log/testing.md
+++ b/docs/modules/log/testing.md
@@ -1,0 +1,7 @@
+# Log Analysis Testing
+
+Tests for this feature area are expected under the matching top-level `*-to-md/tests` folder where present. Run targeted tests before changing the module and run broader `python -m pytest` before cross-module changes.
+
+```bash
+python -m pytest
+```

--- a/docs/modules/log/workflows.md
+++ b/docs/modules/log/workflows.md
@@ -1,0 +1,16 @@
+# Log Analysis Workflows
+
+## CLI Workflow
+
+```bash
+md-log --help
+```
+
+1. Install the required extra.
+2. Provide an input source: Log files and uploaded log content.
+3. Choose an output path.
+4. Review generated Markdown and assets.
+
+## API Workflow
+
+If an API is detected for this module, submit a sync request for small work or a job request for larger work. Download endpoints return generated artifacts after completion.

--- a/docs/modules/media-audio/api.md
+++ b/docs/modules/media-audio/api.md
@@ -1,0 +1,5 @@
+# Audio API
+
+FastAPI title: `audio-to-md`.
+
+Detected endpoints: `/convert/sync, /convert/jobs, /convert/jobs/{job_id}, /convert/jobs/{job_id}/download`.

--- a/docs/modules/media-audio/configuration.md
+++ b/docs/modules/media-audio/configuration.md
@@ -1,0 +1,11 @@
+# Audio Configuration
+
+Configuration is supplied through CLI flags, API request fields, packaged YAML where the module provides it, and environment variables for service runtime concerns.
+
+For this module, begin with:
+
+```bash
+md-audio --help
+```
+
+Source code lives in `src/md_generator/media/audio`.

--- a/docs/modules/media-audio/database.md
+++ b/docs/modules/media-audio/database.md
@@ -1,0 +1,3 @@
+# Audio Database Notes
+
+No repository database tables are owned by this module.

--- a/docs/modules/media-audio/deployment.md
+++ b/docs/modules/media-audio/deployment.md
@@ -1,0 +1,5 @@
+# Audio Deployment
+
+Deploy the API surface only when HTTP access is required. Install the smallest dependency extra set and add `api` for FastAPI runtime.
+
+For Dockerized services, follow the existing `Dockerfile.api` and Compose gateway pattern used by top-level converter folders.

--- a/docs/modules/media-audio/exceptions.md
+++ b/docs/modules/media-audio/exceptions.md
@@ -1,0 +1,5 @@
+# Audio Exceptions
+
+Expected failures include missing optional dependencies, invalid inputs, unsupported source formats, external tool failures, and output write errors.
+
+API callers should receive structured HTTP failures. CLI users should receive a non-zero exit code and actionable terminal output.

--- a/docs/modules/media-audio/installation.md
+++ b/docs/modules/media-audio/installation.md
@@ -1,0 +1,17 @@
+# Audio Installation
+
+```bash
+pip install "mdengine[audio]"
+```
+
+For local development from a clone:
+
+```bash
+pip install -e ".[audio,dev]"
+```
+
+If the module also runs as HTTP API, include `api`:
+
+```bash
+pip install -e ".[audio,api]"
+```

--- a/docs/modules/media-audio/lld.md
+++ b/docs/modules/media-audio/lld.md
@@ -1,0 +1,12 @@
+# Audio Low-Level Design
+
+```mermaid
+flowchart TD
+    Request[CLI_or_API_request] --> Options[Parse_options]
+    Options --> Validate[Validate_input]
+    Validate --> Convert[media_audio_conversion]
+    Convert --> Render[Render_Markdown]
+    Render --> Return[Return_or_download_result]
+```
+
+The module should keep parsing, conversion, rendering, and interface concerns separated enough that CLI and API paths can reuse the same core behavior.

--- a/docs/modules/media-audio/logging.md
+++ b/docs/modules/media-audio/logging.md
@@ -1,0 +1,3 @@
+# Audio Logging
+
+Log module name, input type, job ID when present, output location, and bounded error details. Do not log uploaded file contents, credentials, or database connection secrets.

--- a/docs/modules/media-audio/overview.md
+++ b/docs/modules/media-audio/overview.md
@@ -1,0 +1,15 @@
+# Audio Module Overview
+
+Package: `md_generator.media.audio`  
+Source: `src/md_generator/media/audio`  
+CLI: `md-audio`  
+Extra: `audio`
+
+This module accepts Audio files and produces Whisper transcript Markdown. It participates in the unified `mdengine` distribution and follows the repository pattern of keeping feature dependencies optional.
+
+```mermaid
+flowchart LR
+    Input[Input] --> Module[media_audio_module]
+    Module --> Markdown[Markdown_output]
+    Module --> Assets[Assets_when_enabled]
+```

--- a/docs/modules/media-audio/responsibilities.md
+++ b/docs/modules/media-audio/responsibilities.md
@@ -1,0 +1,5 @@
+# Audio Responsibilities
+
+- Prepare audio for transcription.
+- Run Whisper with the selected model.
+- Return transcript and metadata.

--- a/docs/modules/media-audio/testing.md
+++ b/docs/modules/media-audio/testing.md
@@ -1,0 +1,7 @@
+# Audio Testing
+
+Tests for this feature area are expected under the matching top-level `*-to-md/tests` folder where present. Run targeted tests before changing the module and run broader `python -m pytest` before cross-module changes.
+
+```bash
+python -m pytest
+```

--- a/docs/modules/media-audio/workflows.md
+++ b/docs/modules/media-audio/workflows.md
@@ -1,0 +1,16 @@
+# Audio Workflows
+
+## CLI Workflow
+
+```bash
+md-audio --help
+```
+
+1. Install the required extra.
+2. Provide an input source: Audio files.
+3. Choose an output path.
+4. Review generated Markdown and assets.
+
+## API Workflow
+
+If an API is detected for this module, submit a sync request for small work or a job request for larger work. Download endpoints return generated artifacts after completion.

--- a/docs/modules/media-video/api.md
+++ b/docs/modules/media-video/api.md
@@ -1,0 +1,5 @@
+# Video API
+
+FastAPI title: `video-to-md`.
+
+Detected endpoints: `/convert/sync, /convert/jobs, /convert/jobs/{job_id}, /convert/jobs/{job_id}/download`.

--- a/docs/modules/media-video/configuration.md
+++ b/docs/modules/media-video/configuration.md
@@ -1,0 +1,11 @@
+# Video Configuration
+
+Configuration is supplied through CLI flags, API request fields, packaged YAML where the module provides it, and environment variables for service runtime concerns.
+
+For this module, begin with:
+
+```bash
+md-video --help
+```
+
+Source code lives in `src/md_generator/media/video`.

--- a/docs/modules/media-video/database.md
+++ b/docs/modules/media-video/database.md
@@ -1,0 +1,3 @@
+# Video Database Notes
+
+No repository database tables are owned by this module.

--- a/docs/modules/media-video/deployment.md
+++ b/docs/modules/media-video/deployment.md
@@ -1,0 +1,5 @@
+# Video Deployment
+
+Deploy the API surface only when HTTP access is required. Install the smallest dependency extra set and add `api` for FastAPI runtime.
+
+For Dockerized services, follow the existing `Dockerfile.api` and Compose gateway pattern used by top-level converter folders.

--- a/docs/modules/media-video/exceptions.md
+++ b/docs/modules/media-video/exceptions.md
@@ -1,0 +1,5 @@
+# Video Exceptions
+
+Expected failures include missing optional dependencies, invalid inputs, unsupported source formats, external tool failures, and output write errors.
+
+API callers should receive structured HTTP failures. CLI users should receive a non-zero exit code and actionable terminal output.

--- a/docs/modules/media-video/installation.md
+++ b/docs/modules/media-video/installation.md
@@ -1,0 +1,17 @@
+# Video Installation
+
+```bash
+pip install "mdengine[video]"
+```
+
+For local development from a clone:
+
+```bash
+pip install -e ".[video,dev]"
+```
+
+If the module also runs as HTTP API, include `api`:
+
+```bash
+pip install -e ".[video,api]"
+```

--- a/docs/modules/media-video/lld.md
+++ b/docs/modules/media-video/lld.md
@@ -1,0 +1,12 @@
+# Video Low-Level Design
+
+```mermaid
+flowchart TD
+    Request[CLI_or_API_request] --> Options[Parse_options]
+    Options --> Validate[Validate_input]
+    Validate --> Convert[media_video_conversion]
+    Convert --> Render[Render_Markdown]
+    Render --> Return[Return_or_download_result]
+```
+
+The module should keep parsing, conversion, rendering, and interface concerns separated enough that CLI and API paths can reuse the same core behavior.

--- a/docs/modules/media-video/logging.md
+++ b/docs/modules/media-video/logging.md
@@ -1,0 +1,3 @@
+# Video Logging
+
+Log module name, input type, job ID when present, output location, and bounded error details. Do not log uploaded file contents, credentials, or database connection secrets.

--- a/docs/modules/media-video/overview.md
+++ b/docs/modules/media-video/overview.md
@@ -1,0 +1,15 @@
+# Video Module Overview
+
+Package: `md_generator.media.video`  
+Source: `src/md_generator/media/video`  
+CLI: `md-video`  
+Extra: `video`
+
+This module accepts Video files and produces Audio transcript Markdown with video metadata. It participates in the unified `mdengine` distribution and follows the repository pattern of keeping feature dependencies optional.
+
+```mermaid
+flowchart LR
+    Input[Input] --> Module[media_video_module]
+    Module --> Markdown[Markdown_output]
+    Module --> Assets[Assets_when_enabled]
+```

--- a/docs/modules/media-video/responsibilities.md
+++ b/docs/modules/media-video/responsibilities.md
@@ -1,0 +1,5 @@
+# Video Responsibilities
+
+- Extract audio through ffmpeg/imageio-ffmpeg.
+- Run Whisper transcription.
+- Package transcript output.

--- a/docs/modules/media-video/testing.md
+++ b/docs/modules/media-video/testing.md
@@ -1,0 +1,7 @@
+# Video Testing
+
+Tests for this feature area are expected under the matching top-level `*-to-md/tests` folder where present. Run targeted tests before changing the module and run broader `python -m pytest` before cross-module changes.
+
+```bash
+python -m pytest
+```

--- a/docs/modules/media-video/workflows.md
+++ b/docs/modules/media-video/workflows.md
@@ -1,0 +1,16 @@
+# Video Workflows
+
+## CLI Workflow
+
+```bash
+md-video --help
+```
+
+1. Install the required extra.
+2. Provide an input source: Video files.
+3. Choose an output path.
+4. Review generated Markdown and assets.
+
+## API Workflow
+
+If an API is detected for this module, submit a sync request for small work or a job request for larger work. Download endpoints return generated artifacts after completion.

--- a/docs/modules/media-youtube/api.md
+++ b/docs/modules/media-youtube/api.md
@@ -1,0 +1,5 @@
+# YouTube API
+
+FastAPI title: `youtube-to-md`.
+
+Detected endpoints: `/convert/sync, /convert/jobs, /convert/jobs/{job_id}, /convert/jobs/{job_id}/download`.

--- a/docs/modules/media-youtube/configuration.md
+++ b/docs/modules/media-youtube/configuration.md
@@ -1,0 +1,11 @@
+# YouTube Configuration
+
+Configuration is supplied through CLI flags, API request fields, packaged YAML where the module provides it, and environment variables for service runtime concerns.
+
+For this module, begin with:
+
+```bash
+md-youtube --help
+```
+
+Source code lives in `src/md_generator/media/youtube`.

--- a/docs/modules/media-youtube/database.md
+++ b/docs/modules/media-youtube/database.md
@@ -1,0 +1,3 @@
+# YouTube Database Notes
+
+No repository database tables are owned by this module.

--- a/docs/modules/media-youtube/deployment.md
+++ b/docs/modules/media-youtube/deployment.md
@@ -1,0 +1,5 @@
+# YouTube Deployment
+
+Deploy the API surface only when HTTP access is required. Install the smallest dependency extra set and add `api` for FastAPI runtime.
+
+For Dockerized services, follow the existing `Dockerfile.api` and Compose gateway pattern used by top-level converter folders.

--- a/docs/modules/media-youtube/exceptions.md
+++ b/docs/modules/media-youtube/exceptions.md
@@ -1,0 +1,5 @@
+# YouTube Exceptions
+
+Expected failures include missing optional dependencies, invalid inputs, unsupported source formats, external tool failures, and output write errors.
+
+API callers should receive structured HTTP failures. CLI users should receive a non-zero exit code and actionable terminal output.

--- a/docs/modules/media-youtube/installation.md
+++ b/docs/modules/media-youtube/installation.md
@@ -1,0 +1,17 @@
+# YouTube Installation
+
+```bash
+pip install "mdengine[youtube]"
+```
+
+For local development from a clone:
+
+```bash
+pip install -e ".[youtube,dev]"
+```
+
+If the module also runs as HTTP API, include `api`:
+
+```bash
+pip install -e ".[youtube,api]"
+```

--- a/docs/modules/media-youtube/lld.md
+++ b/docs/modules/media-youtube/lld.md
@@ -1,0 +1,12 @@
+# YouTube Low-Level Design
+
+```mermaid
+flowchart TD
+    Request[CLI_or_API_request] --> Options[Parse_options]
+    Options --> Validate[Validate_input]
+    Validate --> Convert[media_youtube_conversion]
+    Convert --> Render[Render_Markdown]
+    Render --> Return[Return_or_download_result]
+```
+
+The module should keep parsing, conversion, rendering, and interface concerns separated enough that CLI and API paths can reuse the same core behavior.

--- a/docs/modules/media-youtube/logging.md
+++ b/docs/modules/media-youtube/logging.md
@@ -1,0 +1,3 @@
+# YouTube Logging
+
+Log module name, input type, job ID when present, output location, and bounded error details. Do not log uploaded file contents, credentials, or database connection secrets.

--- a/docs/modules/media-youtube/overview.md
+++ b/docs/modules/media-youtube/overview.md
@@ -1,0 +1,15 @@
+# YouTube Module Overview
+
+Package: `md_generator.media.youtube`  
+Source: `src/md_generator/media/youtube`  
+CLI: `md-youtube`  
+Extra: `youtube`
+
+This module accepts YouTube URLs and produces Transcript and page metadata Markdown. It participates in the unified `mdengine` distribution and follows the repository pattern of keeping feature dependencies optional.
+
+```mermaid
+flowchart LR
+    Input[Input] --> Module[media_youtube_module]
+    Module --> Markdown[Markdown_output]
+    Module --> Assets[Assets_when_enabled]
+```

--- a/docs/modules/media-youtube/responsibilities.md
+++ b/docs/modules/media-youtube/responsibilities.md
@@ -1,0 +1,5 @@
+# YouTube Responsibilities
+
+- Resolve YouTube transcript data.
+- Fetch metadata when available.
+- Render transcript Markdown.

--- a/docs/modules/media-youtube/testing.md
+++ b/docs/modules/media-youtube/testing.md
@@ -1,0 +1,7 @@
+# YouTube Testing
+
+Tests for this feature area are expected under the matching top-level `*-to-md/tests` folder where present. Run targeted tests before changing the module and run broader `python -m pytest` before cross-module changes.
+
+```bash
+python -m pytest
+```

--- a/docs/modules/media-youtube/workflows.md
+++ b/docs/modules/media-youtube/workflows.md
@@ -1,0 +1,16 @@
+# YouTube Workflows
+
+## CLI Workflow
+
+```bash
+md-youtube --help
+```
+
+1. Install the required extra.
+2. Provide an input source: YouTube URLs.
+3. Choose an output path.
+4. Review generated Markdown and assets.
+
+## API Workflow
+
+If an API is detected for this module, submit a sync request for small work or a job request for larger work. Download endpoints return generated artifacts after completion.

--- a/docs/modules/openapi/api.md
+++ b/docs/modules/openapi/api.md
@@ -1,0 +1,5 @@
+# OpenAPI API
+
+FastAPI title: `openapi-to-md`.
+
+Detected endpoints: `/health, /openapi-to-md/generate, /mcp`.

--- a/docs/modules/openapi/configuration.md
+++ b/docs/modules/openapi/configuration.md
@@ -1,0 +1,11 @@
+# OpenAPI Configuration
+
+Configuration is supplied through CLI flags, API request fields, packaged YAML where the module provides it, and environment variables for service runtime concerns.
+
+For this module, begin with:
+
+```bash
+md-openapi --help
+```
+
+Source code lives in `src/md_generator/openapi`.

--- a/docs/modules/openapi/database.md
+++ b/docs/modules/openapi/database.md
@@ -1,0 +1,3 @@
+# OpenAPI Database Notes
+
+No repository database tables are owned by this module.

--- a/docs/modules/openapi/deployment.md
+++ b/docs/modules/openapi/deployment.md
@@ -1,0 +1,5 @@
+# OpenAPI Deployment
+
+Deploy the API surface only when HTTP access is required. Install the smallest dependency extra set and add `api` for FastAPI runtime.
+
+For Dockerized services, follow the existing `Dockerfile.api` and Compose gateway pattern used by top-level converter folders.

--- a/docs/modules/openapi/exceptions.md
+++ b/docs/modules/openapi/exceptions.md
@@ -1,0 +1,5 @@
+# OpenAPI Exceptions
+
+Expected failures include missing optional dependencies, invalid inputs, unsupported source formats, external tool failures, and output write errors.
+
+API callers should receive structured HTTP failures. CLI users should receive a non-zero exit code and actionable terminal output.

--- a/docs/modules/openapi/installation.md
+++ b/docs/modules/openapi/installation.md
@@ -1,0 +1,17 @@
+# OpenAPI Installation
+
+```bash
+pip install "mdengine[openapi]"
+```
+
+For local development from a clone:
+
+```bash
+pip install -e ".[openapi,dev]"
+```
+
+If the module also runs as HTTP API, include `api`:
+
+```bash
+pip install -e ".[openapi,api]"
+```

--- a/docs/modules/openapi/lld.md
+++ b/docs/modules/openapi/lld.md
@@ -1,0 +1,12 @@
+# OpenAPI Low-Level Design
+
+```mermaid
+flowchart TD
+    Request[CLI_or_API_request] --> Options[Parse_options]
+    Options --> Validate[Validate_input]
+    Validate --> Convert[openapi_conversion]
+    Convert --> Render[Render_Markdown]
+    Render --> Return[Return_or_download_result]
+```
+
+The module should keep parsing, conversion, rendering, and interface concerns separated enough that CLI and API paths can reuse the same core behavior.

--- a/docs/modules/openapi/logging.md
+++ b/docs/modules/openapi/logging.md
@@ -1,0 +1,3 @@
+# OpenAPI Logging
+
+Log module name, input type, job ID when present, output location, and bounded error details. Do not log uploaded file contents, credentials, or database connection secrets.

--- a/docs/modules/openapi/overview.md
+++ b/docs/modules/openapi/overview.md
@@ -1,0 +1,15 @@
+# OpenAPI Module Overview
+
+Package: `md_generator.openapi`  
+Source: `src/md_generator/openapi`  
+CLI: `md-openapi`  
+Extra: `openapi`
+
+This module accepts OpenAPI 3.x or Swagger 2.0 specifications and produces API documentation bundles. It participates in the unified `mdengine` distribution and follows the repository pattern of keeping feature dependencies optional.
+
+```mermaid
+flowchart LR
+    Input[Input] --> Module[openapi_module]
+    Module --> Markdown[Markdown_output]
+    Module --> Assets[Assets_when_enabled]
+```

--- a/docs/modules/openapi/responsibilities.md
+++ b/docs/modules/openapi/responsibilities.md
@@ -1,0 +1,5 @@
+# OpenAPI Responsibilities
+
+- Parse and validate OpenAPI documents.
+- Convert Swagger 2.0 specs to OpenAPI 3.0.3.
+- Generate endpoint reference Markdown.

--- a/docs/modules/openapi/testing.md
+++ b/docs/modules/openapi/testing.md
@@ -1,0 +1,7 @@
+# OpenAPI Testing
+
+Tests for this feature area are expected under the matching top-level `*-to-md/tests` folder where present. Run targeted tests before changing the module and run broader `python -m pytest` before cross-module changes.
+
+```bash
+python -m pytest
+```

--- a/docs/modules/openapi/workflows.md
+++ b/docs/modules/openapi/workflows.md
@@ -1,0 +1,16 @@
+# OpenAPI Workflows
+
+## CLI Workflow
+
+```bash
+md-openapi --help
+```
+
+1. Install the required extra.
+2. Provide an input source: OpenAPI 3.x or Swagger 2.0 specifications.
+3. Choose an output path.
+4. Review generated Markdown and assets.
+
+## API Workflow
+
+If an API is detected for this module, submit a sync request for small work or a job request for larger work. Download endpoints return generated artifacts after completion.

--- a/docs/modules/pdf/api.md
+++ b/docs/modules/pdf/api.md
@@ -1,0 +1,5 @@
+# PDF API
+
+FastAPI title: `pdf-to-md`.
+
+Detected endpoints: `/convert/sync, /convert/jobs, /convert/jobs/{job_id}, /convert/jobs/{job_id}/download`.

--- a/docs/modules/pdf/configuration.md
+++ b/docs/modules/pdf/configuration.md
@@ -1,0 +1,11 @@
+# PDF Configuration
+
+Configuration is supplied through CLI flags, API request fields, packaged YAML where the module provides it, and environment variables for service runtime concerns.
+
+For this module, begin with:
+
+```bash
+md-pdf --help
+```
+
+Source code lives in `src/md_generator/pdf`.

--- a/docs/modules/pdf/database.md
+++ b/docs/modules/pdf/database.md
@@ -1,0 +1,3 @@
+# PDF Database Notes
+
+No repository database tables are owned by this module.

--- a/docs/modules/pdf/deployment.md
+++ b/docs/modules/pdf/deployment.md
@@ -1,0 +1,5 @@
+# PDF Deployment
+
+Deploy the API surface only when HTTP access is required. Install the smallest dependency extra set and add `api` for FastAPI runtime.
+
+For Dockerized services, follow the existing `Dockerfile.api` and Compose gateway pattern used by top-level converter folders.

--- a/docs/modules/pdf/exceptions.md
+++ b/docs/modules/pdf/exceptions.md
@@ -1,0 +1,5 @@
+# PDF Exceptions
+
+Expected failures include missing optional dependencies, invalid inputs, unsupported source formats, external tool failures, and output write errors.
+
+API callers should receive structured HTTP failures. CLI users should receive a non-zero exit code and actionable terminal output.

--- a/docs/modules/pdf/installation.md
+++ b/docs/modules/pdf/installation.md
@@ -1,0 +1,17 @@
+# PDF Installation
+
+```bash
+pip install "mdengine[pdf]"
+```
+
+For local development from a clone:
+
+```bash
+pip install -e ".[pdf,dev]"
+```
+
+If the module also runs as HTTP API, include `api`:
+
+```bash
+pip install -e ".[pdf,api]"
+```

--- a/docs/modules/pdf/lld.md
+++ b/docs/modules/pdf/lld.md
@@ -1,0 +1,12 @@
+# PDF Low-Level Design
+
+```mermaid
+flowchart TD
+    Request[CLI_or_API_request] --> Options[Parse_options]
+    Options --> Validate[Validate_input]
+    Validate --> Convert[pdf_conversion]
+    Convert --> Render[Render_Markdown]
+    Render --> Return[Return_or_download_result]
+```
+
+The module should keep parsing, conversion, rendering, and interface concerns separated enough that CLI and API paths can reuse the same core behavior.

--- a/docs/modules/pdf/logging.md
+++ b/docs/modules/pdf/logging.md
@@ -1,0 +1,3 @@
+# PDF Logging
+
+Log module name, input type, job ID when present, output location, and bounded error details. Do not log uploaded file contents, credentials, or database connection secrets.

--- a/docs/modules/pdf/overview.md
+++ b/docs/modules/pdf/overview.md
@@ -1,0 +1,15 @@
+# PDF Module Overview
+
+Package: `md_generator.pdf`  
+Source: `src/md_generator/pdf`  
+CLI: `md-pdf`  
+Extra: `pdf`
+
+This module accepts PDF documents and produces Markdown with optional artifact layout and extracted images. It participates in the unified `mdengine` distribution and follows the repository pattern of keeping feature dependencies optional.
+
+```mermaid
+flowchart LR
+    Input[Input] --> Module[pdf_module]
+    Module --> Markdown[Markdown_output]
+    Module --> Assets[Assets_when_enabled]
+```

--- a/docs/modules/pdf/responsibilities.md
+++ b/docs/modules/pdf/responsibilities.md
@@ -1,0 +1,5 @@
+# PDF Responsibilities
+
+- Extract text and page structure from PDF files.
+- Preserve document order for Markdown output.
+- Support CLI and FastAPI conversion paths.

--- a/docs/modules/pdf/testing.md
+++ b/docs/modules/pdf/testing.md
@@ -1,0 +1,7 @@
+# PDF Testing
+
+Tests for this feature area are expected under the matching top-level `*-to-md/tests` folder where present. Run targeted tests before changing the module and run broader `python -m pytest` before cross-module changes.
+
+```bash
+python -m pytest
+```

--- a/docs/modules/pdf/workflows.md
+++ b/docs/modules/pdf/workflows.md
@@ -1,0 +1,16 @@
+# PDF Workflows
+
+## CLI Workflow
+
+```bash
+md-pdf --help
+```
+
+1. Install the required extra.
+2. Provide an input source: PDF documents.
+3. Choose an output path.
+4. Review generated Markdown and assets.
+
+## API Workflow
+
+If an API is detected for this module, submit a sync request for small work or a job request for larger work. Download endpoints return generated artifacts after completion.

--- a/docs/modules/playwright/api.md
+++ b/docs/modules/playwright/api.md
@@ -1,0 +1,5 @@
+# Playwright Web Capture API
+
+FastAPI title: `playwright-to-md`.
+
+Detected endpoints: `/convert/sync, /convert/jobs, /convert/jobs/{job_id}, /convert/jobs/{job_id}/download`.

--- a/docs/modules/playwright/configuration.md
+++ b/docs/modules/playwright/configuration.md
@@ -1,0 +1,11 @@
+# Playwright Web Capture Configuration
+
+Configuration is supplied through CLI flags, API request fields, packaged YAML where the module provides it, and environment variables for service runtime concerns.
+
+For this module, begin with:
+
+```bash
+md-playwright --help
+```
+
+Source code lives in `src/md_generator/playwright`.

--- a/docs/modules/playwright/database.md
+++ b/docs/modules/playwright/database.md
@@ -1,0 +1,3 @@
+# Playwright Web Capture Database Notes
+
+No repository database tables are owned by this module.

--- a/docs/modules/playwright/deployment.md
+++ b/docs/modules/playwright/deployment.md
@@ -1,0 +1,5 @@
+# Playwright Web Capture Deployment
+
+Deploy the API surface only when HTTP access is required. Install the smallest dependency extra set and add `api` for FastAPI runtime.
+
+For Dockerized services, follow the existing `Dockerfile.api` and Compose gateway pattern used by top-level converter folders.

--- a/docs/modules/playwright/exceptions.md
+++ b/docs/modules/playwright/exceptions.md
@@ -1,0 +1,5 @@
+# Playwright Web Capture Exceptions
+
+Expected failures include missing optional dependencies, invalid inputs, unsupported source formats, external tool failures, and output write errors.
+
+API callers should receive structured HTTP failures. CLI users should receive a non-zero exit code and actionable terminal output.

--- a/docs/modules/playwright/installation.md
+++ b/docs/modules/playwright/installation.md
@@ -1,0 +1,17 @@
+# Playwright Web Capture Installation
+
+```bash
+pip install "mdengine[playwright]"
+```
+
+For local development from a clone:
+
+```bash
+pip install -e ".[playwright,dev]"
+```
+
+If the module also runs as HTTP API, include `api`:
+
+```bash
+pip install -e ".[playwright,api]"
+```

--- a/docs/modules/playwright/lld.md
+++ b/docs/modules/playwright/lld.md
@@ -1,0 +1,12 @@
+# Playwright Web Capture Low-Level Design
+
+```mermaid
+flowchart TD
+    Request[CLI_or_API_request] --> Options[Parse_options]
+    Options --> Validate[Validate_input]
+    Validate --> Convert[playwright_conversion]
+    Convert --> Render[Render_Markdown]
+    Render --> Return[Return_or_download_result]
+```
+
+The module should keep parsing, conversion, rendering, and interface concerns separated enough that CLI and API paths can reuse the same core behavior.

--- a/docs/modules/playwright/logging.md
+++ b/docs/modules/playwright/logging.md
@@ -1,0 +1,3 @@
+# Playwright Web Capture Logging
+
+Log module name, input type, job ID when present, output location, and bounded error details. Do not log uploaded file contents, credentials, or database connection secrets.

--- a/docs/modules/playwright/overview.md
+++ b/docs/modules/playwright/overview.md
@@ -1,0 +1,15 @@
+# Playwright Web Capture Module Overview
+
+Package: `md_generator.playwright`  
+Source: `src/md_generator/playwright`  
+CLI: `md-playwright`  
+Extra: `playwright`
+
+This module accepts Rendered web pages and SPAs and produces Markdown captured after browser rendering. It participates in the unified `mdengine` distribution and follows the repository pattern of keeping feature dependencies optional.
+
+```mermaid
+flowchart LR
+    Input[Input] --> Module[playwright_module]
+    Module --> Markdown[Markdown_output]
+    Module --> Assets[Assets_when_enabled]
+```

--- a/docs/modules/playwright/responsibilities.md
+++ b/docs/modules/playwright/responsibilities.md
@@ -1,0 +1,5 @@
+# Playwright Web Capture Responsibilities
+
+- Launch browser-backed page capture.
+- Wait for rendered SPA content.
+- Convert captured DOM content to Markdown.

--- a/docs/modules/playwright/testing.md
+++ b/docs/modules/playwright/testing.md
@@ -1,0 +1,7 @@
+# Playwright Web Capture Testing
+
+Tests for this feature area are expected under the matching top-level `*-to-md/tests` folder where present. Run targeted tests before changing the module and run broader `python -m pytest` before cross-module changes.
+
+```bash
+python -m pytest
+```

--- a/docs/modules/playwright/workflows.md
+++ b/docs/modules/playwright/workflows.md
@@ -1,0 +1,16 @@
+# Playwright Web Capture Workflows
+
+## CLI Workflow
+
+```bash
+md-playwright --help
+```
+
+1. Install the required extra.
+2. Provide an input source: Rendered web pages and SPAs.
+3. Choose an output path.
+4. Review generated Markdown and assets.
+
+## API Workflow
+
+If an API is detected for this module, submit a sync request for small work or a job request for larger work. Download endpoints return generated artifacts after completion.

--- a/docs/modules/ppt/api.md
+++ b/docs/modules/ppt/api.md
@@ -1,0 +1,5 @@
+# PowerPoint API
+
+FastAPI title: `ppt-to-md`.
+
+Detected endpoints: `/convert/sync, /convert/jobs, /convert/jobs/{job_id}, /convert/jobs/{job_id}/download`.

--- a/docs/modules/ppt/configuration.md
+++ b/docs/modules/ppt/configuration.md
@@ -1,0 +1,11 @@
+# PowerPoint Configuration
+
+Configuration is supplied through CLI flags, API request fields, packaged YAML where the module provides it, and environment variables for service runtime concerns.
+
+For this module, begin with:
+
+```bash
+md-ppt --help
+```
+
+Source code lives in `src/md_generator/ppt`.

--- a/docs/modules/ppt/database.md
+++ b/docs/modules/ppt/database.md
@@ -1,0 +1,3 @@
+# PowerPoint Database Notes
+
+No repository database tables are owned by this module.

--- a/docs/modules/ppt/deployment.md
+++ b/docs/modules/ppt/deployment.md
@@ -1,0 +1,5 @@
+# PowerPoint Deployment
+
+Deploy the API surface only when HTTP access is required. Install the smallest dependency extra set and add `api` for FastAPI runtime.
+
+For Dockerized services, follow the existing `Dockerfile.api` and Compose gateway pattern used by top-level converter folders.

--- a/docs/modules/ppt/exceptions.md
+++ b/docs/modules/ppt/exceptions.md
@@ -1,0 +1,5 @@
+# PowerPoint Exceptions
+
+Expected failures include missing optional dependencies, invalid inputs, unsupported source formats, external tool failures, and output write errors.
+
+API callers should receive structured HTTP failures. CLI users should receive a non-zero exit code and actionable terminal output.

--- a/docs/modules/ppt/installation.md
+++ b/docs/modules/ppt/installation.md
@@ -1,0 +1,17 @@
+# PowerPoint Installation
+
+```bash
+pip install "mdengine[ppt]"
+```
+
+For local development from a clone:
+
+```bash
+pip install -e ".[ppt,dev]"
+```
+
+If the module also runs as HTTP API, include `api`:
+
+```bash
+pip install -e ".[ppt,api]"
+```

--- a/docs/modules/ppt/lld.md
+++ b/docs/modules/ppt/lld.md
@@ -1,0 +1,12 @@
+# PowerPoint Low-Level Design
+
+```mermaid
+flowchart TD
+    Request[CLI_or_API_request] --> Options[Parse_options]
+    Options --> Validate[Validate_input]
+    Validate --> Convert[ppt_conversion]
+    Convert --> Render[Render_Markdown]
+    Render --> Return[Return_or_download_result]
+```
+
+The module should keep parsing, conversion, rendering, and interface concerns separated enough that CLI and API paths can reuse the same core behavior.

--- a/docs/modules/ppt/logging.md
+++ b/docs/modules/ppt/logging.md
@@ -1,0 +1,3 @@
+# PowerPoint Logging
+
+Log module name, input type, job ID when present, output location, and bounded error details. Do not log uploaded file contents, credentials, or database connection secrets.

--- a/docs/modules/ppt/overview.md
+++ b/docs/modules/ppt/overview.md
@@ -1,0 +1,15 @@
+# PowerPoint Module Overview
+
+Package: `md_generator.ppt`  
+Source: `src/md_generator/ppt`  
+CLI: `md-ppt`  
+Extra: `ppt`
+
+This module accepts PPTX slide decks and produces Slide-oriented Markdown and extracted assets. It participates in the unified `mdengine` distribution and follows the repository pattern of keeping feature dependencies optional.
+
+```mermaid
+flowchart LR
+    Input[Input] --> Module[ppt_module]
+    Module --> Markdown[Markdown_output]
+    Module --> Assets[Assets_when_enabled]
+```

--- a/docs/modules/ppt/responsibilities.md
+++ b/docs/modules/ppt/responsibilities.md
@@ -1,0 +1,5 @@
+# PowerPoint Responsibilities
+
+- Read slides and presentation metadata.
+- Convert slide text and embedded content to Markdown.
+- Package output for CLI and API download flows.

--- a/docs/modules/ppt/testing.md
+++ b/docs/modules/ppt/testing.md
@@ -1,0 +1,7 @@
+# PowerPoint Testing
+
+Tests for this feature area are expected under the matching top-level `*-to-md/tests` folder where present. Run targeted tests before changing the module and run broader `python -m pytest` before cross-module changes.
+
+```bash
+python -m pytest
+```

--- a/docs/modules/ppt/workflows.md
+++ b/docs/modules/ppt/workflows.md
@@ -1,0 +1,16 @@
+# PowerPoint Workflows
+
+## CLI Workflow
+
+```bash
+md-ppt --help
+```
+
+1. Install the required extra.
+2. Provide an input source: PPTX slide decks.
+3. Choose an output path.
+4. Review generated Markdown and assets.
+
+## API Workflow
+
+If an API is detected for this module, submit a sync request for small work or a job request for larger work. Download endpoints return generated artifacts after completion.

--- a/docs/modules/text/api.md
+++ b/docs/modules/text/api.md
@@ -1,0 +1,5 @@
+# Text JSON XML API
+
+FastAPI title: `txt-json-xml-to-md`.
+
+Detected endpoints: `/convert/sync, /convert/jobs, /convert/jobs/{job_id}, /convert/jobs/{job_id}/download`.

--- a/docs/modules/text/configuration.md
+++ b/docs/modules/text/configuration.md
@@ -1,0 +1,11 @@
+# Text JSON XML Configuration
+
+Configuration is supplied through CLI flags, API request fields, packaged YAML where the module provides it, and environment variables for service runtime concerns.
+
+For this module, begin with:
+
+```bash
+md-text --help
+```
+
+Source code lives in `src/md_generator/text`.

--- a/docs/modules/text/database.md
+++ b/docs/modules/text/database.md
@@ -1,0 +1,3 @@
+# Text JSON XML Database Notes
+
+No repository database tables are owned by this module.

--- a/docs/modules/text/deployment.md
+++ b/docs/modules/text/deployment.md
@@ -1,0 +1,5 @@
+# Text JSON XML Deployment
+
+Deploy the API surface only when HTTP access is required. Install the smallest dependency extra set and add `api` for FastAPI runtime.
+
+For Dockerized services, follow the existing `Dockerfile.api` and Compose gateway pattern used by top-level converter folders.

--- a/docs/modules/text/exceptions.md
+++ b/docs/modules/text/exceptions.md
@@ -1,0 +1,5 @@
+# Text JSON XML Exceptions
+
+Expected failures include missing optional dependencies, invalid inputs, unsupported source formats, external tool failures, and output write errors.
+
+API callers should receive structured HTTP failures. CLI users should receive a non-zero exit code and actionable terminal output.

--- a/docs/modules/text/installation.md
+++ b/docs/modules/text/installation.md
@@ -1,0 +1,17 @@
+# Text JSON XML Installation
+
+```bash
+pip install "mdengine[text]"
+```
+
+For local development from a clone:
+
+```bash
+pip install -e ".[text,dev]"
+```
+
+If the module also runs as HTTP API, include `api`:
+
+```bash
+pip install -e ".[text,api]"
+```

--- a/docs/modules/text/lld.md
+++ b/docs/modules/text/lld.md
@@ -1,0 +1,12 @@
+# Text JSON XML Low-Level Design
+
+```mermaid
+flowchart TD
+    Request[CLI_or_API_request] --> Options[Parse_options]
+    Options --> Validate[Validate_input]
+    Validate --> Convert[text_conversion]
+    Convert --> Render[Render_Markdown]
+    Render --> Return[Return_or_download_result]
+```
+
+The module should keep parsing, conversion, rendering, and interface concerns separated enough that CLI and API paths can reuse the same core behavior.

--- a/docs/modules/text/logging.md
+++ b/docs/modules/text/logging.md
@@ -1,0 +1,3 @@
+# Text JSON XML Logging
+
+Log module name, input type, job ID when present, output location, and bounded error details. Do not log uploaded file contents, credentials, or database connection secrets.

--- a/docs/modules/text/overview.md
+++ b/docs/modules/text/overview.md
@@ -1,0 +1,15 @@
+# Text JSON XML Module Overview
+
+Package: `md_generator.text`  
+Source: `src/md_generator/text`  
+CLI: `md-text`  
+Extra: `text`
+
+This module accepts Plain text, JSON, and XML files and produces Readable Markdown representations. It participates in the unified `mdengine` distribution and follows the repository pattern of keeping feature dependencies optional.
+
+```mermaid
+flowchart LR
+    Input[Input] --> Module[text_module]
+    Module --> Markdown[Markdown_output]
+    Module --> Assets[Assets_when_enabled]
+```

--- a/docs/modules/text/responsibilities.md
+++ b/docs/modules/text/responsibilities.md
@@ -1,0 +1,5 @@
+# Text JSON XML Responsibilities
+
+- Normalize structured text sources.
+- Render JSON and XML into navigable Markdown.
+- Expose uniform converter API endpoints.

--- a/docs/modules/text/testing.md
+++ b/docs/modules/text/testing.md
@@ -1,0 +1,7 @@
+# Text JSON XML Testing
+
+Tests for this feature area are expected under the matching top-level `*-to-md/tests` folder where present. Run targeted tests before changing the module and run broader `python -m pytest` before cross-module changes.
+
+```bash
+python -m pytest
+```

--- a/docs/modules/text/workflows.md
+++ b/docs/modules/text/workflows.md
@@ -1,0 +1,16 @@
+# Text JSON XML Workflows
+
+## CLI Workflow
+
+```bash
+md-text --help
+```
+
+1. Install the required extra.
+2. Provide an input source: Plain text, JSON, and XML files.
+3. Choose an output path.
+4. Review generated Markdown and assets.
+
+## API Workflow
+
+If an API is detected for this module, submit a sync request for small work or a job request for larger work. Download endpoints return generated artifacts after completion.

--- a/docs/modules/tools-assistant/api.md
+++ b/docs/modules/tools-assistant/api.md
@@ -1,0 +1,5 @@
+# AI Assistant Tools API
+
+FastAPI title: `No FastAPI app detected`.
+
+Detected endpoints: `No HTTP API route set was detected for this module.`.

--- a/docs/modules/tools-assistant/configuration.md
+++ b/docs/modules/tools-assistant/configuration.md
@@ -1,0 +1,11 @@
+# AI Assistant Tools Configuration
+
+Configuration is supplied through CLI flags, API request fields, packaged YAML where the module provides it, and environment variables for service runtime concerns.
+
+For this module, begin with:
+
+```bash
+mdengine --help
+```
+
+Source code lives in `src/md_generator/tools/assistant`.

--- a/docs/modules/tools-assistant/database.md
+++ b/docs/modules/tools-assistant/database.md
@@ -1,0 +1,3 @@
+# AI Assistant Tools Database Notes
+
+Optional Chroma integration is dependency-gated; no repository-owned tables are defined.

--- a/docs/modules/tools-assistant/deployment.md
+++ b/docs/modules/tools-assistant/deployment.md
@@ -1,0 +1,5 @@
+# AI Assistant Tools Deployment
+
+Deploy the API surface only when HTTP access is required. Install the smallest dependency extra set and add `api` for FastAPI runtime.
+
+For Dockerized services, follow the existing `Dockerfile.api` and Compose gateway pattern used by top-level converter folders.

--- a/docs/modules/tools-assistant/exceptions.md
+++ b/docs/modules/tools-assistant/exceptions.md
@@ -1,0 +1,5 @@
+# AI Assistant Tools Exceptions
+
+Expected failures include missing optional dependencies, invalid inputs, unsupported source formats, external tool failures, and output write errors.
+
+API callers should receive structured HTTP failures. CLI users should receive a non-zero exit code and actionable terminal output.

--- a/docs/modules/tools-assistant/installation.md
+++ b/docs/modules/tools-assistant/installation.md
@@ -1,0 +1,17 @@
+# AI Assistant Tools Installation
+
+```bash
+pip install "mdengine[skill-openai]"
+```
+
+For local development from a clone:
+
+```bash
+pip install -e ".[skill-openai,dev]"
+```
+
+If the module also runs as HTTP API, include `api`:
+
+```bash
+pip install -e ".[skill-openai,api]"
+```

--- a/docs/modules/tools-assistant/lld.md
+++ b/docs/modules/tools-assistant/lld.md
@@ -1,0 +1,12 @@
+# AI Assistant Tools Low-Level Design
+
+```mermaid
+flowchart TD
+    Request[CLI_or_API_request] --> Options[Parse_options]
+    Options --> Validate[Validate_input]
+    Validate --> Convert[tools_assistant_conversion]
+    Convert --> Render[Render_Markdown]
+    Render --> Return[Return_or_download_result]
+```
+
+The module should keep parsing, conversion, rendering, and interface concerns separated enough that CLI and API paths can reuse the same core behavior.

--- a/docs/modules/tools-assistant/logging.md
+++ b/docs/modules/tools-assistant/logging.md
@@ -1,0 +1,3 @@
+# AI Assistant Tools Logging
+
+Log module name, input type, job ID when present, output location, and bounded error details. Do not log uploaded file contents, credentials, or database connection secrets.

--- a/docs/modules/tools-assistant/overview.md
+++ b/docs/modules/tools-assistant/overview.md
@@ -1,0 +1,15 @@
+# AI Assistant Tools Module Overview
+
+Package: `md_generator.tools.assistant`  
+Source: `src/md_generator/tools/assistant`  
+CLI: `mdengine ai assist / mdengine ai export`  
+Extra: `skill-openai or skill-rag-chroma for optional providers`
+
+This module accepts Skill markdown bundles and prompts and produces Assembled context and assistant responses. It participates in the unified `mdengine` distribution and follows the repository pattern of keeping feature dependencies optional.
+
+```mermaid
+flowchart LR
+    Input[Input] --> Module[tools_assistant_module]
+    Module --> Markdown[Markdown_output]
+    Module --> Assets[Assets_when_enabled]
+```

--- a/docs/modules/tools-assistant/responsibilities.md
+++ b/docs/modules/tools-assistant/responsibilities.md
@@ -1,0 +1,5 @@
+# AI Assistant Tools Responsibilities
+
+- Load packaged skill data.
+- Assemble prompt context.
+- Optionally integrate provider or RAG helpers.

--- a/docs/modules/tools-assistant/testing.md
+++ b/docs/modules/tools-assistant/testing.md
@@ -1,0 +1,7 @@
+# AI Assistant Tools Testing
+
+Tests for this feature area are expected under the matching top-level `*-to-md/tests` folder where present. Run targeted tests before changing the module and run broader `python -m pytest` before cross-module changes.
+
+```bash
+python -m pytest
+```

--- a/docs/modules/tools-assistant/workflows.md
+++ b/docs/modules/tools-assistant/workflows.md
@@ -1,0 +1,16 @@
+# AI Assistant Tools Workflows
+
+## CLI Workflow
+
+```bash
+mdengine --help
+```
+
+1. Install the required extra.
+2. Provide an input source: Skill markdown bundles and prompts.
+3. Choose an output path.
+4. Review generated Markdown and assets.
+
+## API Workflow
+
+If an API is detected for this module, submit a sync request for small work or a job request for larger work. Download endpoints return generated artifacts after completion.

--- a/docs/modules/tools-skill-builder/api.md
+++ b/docs/modules/tools-skill-builder/api.md
@@ -1,0 +1,5 @@
+# Skill Builder API
+
+FastAPI title: `No FastAPI app detected`.
+
+Detected endpoints: `No HTTP API route set was detected for this module.`.

--- a/docs/modules/tools-skill-builder/configuration.md
+++ b/docs/modules/tools-skill-builder/configuration.md
@@ -1,0 +1,11 @@
+# Skill Builder Configuration
+
+Configuration is supplied through CLI flags, API request fields, packaged YAML where the module provides it, and environment variables for service runtime concerns.
+
+For this module, begin with:
+
+```bash
+mdengine --help
+```
+
+Source code lives in `src/md_generator/tools/skill_builder`.

--- a/docs/modules/tools-skill-builder/database.md
+++ b/docs/modules/tools-skill-builder/database.md
@@ -1,0 +1,3 @@
+# Skill Builder Database Notes
+
+No repository database tables are owned by this module.

--- a/docs/modules/tools-skill-builder/deployment.md
+++ b/docs/modules/tools-skill-builder/deployment.md
@@ -1,0 +1,5 @@
+# Skill Builder Deployment
+
+Deploy the API surface only when HTTP access is required. Install the smallest dependency extra set and add `api` for FastAPI runtime.
+
+For Dockerized services, follow the existing `Dockerfile.api` and Compose gateway pattern used by top-level converter folders.

--- a/docs/modules/tools-skill-builder/exceptions.md
+++ b/docs/modules/tools-skill-builder/exceptions.md
@@ -1,0 +1,5 @@
+# Skill Builder Exceptions
+
+Expected failures include missing optional dependencies, invalid inputs, unsupported source formats, external tool failures, and output write errors.
+
+API callers should receive structured HTTP failures. CLI users should receive a non-zero exit code and actionable terminal output.

--- a/docs/modules/tools-skill-builder/installation.md
+++ b/docs/modules/tools-skill-builder/installation.md
@@ -1,0 +1,17 @@
+# Skill Builder Installation
+
+```bash
+pip install "mdengine"
+```
+
+For local development from a clone:
+
+```bash
+pip install -e ".[dev]"
+```
+
+This module does not expose a FastAPI service. Install `docs` only when you are building the MkDocs site:
+
+```bash
+pip install -e ".[dev,docs]"
+```

--- a/docs/modules/tools-skill-builder/lld.md
+++ b/docs/modules/tools-skill-builder/lld.md
@@ -1,0 +1,12 @@
+# Skill Builder Low-Level Design
+
+```mermaid
+flowchart TD
+    Request[CLI_or_API_request] --> Options[Parse_options]
+    Options --> Validate[Validate_input]
+    Validate --> Convert[tools_skill_builder_conversion]
+    Convert --> Render[Render_Markdown]
+    Render --> Return[Return_or_download_result]
+```
+
+The module should keep parsing, conversion, rendering, and interface concerns separated enough that CLI and API paths can reuse the same core behavior.

--- a/docs/modules/tools-skill-builder/logging.md
+++ b/docs/modules/tools-skill-builder/logging.md
@@ -1,0 +1,3 @@
+# Skill Builder Logging
+
+Log module name, input type, job ID when present, output location, and bounded error details. Do not log uploaded file contents, credentials, or database connection secrets.

--- a/docs/modules/tools-skill-builder/overview.md
+++ b/docs/modules/tools-skill-builder/overview.md
@@ -1,0 +1,15 @@
+# Skill Builder Module Overview
+
+Package: `md_generator.tools.skill_builder`  
+Source: `src/md_generator/tools/skill_builder`  
+CLI: `mdengine skill build`  
+Extra: `base package`
+
+This module accepts Project metadata and skill sources and produces Structured skill Markdown under ai/. It participates in the unified `mdengine` distribution and follows the repository pattern of keeping feature dependencies optional.
+
+```mermaid
+flowchart LR
+    Input[Input] --> Module[tools_skill_builder_module]
+    Module --> Markdown[Markdown_output]
+    Module --> Assets[Assets_when_enabled]
+```

--- a/docs/modules/tools-skill-builder/responsibilities.md
+++ b/docs/modules/tools-skill-builder/responsibilities.md
@@ -1,0 +1,5 @@
+# Skill Builder Responsibilities
+
+- Read project scripts and package metadata.
+- Generate skill documentation.
+- Keep distributable AI skill bundles organized.

--- a/docs/modules/tools-skill-builder/testing.md
+++ b/docs/modules/tools-skill-builder/testing.md
@@ -1,0 +1,7 @@
+# Skill Builder Testing
+
+Tests for this feature area are expected under the matching top-level `*-to-md/tests` folder where present. Run targeted tests before changing the module and run broader `python -m pytest` before cross-module changes.
+
+```bash
+python -m pytest
+```

--- a/docs/modules/tools-skill-builder/workflows.md
+++ b/docs/modules/tools-skill-builder/workflows.md
@@ -1,0 +1,16 @@
+# Skill Builder Workflows
+
+## CLI Workflow
+
+```bash
+mdengine --help
+```
+
+1. Install the required extra.
+2. Provide an input source: Project metadata and skill sources.
+3. Choose an output path.
+4. Review generated Markdown and assets.
+
+## API Workflow
+
+If an API is detected for this module, submit a sync request for small work or a job request for larger work. Download endpoints return generated artifacts after completion.

--- a/docs/modules/url/api.md
+++ b/docs/modules/url/api.md
@@ -1,0 +1,5 @@
+# URL and Web API
+
+FastAPI title: `url-to-md`.
+
+Detected endpoints: `/convert/sync, /convert/jobs, /convert/jobs/{job_id}, /convert/jobs/{job_id}/download`.

--- a/docs/modules/url/configuration.md
+++ b/docs/modules/url/configuration.md
@@ -1,0 +1,11 @@
+# URL and Web Configuration
+
+Configuration is supplied through CLI flags, API request fields, packaged YAML where the module provides it, and environment variables for service runtime concerns.
+
+For this module, begin with:
+
+```bash
+md-url --help
+```
+
+Source code lives in `src/md_generator/url`.

--- a/docs/modules/url/database.md
+++ b/docs/modules/url/database.md
@@ -1,0 +1,3 @@
+# URL and Web Database Notes
+
+No repository database tables are owned by this module.

--- a/docs/modules/url/deployment.md
+++ b/docs/modules/url/deployment.md
@@ -1,0 +1,5 @@
+# URL and Web Deployment
+
+Deploy the API surface only when HTTP access is required. Install the smallest dependency extra set and add `api` for FastAPI runtime.
+
+For Dockerized services, follow the existing `Dockerfile.api` and Compose gateway pattern used by top-level converter folders.

--- a/docs/modules/url/exceptions.md
+++ b/docs/modules/url/exceptions.md
@@ -1,0 +1,5 @@
+# URL and Web Exceptions
+
+Expected failures include missing optional dependencies, invalid inputs, unsupported source formats, external tool failures, and output write errors.
+
+API callers should receive structured HTTP failures. CLI users should receive a non-zero exit code and actionable terminal output.

--- a/docs/modules/url/installation.md
+++ b/docs/modules/url/installation.md
@@ -1,0 +1,17 @@
+# URL and Web Installation
+
+```bash
+pip install "mdengine[url]"
+```
+
+For local development from a clone:
+
+```bash
+pip install -e ".[url,dev]"
+```
+
+If the module also runs as HTTP API, include `api`:
+
+```bash
+pip install -e ".[url,api]"
+```

--- a/docs/modules/url/lld.md
+++ b/docs/modules/url/lld.md
@@ -1,0 +1,12 @@
+# URL and Web Low-Level Design
+
+```mermaid
+flowchart TD
+    Request[CLI_or_API_request] --> Options[Parse_options]
+    Options --> Validate[Validate_input]
+    Validate --> Convert[url_conversion]
+    Convert --> Render[Render_Markdown]
+    Render --> Return[Return_or_download_result]
+```
+
+The module should keep parsing, conversion, rendering, and interface concerns separated enough that CLI and API paths can reuse the same core behavior.

--- a/docs/modules/url/logging.md
+++ b/docs/modules/url/logging.md
@@ -1,0 +1,3 @@
+# URL and Web Logging
+
+Log module name, input type, job ID when present, output location, and bounded error details. Do not log uploaded file contents, credentials, or database connection secrets.

--- a/docs/modules/url/overview.md
+++ b/docs/modules/url/overview.md
@@ -1,0 +1,15 @@
+# URL and Web Module Overview
+
+Package: `md_generator.url`  
+Source: `src/md_generator/url`  
+CLI: `md-url`  
+Extra: `url or url-full`
+
+This module accepts HTTP and HTTPS web pages and produces Cleaned Markdown plus optional artifacts. It participates in the unified `mdengine` distribution and follows the repository pattern of keeping feature dependencies optional.
+
+```mermaid
+flowchart LR
+    Input[Input] --> Module[url_module]
+    Module --> Markdown[Markdown_output]
+    Module --> Assets[Assets_when_enabled]
+```

--- a/docs/modules/url/responsibilities.md
+++ b/docs/modules/url/responsibilities.md
@@ -1,0 +1,5 @@
+# URL and Web Responsibilities
+
+- Fetch remote pages with HTTP clients.
+- Extract readable HTML content.
+- Optionally post-convert linked documents with url-full dependencies.

--- a/docs/modules/url/testing.md
+++ b/docs/modules/url/testing.md
@@ -1,0 +1,7 @@
+# URL and Web Testing
+
+Tests for this feature area are expected under the matching top-level `*-to-md/tests` folder where present. Run targeted tests before changing the module and run broader `python -m pytest` before cross-module changes.
+
+```bash
+python -m pytest
+```

--- a/docs/modules/url/workflows.md
+++ b/docs/modules/url/workflows.md
@@ -1,0 +1,16 @@
+# URL and Web Workflows
+
+## CLI Workflow
+
+```bash
+md-url --help
+```
+
+1. Install the required extra.
+2. Provide an input source: HTTP and HTTPS web pages.
+3. Choose an output path.
+4. Review generated Markdown and assets.
+
+## API Workflow
+
+If an API is detected for this module, submit a sync request for small work or a job request for larger work. Download endpoints return generated artifacts after completion.

--- a/docs/modules/word/api.md
+++ b/docs/modules/word/api.md
@@ -1,0 +1,5 @@
+# Word API
+
+FastAPI title: `word-to-md`.
+
+Detected endpoints: `/convert/sync, /convert/jobs, /convert/jobs/{job_id}, /convert/jobs/{job_id}/download`.

--- a/docs/modules/word/configuration.md
+++ b/docs/modules/word/configuration.md
@@ -1,0 +1,11 @@
+# Word Configuration
+
+Configuration is supplied through CLI flags, API request fields, packaged YAML where the module provides it, and environment variables for service runtime concerns.
+
+For this module, begin with:
+
+```bash
+md-word --help
+```
+
+Source code lives in `src/md_generator/word`.

--- a/docs/modules/word/database.md
+++ b/docs/modules/word/database.md
@@ -1,0 +1,3 @@
+# Word Database Notes
+
+No repository database tables are owned by this module.

--- a/docs/modules/word/deployment.md
+++ b/docs/modules/word/deployment.md
@@ -1,0 +1,5 @@
+# Word Deployment
+
+Deploy the API surface only when HTTP access is required. Install the smallest dependency extra set and add `api` for FastAPI runtime.
+
+For Dockerized services, follow the existing `Dockerfile.api` and Compose gateway pattern used by top-level converter folders.

--- a/docs/modules/word/exceptions.md
+++ b/docs/modules/word/exceptions.md
@@ -1,0 +1,5 @@
+# Word Exceptions
+
+Expected failures include missing optional dependencies, invalid inputs, unsupported source formats, external tool failures, and output write errors.
+
+API callers should receive structured HTTP failures. CLI users should receive a non-zero exit code and actionable terminal output.

--- a/docs/modules/word/installation.md
+++ b/docs/modules/word/installation.md
@@ -1,0 +1,17 @@
+# Word Installation
+
+```bash
+pip install "mdengine[word]"
+```
+
+For local development from a clone:
+
+```bash
+pip install -e ".[word,dev]"
+```
+
+If the module also runs as HTTP API, include `api`:
+
+```bash
+pip install -e ".[word,api]"
+```

--- a/docs/modules/word/lld.md
+++ b/docs/modules/word/lld.md
@@ -1,0 +1,12 @@
+# Word Low-Level Design
+
+```mermaid
+flowchart TD
+    Request[CLI_or_API_request] --> Options[Parse_options]
+    Options --> Validate[Validate_input]
+    Validate --> Convert[word_conversion]
+    Convert --> Render[Render_Markdown]
+    Render --> Return[Return_or_download_result]
+```
+
+The module should keep parsing, conversion, rendering, and interface concerns separated enough that CLI and API paths can reuse the same core behavior.

--- a/docs/modules/word/logging.md
+++ b/docs/modules/word/logging.md
@@ -1,0 +1,3 @@
+# Word Logging
+
+Log module name, input type, job ID when present, output location, and bounded error details. Do not log uploaded file contents, credentials, or database connection secrets.

--- a/docs/modules/word/overview.md
+++ b/docs/modules/word/overview.md
@@ -1,0 +1,15 @@
+# Word Module Overview
+
+Package: `md_generator.word`  
+Source: `src/md_generator/word`  
+CLI: `md-word`  
+Extra: `word`
+
+This module accepts DOCX documents and produces Markdown with optional image extraction. It participates in the unified `mdengine` distribution and follows the repository pattern of keeping feature dependencies optional.
+
+```mermaid
+flowchart LR
+    Input[Input] --> Module[word_module]
+    Module --> Markdown[Markdown_output]
+    Module --> Assets[Assets_when_enabled]
+```

--- a/docs/modules/word/responsibilities.md
+++ b/docs/modules/word/responsibilities.md
@@ -1,0 +1,5 @@
+# Word Responsibilities
+
+- Convert DOCX body content to Markdown.
+- Handle embedded images through configured output directories.
+- Expose synchronous and job-based conversion APIs.

--- a/docs/modules/word/testing.md
+++ b/docs/modules/word/testing.md
@@ -1,0 +1,7 @@
+# Word Testing
+
+Tests for this feature area are expected under the matching top-level `*-to-md/tests` folder where present. Run targeted tests before changing the module and run broader `python -m pytest` before cross-module changes.
+
+```bash
+python -m pytest
+```

--- a/docs/modules/word/workflows.md
+++ b/docs/modules/word/workflows.md
@@ -1,0 +1,16 @@
+# Word Workflows
+
+## CLI Workflow
+
+```bash
+md-word --help
+```
+
+1. Install the required extra.
+2. Provide an input source: DOCX documents.
+3. Choose an output path.
+4. Review generated Markdown and assets.
+
+## API Workflow
+
+If an API is detected for this module, submit a sync request for small work or a job request for larger work. Download endpoints return generated artifacts after completion.

--- a/docs/modules/xlsx/api.md
+++ b/docs/modules/xlsx/api.md
@@ -1,0 +1,5 @@
+# Excel and CSV API
+
+FastAPI title: `xlsx-to-md`.
+
+Detected endpoints: `/convert/sync, /convert/jobs, /convert/jobs/{job_id}, /convert/jobs/{job_id}/download`.

--- a/docs/modules/xlsx/configuration.md
+++ b/docs/modules/xlsx/configuration.md
@@ -1,0 +1,11 @@
+# Excel and CSV Configuration
+
+Configuration is supplied through CLI flags, API request fields, packaged YAML where the module provides it, and environment variables for service runtime concerns.
+
+For this module, begin with:
+
+```bash
+md-xlsx --help
+```
+
+Source code lives in `src/md_generator/xlsx`.

--- a/docs/modules/xlsx/database.md
+++ b/docs/modules/xlsx/database.md
@@ -1,0 +1,3 @@
+# Excel and CSV Database Notes
+
+No repository database tables are owned by this module.

--- a/docs/modules/xlsx/deployment.md
+++ b/docs/modules/xlsx/deployment.md
@@ -1,0 +1,5 @@
+# Excel and CSV Deployment
+
+Deploy the API surface only when HTTP access is required. Install the smallest dependency extra set and add `api` for FastAPI runtime.
+
+For Dockerized services, follow the existing `Dockerfile.api` and Compose gateway pattern used by top-level converter folders.

--- a/docs/modules/xlsx/exceptions.md
+++ b/docs/modules/xlsx/exceptions.md
@@ -1,0 +1,5 @@
+# Excel and CSV Exceptions
+
+Expected failures include missing optional dependencies, invalid inputs, unsupported source formats, external tool failures, and output write errors.
+
+API callers should receive structured HTTP failures. CLI users should receive a non-zero exit code and actionable terminal output.

--- a/docs/modules/xlsx/installation.md
+++ b/docs/modules/xlsx/installation.md
@@ -1,0 +1,17 @@
+# Excel and CSV Installation
+
+```bash
+pip install "mdengine[xlsx]"
+```
+
+For local development from a clone:
+
+```bash
+pip install -e ".[xlsx,dev]"
+```
+
+If the module also runs as HTTP API, include `api`:
+
+```bash
+pip install -e ".[xlsx,api]"
+```

--- a/docs/modules/xlsx/lld.md
+++ b/docs/modules/xlsx/lld.md
@@ -1,0 +1,12 @@
+# Excel and CSV Low-Level Design
+
+```mermaid
+flowchart TD
+    Request[CLI_or_API_request] --> Options[Parse_options]
+    Options --> Validate[Validate_input]
+    Validate --> Convert[xlsx_conversion]
+    Convert --> Render[Render_Markdown]
+    Render --> Return[Return_or_download_result]
+```
+
+The module should keep parsing, conversion, rendering, and interface concerns separated enough that CLI and API paths can reuse the same core behavior.

--- a/docs/modules/xlsx/logging.md
+++ b/docs/modules/xlsx/logging.md
@@ -1,0 +1,3 @@
+# Excel and CSV Logging
+
+Log module name, input type, job ID when present, output location, and bounded error details. Do not log uploaded file contents, credentials, or database connection secrets.

--- a/docs/modules/xlsx/overview.md
+++ b/docs/modules/xlsx/overview.md
@@ -1,0 +1,15 @@
+# Excel and CSV Module Overview
+
+Package: `md_generator.xlsx`  
+Source: `src/md_generator/xlsx`  
+CLI: `md-xlsx`  
+Extra: `xlsx`
+
+This module accepts XLSX, XLSM, and CSV files and produces Worksheet or CSV Markdown tables. It participates in the unified `mdengine` distribution and follows the repository pattern of keeping feature dependencies optional.
+
+```mermaid
+flowchart LR
+    Input[Input] --> Module[xlsx_module]
+    Module --> Markdown[Markdown_output]
+    Module --> Assets[Assets_when_enabled]
+```

--- a/docs/modules/xlsx/responsibilities.md
+++ b/docs/modules/xlsx/responsibilities.md
@@ -1,0 +1,5 @@
+# Excel and CSV Responsibilities
+
+- Load workbook and CSV inputs.
+- Render sheets as Markdown tables.
+- Support split output for multi-sheet workbooks.

--- a/docs/modules/xlsx/testing.md
+++ b/docs/modules/xlsx/testing.md
@@ -1,0 +1,7 @@
+# Excel and CSV Testing
+
+Tests for this feature area are expected under the matching top-level `*-to-md/tests` folder where present. Run targeted tests before changing the module and run broader `python -m pytest` before cross-module changes.
+
+```bash
+python -m pytest
+```

--- a/docs/modules/xlsx/workflows.md
+++ b/docs/modules/xlsx/workflows.md
@@ -1,0 +1,16 @@
+# Excel and CSV Workflows
+
+## CLI Workflow
+
+```bash
+md-xlsx --help
+```
+
+1. Install the required extra.
+2. Provide an input source: XLSX, XLSM, and CSV files.
+3. Choose an output path.
+4. Review generated Markdown and assets.
+
+## API Workflow
+
+If an API is detected for this module, submit a sync request for small work or a job request for larger work. Download endpoints return generated artifacts after completion.

--- a/docs/non-technical/business-overview.md
+++ b/docs/non-technical/business-overview.md
@@ -1,0 +1,3 @@
+# Business Overview
+
+`mdengine` reduces manual documentation work by converting operational, API, database, graph, source-code, media, and document inputs into Markdown artifacts that can be reviewed and published.

--- a/docs/non-technical/faq.md
+++ b/docs/non-technical/faq.md
@@ -1,0 +1,13 @@
+# Faq
+
+## Is this one application?
+
+No. It is one Python distribution with many modules and optional runtime surfaces.
+
+## Are all dependencies installed by default?
+
+No. Install only the extras required for your workflow.
+
+## Does the repository include Kubernetes manifests?
+
+No Kubernetes manifests were detected.

--- a/docs/non-technical/glossary.md
+++ b/docs/non-technical/glossary.md
@@ -1,0 +1,7 @@
+# Glossary
+
+- CLI: command-line interface.
+- FastAPI: Python framework used for HTTP APIs.
+- MCP: Model Context Protocol tool server integration.
+- Extra: optional dependency group in `pyproject.toml`.
+- Artifact layout: generated Markdown plus supporting assets.

--- a/docs/non-technical/onboarding.md
+++ b/docs/non-technical/onboarding.md
@@ -1,0 +1,3 @@
+# Onboarding
+
+Start with `README.md`, install `.[dev,docs]`, run a small converter, run `python -m pytest db-to-md/tests -v -m "not integration"`, and build this documentation site with `mkdocs build --strict`.

--- a/docs/non-technical/user-guide.md
+++ b/docs/non-technical/user-guide.md
@@ -1,0 +1,3 @@
+# User Guide
+
+Choose the converter matching the input type, install the matching extra, run the CLI or API service, and review the generated Markdown bundle before publishing it downstream.

--- a/docs/operations/alerting.md
+++ b/docs/operations/alerting.md
@@ -1,0 +1,3 @@
+# Alerting
+
+Alert on elevated conversion failure rates, exhausted temporary storage, repeated upload limit violations, dependency startup failures, and documentation deployment failures.

--- a/docs/operations/logging.md
+++ b/docs/operations/logging.md
@@ -1,0 +1,3 @@
+# Logging
+
+Keep logs free of secrets and uploaded document contents unless explicitly required. Include job IDs, module names, and bounded error details for supportability.

--- a/docs/operations/monitoring.md
+++ b/docs/operations/monitoring.md
@@ -1,0 +1,3 @@
+# Monitoring
+
+Monitor request counts, conversion durations, job failures, upload sizes, output sizes, and dependency-specific failures such as OCR, browser, database, Graphviz, or ffmpeg errors.

--- a/docs/operations/observability.md
+++ b/docs/operations/observability.md
@@ -1,0 +1,3 @@
+# Observability
+
+Use structured application logs, gateway access logs, and job progress events. Domain APIs such as DB, graph, and log expose event or stream endpoints for long-running jobs.

--- a/docs/operations/troubleshooting.md
+++ b/docs/operations/troubleshooting.md
@@ -1,0 +1,3 @@
+# Troubleshooting
+
+Check installed extras first, then verify external tools, input size limits, service root paths, and generated workspace permissions. For Docker gateway issues, inspect nginx path routing and per-service container logs.

--- a/docs/reference/api/archive.md
+++ b/docs/reference/api/archive.md
@@ -1,0 +1,7 @@
+# `md_generator.archive`
+
+::: md_generator.archive
+    options:
+      show_source: true
+      show_signature_annotations: true
+      members_order: source

--- a/docs/reference/api/codeflow.md
+++ b/docs/reference/api/codeflow.md
@@ -1,0 +1,7 @@
+# `md_generator.codeflow`
+
+::: md_generator.codeflow
+    options:
+      show_source: true
+      show_signature_annotations: true
+      members_order: source

--- a/docs/reference/api/db.md
+++ b/docs/reference/api/db.md
@@ -1,0 +1,7 @@
+# `md_generator.db`
+
+::: md_generator.db
+    options:
+      show_source: true
+      show_signature_annotations: true
+      members_order: source

--- a/docs/reference/api/engine-cli.md
+++ b/docs/reference/api/engine-cli.md
@@ -1,0 +1,7 @@
+# `md_generator.engine_cli`
+
+::: md_generator.engine_cli
+    options:
+      show_source: true
+      show_signature_annotations: true
+      members_order: source

--- a/docs/reference/api/graph.md
+++ b/docs/reference/api/graph.md
@@ -1,0 +1,7 @@
+# `md_generator.graph`
+
+::: md_generator.graph
+    options:
+      show_source: true
+      show_signature_annotations: true
+      members_order: source

--- a/docs/reference/api/image.md
+++ b/docs/reference/api/image.md
@@ -1,0 +1,7 @@
+# `md_generator.image`
+
+::: md_generator.image
+    options:
+      show_source: true
+      show_signature_annotations: true
+      members_order: source

--- a/docs/reference/api/log.md
+++ b/docs/reference/api/log.md
@@ -1,0 +1,7 @@
+# `md_generator.log`
+
+::: md_generator.log
+    options:
+      show_source: true
+      show_signature_annotations: true
+      members_order: source

--- a/docs/reference/api/media-audio.md
+++ b/docs/reference/api/media-audio.md
@@ -1,0 +1,7 @@
+# `md_generator.media.audio`
+
+::: md_generator.media.audio
+    options:
+      show_source: true
+      show_signature_annotations: true
+      members_order: source

--- a/docs/reference/api/media-video.md
+++ b/docs/reference/api/media-video.md
@@ -1,0 +1,7 @@
+# `md_generator.media.video`
+
+::: md_generator.media.video
+    options:
+      show_source: true
+      show_signature_annotations: true
+      members_order: source

--- a/docs/reference/api/media-youtube.md
+++ b/docs/reference/api/media-youtube.md
@@ -1,0 +1,7 @@
+# `md_generator.media.youtube`
+
+::: md_generator.media.youtube
+    options:
+      show_source: true
+      show_signature_annotations: true
+      members_order: source

--- a/docs/reference/api/openapi.md
+++ b/docs/reference/api/openapi.md
@@ -1,0 +1,7 @@
+# `md_generator.openapi`
+
+::: md_generator.openapi
+    options:
+      show_source: true
+      show_signature_annotations: true
+      members_order: source

--- a/docs/reference/api/pdf.md
+++ b/docs/reference/api/pdf.md
@@ -1,0 +1,7 @@
+# `md_generator.pdf`
+
+::: md_generator.pdf
+    options:
+      show_source: true
+      show_signature_annotations: true
+      members_order: source

--- a/docs/reference/api/playwright.md
+++ b/docs/reference/api/playwright.md
@@ -1,0 +1,7 @@
+# `md_generator.playwright`
+
+::: md_generator.playwright
+    options:
+      show_source: true
+      show_signature_annotations: true
+      members_order: source

--- a/docs/reference/api/ppt.md
+++ b/docs/reference/api/ppt.md
@@ -1,0 +1,7 @@
+# `md_generator.ppt`
+
+::: md_generator.ppt
+    options:
+      show_source: true
+      show_signature_annotations: true
+      members_order: source

--- a/docs/reference/api/text.md
+++ b/docs/reference/api/text.md
@@ -1,0 +1,7 @@
+# `md_generator.text`
+
+::: md_generator.text
+    options:
+      show_source: true
+      show_signature_annotations: true
+      members_order: source

--- a/docs/reference/api/tools-assistant.md
+++ b/docs/reference/api/tools-assistant.md
@@ -1,0 +1,7 @@
+# `md_generator.tools.assistant`
+
+::: md_generator.tools.assistant
+    options:
+      show_source: true
+      show_signature_annotations: true
+      members_order: source

--- a/docs/reference/api/tools-skill-builder.md
+++ b/docs/reference/api/tools-skill-builder.md
@@ -1,0 +1,7 @@
+# `md_generator.tools.skill_builder`
+
+::: md_generator.tools.skill_builder
+    options:
+      show_source: true
+      show_signature_annotations: true
+      members_order: source

--- a/docs/reference/api/url.md
+++ b/docs/reference/api/url.md
@@ -1,0 +1,7 @@
+# `md_generator.url`
+
+::: md_generator.url
+    options:
+      show_source: true
+      show_signature_annotations: true
+      members_order: source

--- a/docs/reference/api/word.md
+++ b/docs/reference/api/word.md
@@ -1,0 +1,7 @@
+# `md_generator.word`
+
+::: md_generator.word
+    options:
+      show_source: true
+      show_signature_annotations: true
+      members_order: source

--- a/docs/reference/api/xlsx.md
+++ b/docs/reference/api/xlsx.md
@@ -1,0 +1,7 @@
+# `md_generator.xlsx`
+
+::: md_generator.xlsx
+    options:
+      show_source: true
+      show_signature_annotations: true
+      members_order: source

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -1,0 +1,31 @@
+# Commands
+
+| Command | Package | Extra | Input |
+|---------|---------|-------|-------|
+| `md-pdf` | `md_generator.pdf` | `pdf` | PDF documents |
+| `md-word` | `md_generator.word` | `word` | DOCX documents |
+| `md-ppt` | `md_generator.ppt` | `ppt` | PPTX slide decks |
+| `md-xlsx` | `md_generator.xlsx` | `xlsx` | XLSX, XLSM, and CSV files |
+| `md-image` | `md_generator.image` | `image or image-ocr` | Image files or directories |
+| `md-text` | `md_generator.text` | `text` | Plain text, JSON, and XML files |
+| `md-zip` | `md_generator.archive` | `archive plus nested format extras` | ZIP archives |
+| `md-url` | `md_generator.url` | `url or url-full` | HTTP and HTTPS web pages |
+| `md-audio` | `md_generator.media.audio` | `audio` | Audio files |
+| `md-video` | `md_generator.media.video` | `video` | Video files |
+| `md-youtube` | `md_generator.media.youtube` | `youtube` | YouTube URLs |
+| `md-playwright` | `md_generator.playwright` | `playwright` | Rendered web pages and SPAs |
+| `md-db` | `md_generator.db` | `db` | Postgres, MySQL, Oracle, SQLite, and Mongo metadata sources |
+| `md-graph` | `md_generator.graph` | `graph` | Neo4j and NetworkX graph sources |
+| `md-openapi` | `md_generator.openapi` | `openapi` | OpenAPI 3.x or Swagger 2.0 specifications |
+| `md-codeflow or codeflow` | `md_generator.codeflow` | `codeflow` | Source repositories and code trees |
+| `md-log` | `md_generator.log` | `log` | Log files and uploaded log content |
+| `mdengine ai assist / mdengine ai export` | `md_generator.tools.assistant` | `skill-openai or skill-rag-chroma for optional providers` | Skill markdown bundles and prompts |
+| `mdengine skill build` | `md_generator.tools.skill_builder` | `base package` | Project metadata and skill sources |
+
+## Documentation Commands
+
+```bash
+pip install -e ".[docs]"
+mkdocs serve
+mkdocs build --strict
+```

--- a/docs/reference/configuration-reference.md
+++ b/docs/reference/configuration-reference.md
@@ -1,0 +1,8 @@
+# Configuration Reference
+
+Configuration is domain-specific:
+
+- Database, graph, OpenAPI, and log modules include packaged YAML defaults or config-driven CLI/API flows.
+- Converter modules expose CLI flags and API request fields for input/output options.
+- Docker gateway path configuration lives in `deploy/nginx/default.conf`.
+- Python packaging, scripts, extras, and tests are centralized in `pyproject.toml`.

--- a/docs/reference/dependencies.md
+++ b/docs/reference/dependencies.md
@@ -1,0 +1,12 @@
+# Dependencies
+
+`pyproject.toml` keeps the base dependency set empty and uses optional extras for feature dependencies.
+
+Detected extras: `pdf`, `word`, `ppt`, `xlsx`, `image`, `image-ocr`, `text`, `archive`, `url`, `url-full`, `audio`, `video`, `youtube`, `playwright`, `db`, `graph`, `openapi`, `codeflow`, `codeflow-worker`, `codeflow-treesitter`, `codeflow-clang`, `codeflow-semantic`, `log`, `log-cluster`, `log-semantic`, `log-pretty`, `api`, `mcp`, `skill-openai`, `skill-rag-chroma`, `dev`, `all`, and `docs`.
+
+## Recommended Install Strategy
+
+- Use `.[docs]` for documentation builds.
+- Use `.[dev]` for tests and development helpers.
+- Use domain extras such as `.[db]`, `.[graph]`, `.[openapi]`, `.[codeflow]`, or `.[log]` only when needed.
+- Avoid `.[all]` in slim production images unless every converter is required.

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -1,0 +1,12 @@
+# Environment Variables
+
+Detected examples and operational variables include:
+
+- `DB_TO_MD_PORT`: DB API port.
+- `GRAPH_TO_MD_PORT`: graph API port.
+- `OPENAPI_TO_MD_PORT`: OpenAPI API port.
+- `DB_TO_MD_MAX_SQLITE_UPLOAD_MB`: SQLite upload limit.
+- `DB_TO_MD_MAX_SYNC_ZIP_MB`: sync ZIP response limit for DB uploads.
+- `GRAPHVIZ_DOT`: path to Graphviz `dot`.
+- `MERMAID_INK_SERVER`: alternate mermaid.ink server for Mermaid image generation.
+- `DOCS_DIR`, `OUT_DIR`, `IMAGE_ENGINES`: batch conversion script controls.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,422 @@
+site_name: mdengine Documentation
+site_description: Enterprise documentation for the mdengine Python monorepo.
+site_url: https://vishal7090.github.io/md-generator/
+repo_url: https://github.com/vishal7090/md-generator
+repo_name: vishal7090/md-generator
+edit_uri: edit/main/docs/
+
+strict: true
+
+nav:
+  - Home: index.md
+  - Getting Started:
+      - Introduction: getting-started/introduction.md
+      - Quick Start: getting-started/quick-start.md
+      - Prerequisites: getting-started/prerequisites.md
+      - Installation: getting-started/installation.md
+      - Local Development: getting-started/local-development.md
+      - Environment Setup: getting-started/environment-setup.md
+  - Architecture:
+      - Overview: architecture/overview.md
+      - HLD: architecture/hld.md
+      - LLD: architecture/lld.md
+      - System Design: architecture/system-design.md
+      - Module Interactions: architecture/module-interactions.md
+      - Deployment Architecture: architecture/deployment-architecture.md
+      - Sequence Diagrams: architecture/sequence-diagrams.md
+      - Data Flow: architecture/data-flow.md
+  - Modules:
+      - PDF:
+          - Overview: modules/pdf/overview.md
+          - Responsibilities: modules/pdf/responsibilities.md
+          - Installation: modules/pdf/installation.md
+          - Configuration: modules/pdf/configuration.md
+          - Workflows: modules/pdf/workflows.md
+          - Api: modules/pdf/api.md
+          - Database: modules/pdf/database.md
+          - Exceptions: modules/pdf/exceptions.md
+          - Logging: modules/pdf/logging.md
+          - Testing: modules/pdf/testing.md
+          - Deployment: modules/pdf/deployment.md
+          - Lld: modules/pdf/lld.md
+      - Word:
+          - Overview: modules/word/overview.md
+          - Responsibilities: modules/word/responsibilities.md
+          - Installation: modules/word/installation.md
+          - Configuration: modules/word/configuration.md
+          - Workflows: modules/word/workflows.md
+          - Api: modules/word/api.md
+          - Database: modules/word/database.md
+          - Exceptions: modules/word/exceptions.md
+          - Logging: modules/word/logging.md
+          - Testing: modules/word/testing.md
+          - Deployment: modules/word/deployment.md
+          - Lld: modules/word/lld.md
+      - PowerPoint:
+          - Overview: modules/ppt/overview.md
+          - Responsibilities: modules/ppt/responsibilities.md
+          - Installation: modules/ppt/installation.md
+          - Configuration: modules/ppt/configuration.md
+          - Workflows: modules/ppt/workflows.md
+          - Api: modules/ppt/api.md
+          - Database: modules/ppt/database.md
+          - Exceptions: modules/ppt/exceptions.md
+          - Logging: modules/ppt/logging.md
+          - Testing: modules/ppt/testing.md
+          - Deployment: modules/ppt/deployment.md
+          - Lld: modules/ppt/lld.md
+      - Excel and CSV:
+          - Overview: modules/xlsx/overview.md
+          - Responsibilities: modules/xlsx/responsibilities.md
+          - Installation: modules/xlsx/installation.md
+          - Configuration: modules/xlsx/configuration.md
+          - Workflows: modules/xlsx/workflows.md
+          - Api: modules/xlsx/api.md
+          - Database: modules/xlsx/database.md
+          - Exceptions: modules/xlsx/exceptions.md
+          - Logging: modules/xlsx/logging.md
+          - Testing: modules/xlsx/testing.md
+          - Deployment: modules/xlsx/deployment.md
+          - Lld: modules/xlsx/lld.md
+      - Image OCR:
+          - Overview: modules/image/overview.md
+          - Responsibilities: modules/image/responsibilities.md
+          - Installation: modules/image/installation.md
+          - Configuration: modules/image/configuration.md
+          - Workflows: modules/image/workflows.md
+          - Api: modules/image/api.md
+          - Database: modules/image/database.md
+          - Exceptions: modules/image/exceptions.md
+          - Logging: modules/image/logging.md
+          - Testing: modules/image/testing.md
+          - Deployment: modules/image/deployment.md
+          - Lld: modules/image/lld.md
+      - Text JSON XML:
+          - Overview: modules/text/overview.md
+          - Responsibilities: modules/text/responsibilities.md
+          - Installation: modules/text/installation.md
+          - Configuration: modules/text/configuration.md
+          - Workflows: modules/text/workflows.md
+          - Api: modules/text/api.md
+          - Database: modules/text/database.md
+          - Exceptions: modules/text/exceptions.md
+          - Logging: modules/text/logging.md
+          - Testing: modules/text/testing.md
+          - Deployment: modules/text/deployment.md
+          - Lld: modules/text/lld.md
+      - ZIP Archive:
+          - Overview: modules/archive/overview.md
+          - Responsibilities: modules/archive/responsibilities.md
+          - Installation: modules/archive/installation.md
+          - Configuration: modules/archive/configuration.md
+          - Workflows: modules/archive/workflows.md
+          - Api: modules/archive/api.md
+          - Database: modules/archive/database.md
+          - Exceptions: modules/archive/exceptions.md
+          - Logging: modules/archive/logging.md
+          - Testing: modules/archive/testing.md
+          - Deployment: modules/archive/deployment.md
+          - Lld: modules/archive/lld.md
+      - URL and Web:
+          - Overview: modules/url/overview.md
+          - Responsibilities: modules/url/responsibilities.md
+          - Installation: modules/url/installation.md
+          - Configuration: modules/url/configuration.md
+          - Workflows: modules/url/workflows.md
+          - Api: modules/url/api.md
+          - Database: modules/url/database.md
+          - Exceptions: modules/url/exceptions.md
+          - Logging: modules/url/logging.md
+          - Testing: modules/url/testing.md
+          - Deployment: modules/url/deployment.md
+          - Lld: modules/url/lld.md
+      - Audio:
+          - Overview: modules/media-audio/overview.md
+          - Responsibilities: modules/media-audio/responsibilities.md
+          - Installation: modules/media-audio/installation.md
+          - Configuration: modules/media-audio/configuration.md
+          - Workflows: modules/media-audio/workflows.md
+          - Api: modules/media-audio/api.md
+          - Database: modules/media-audio/database.md
+          - Exceptions: modules/media-audio/exceptions.md
+          - Logging: modules/media-audio/logging.md
+          - Testing: modules/media-audio/testing.md
+          - Deployment: modules/media-audio/deployment.md
+          - Lld: modules/media-audio/lld.md
+      - Video:
+          - Overview: modules/media-video/overview.md
+          - Responsibilities: modules/media-video/responsibilities.md
+          - Installation: modules/media-video/installation.md
+          - Configuration: modules/media-video/configuration.md
+          - Workflows: modules/media-video/workflows.md
+          - Api: modules/media-video/api.md
+          - Database: modules/media-video/database.md
+          - Exceptions: modules/media-video/exceptions.md
+          - Logging: modules/media-video/logging.md
+          - Testing: modules/media-video/testing.md
+          - Deployment: modules/media-video/deployment.md
+          - Lld: modules/media-video/lld.md
+      - YouTube:
+          - Overview: modules/media-youtube/overview.md
+          - Responsibilities: modules/media-youtube/responsibilities.md
+          - Installation: modules/media-youtube/installation.md
+          - Configuration: modules/media-youtube/configuration.md
+          - Workflows: modules/media-youtube/workflows.md
+          - Api: modules/media-youtube/api.md
+          - Database: modules/media-youtube/database.md
+          - Exceptions: modules/media-youtube/exceptions.md
+          - Logging: modules/media-youtube/logging.md
+          - Testing: modules/media-youtube/testing.md
+          - Deployment: modules/media-youtube/deployment.md
+          - Lld: modules/media-youtube/lld.md
+      - Playwright Web Capture:
+          - Overview: modules/playwright/overview.md
+          - Responsibilities: modules/playwright/responsibilities.md
+          - Installation: modules/playwright/installation.md
+          - Configuration: modules/playwright/configuration.md
+          - Workflows: modules/playwright/workflows.md
+          - Api: modules/playwright/api.md
+          - Database: modules/playwright/database.md
+          - Exceptions: modules/playwright/exceptions.md
+          - Logging: modules/playwright/logging.md
+          - Testing: modules/playwright/testing.md
+          - Deployment: modules/playwright/deployment.md
+          - Lld: modules/playwright/lld.md
+      - Database Metadata:
+          - Overview: modules/db/overview.md
+          - Responsibilities: modules/db/responsibilities.md
+          - Installation: modules/db/installation.md
+          - Configuration: modules/db/configuration.md
+          - Workflows: modules/db/workflows.md
+          - Api: modules/db/api.md
+          - Database: modules/db/database.md
+          - Exceptions: modules/db/exceptions.md
+          - Logging: modules/db/logging.md
+          - Testing: modules/db/testing.md
+          - Deployment: modules/db/deployment.md
+          - Lld: modules/db/lld.md
+      - Graph Metadata:
+          - Overview: modules/graph/overview.md
+          - Responsibilities: modules/graph/responsibilities.md
+          - Installation: modules/graph/installation.md
+          - Configuration: modules/graph/configuration.md
+          - Workflows: modules/graph/workflows.md
+          - Api: modules/graph/api.md
+          - Database: modules/graph/database.md
+          - Exceptions: modules/graph/exceptions.md
+          - Logging: modules/graph/logging.md
+          - Testing: modules/graph/testing.md
+          - Deployment: modules/graph/deployment.md
+          - Lld: modules/graph/lld.md
+      - OpenAPI:
+          - Overview: modules/openapi/overview.md
+          - Responsibilities: modules/openapi/responsibilities.md
+          - Installation: modules/openapi/installation.md
+          - Configuration: modules/openapi/configuration.md
+          - Workflows: modules/openapi/workflows.md
+          - Api: modules/openapi/api.md
+          - Database: modules/openapi/database.md
+          - Exceptions: modules/openapi/exceptions.md
+          - Logging: modules/openapi/logging.md
+          - Testing: modules/openapi/testing.md
+          - Deployment: modules/openapi/deployment.md
+          - Lld: modules/openapi/lld.md
+      - Codeflow:
+          - Overview: modules/codeflow/overview.md
+          - Responsibilities: modules/codeflow/responsibilities.md
+          - Installation: modules/codeflow/installation.md
+          - Configuration: modules/codeflow/configuration.md
+          - Workflows: modules/codeflow/workflows.md
+          - Api: modules/codeflow/api.md
+          - Database: modules/codeflow/database.md
+          - Exceptions: modules/codeflow/exceptions.md
+          - Logging: modules/codeflow/logging.md
+          - Testing: modules/codeflow/testing.md
+          - Deployment: modules/codeflow/deployment.md
+          - Lld: modules/codeflow/lld.md
+      - Log Analysis:
+          - Overview: modules/log/overview.md
+          - Responsibilities: modules/log/responsibilities.md
+          - Installation: modules/log/installation.md
+          - Configuration: modules/log/configuration.md
+          - Workflows: modules/log/workflows.md
+          - Api: modules/log/api.md
+          - Database: modules/log/database.md
+          - Exceptions: modules/log/exceptions.md
+          - Logging: modules/log/logging.md
+          - Testing: modules/log/testing.md
+          - Deployment: modules/log/deployment.md
+          - Lld: modules/log/lld.md
+      - AI Assistant Tools:
+          - Overview: modules/tools-assistant/overview.md
+          - Responsibilities: modules/tools-assistant/responsibilities.md
+          - Installation: modules/tools-assistant/installation.md
+          - Configuration: modules/tools-assistant/configuration.md
+          - Workflows: modules/tools-assistant/workflows.md
+          - Api: modules/tools-assistant/api.md
+          - Database: modules/tools-assistant/database.md
+          - Exceptions: modules/tools-assistant/exceptions.md
+          - Logging: modules/tools-assistant/logging.md
+          - Testing: modules/tools-assistant/testing.md
+          - Deployment: modules/tools-assistant/deployment.md
+          - Lld: modules/tools-assistant/lld.md
+      - Skill Builder:
+          - Overview: modules/tools-skill-builder/overview.md
+          - Responsibilities: modules/tools-skill-builder/responsibilities.md
+          - Installation: modules/tools-skill-builder/installation.md
+          - Configuration: modules/tools-skill-builder/configuration.md
+          - Workflows: modules/tools-skill-builder/workflows.md
+          - Api: modules/tools-skill-builder/api.md
+          - Database: modules/tools-skill-builder/database.md
+          - Exceptions: modules/tools-skill-builder/exceptions.md
+          - Logging: modules/tools-skill-builder/logging.md
+          - Testing: modules/tools-skill-builder/testing.md
+          - Deployment: modules/tools-skill-builder/deployment.md
+          - Lld: modules/tools-skill-builder/lld.md
+  - API:
+      - Overview: api/overview.md
+      - Authentication: api/authentication.md
+      - Endpoints: api/endpoints.md
+      - Request Response: api/request-response.md
+      - Error Handling: api/error-handling.md
+      - Examples: api/examples.md
+  - Database:
+      - Schema: database/schema.md
+      - Migrations: database/migrations.md
+      - Indexing: database/indexing.md
+      - Optimization: database/optimization.md
+  - Integrations:
+      - Kafka: integrations/kafka.md
+      - Redis: integrations/redis.md
+      - MongoDB: integrations/mongodb.md
+      - Postgres: integrations/postgres.md
+      - Elasticsearch: integrations/elasticsearch.md
+      - External APIs: integrations/external-apis.md
+      - Cloud Services: integrations/cloud-services.md
+  - Deployment:
+      - Docker: deployment/docker.md
+      - Kubernetes: deployment/kubernetes.md
+      - Helm: deployment/helm.md
+      - CI/CD: deployment/ci-cd.md
+      - Scaling: deployment/scaling.md
+      - Production Checklist: deployment/production-checklist.md
+  - Development:
+      - Coding Standards: development/coding-standards.md
+      - Project Structure: development/project-structure.md
+      - Debugging: development/debugging.md
+      - Testing Strategy: development/testing-strategy.md
+      - Linting: development/linting.md
+      - Release Process: development/release-process.md
+  - AI/ML:
+      - Models: ai-ml/models.md
+      - Pipelines: ai-ml/pipelines.md
+      - Datasets: ai-ml/datasets.md
+      - Embeddings: ai-ml/embeddings.md
+      - Vector Database: ai-ml/vector-database.md
+      - Inference Flow: ai-ml/inference-flow.md
+  - Operations:
+      - Monitoring: operations/monitoring.md
+      - Observability: operations/observability.md
+      - Alerting: operations/alerting.md
+      - Logging: operations/logging.md
+      - Troubleshooting: operations/troubleshooting.md
+  - Non Technical:
+      - Business Overview: non-technical/business-overview.md
+      - User Guide: non-technical/user-guide.md
+      - FAQ: non-technical/faq.md
+      - Glossary: non-technical/glossary.md
+      - Onboarding: non-technical/onboarding.md
+  - Reference:
+      - Environment Variables: reference/environment-variables.md
+      - Commands: reference/commands.md
+      - Dependencies: reference/dependencies.md
+      - Configuration Reference: reference/configuration-reference.md
+      - Python API:
+          - engine-cli: reference/api/engine-cli.md
+          - pdf: reference/api/pdf.md
+          - word: reference/api/word.md
+          - ppt: reference/api/ppt.md
+          - xlsx: reference/api/xlsx.md
+          - image: reference/api/image.md
+          - text: reference/api/text.md
+          - archive: reference/api/archive.md
+          - url: reference/api/url.md
+          - media-audio: reference/api/media-audio.md
+          - media-video: reference/api/media-video.md
+          - media-youtube: reference/api/media-youtube.md
+          - playwright: reference/api/playwright.md
+          - db: reference/api/db.md
+          - graph: reference/api/graph.md
+          - openapi: reference/api/openapi.md
+          - codeflow: reference/api/codeflow.md
+          - log: reference/api/log.md
+          - tools-assistant: reference/api/tools-assistant.md
+          - tools-skill-builder: reference/api/tools-skill-builder.md
+
+theme:
+  name: material
+  language: en
+  features:
+    - navigation.tabs
+    - navigation.sections
+    - navigation.expand
+    - navigation.path
+    - navigation.indexes
+    - search.highlight
+    - search.suggest
+    - content.code.copy
+    - content.action.edit
+  palette:
+    - scheme: default
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/weather-night
+        name: Switch to dark mode
+    - scheme: slate
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/weather-sunny
+        name: Switch to light mode
+
+plugins:
+  - search
+  - mermaid2
+  - mkdocstrings:
+      handlers:
+        python:
+          paths:
+            - src
+          options:
+            docstring_style: google
+            show_root_heading: true
+            show_root_full_path: false
+            merge_init_into_class: true
+            separate_signature: true
+
+markdown_extensions:
+  - admonition
+  - attr_list
+  - def_list
+  - footnotes
+  - md_in_html
+  - tables
+  - toc:
+      permalink: true
+  - pymdownx.details
+  - pymdownx.highlight:
+      anchor_linenums: true
+      line_spans: __span
+      pygments_lang_class: true
+  - pymdownx.inlinehilite
+  - pymdownx.snippets
+  - pymdownx.superfences
+  - pymdownx.tabbed:
+      alternate_style: true
+  - pymdownx.tasklist:
+      custom_checkbox: true
+
+extra:
+  version:
+    provider: mike

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -159,6 +159,15 @@ api = [
   "pydantic-settings>=2.0.0",
 ]
 mcp = ["mcp>=1.2.0", "fastmcp>=2.3.0"]
+docs = [
+  "mkdocs-material",
+  "mkdocstrings",
+  "mkdocstrings-python",
+  "pymdown-extensions",
+  "mkdocs-mermaid2-plugin",
+  "mkdocs-git-revision-date-localized-plugin",
+  "mike",
+]
 # Optional: AI skill bundle helpers (md_generator.tools.assistant)
 skill-openai = ["openai>=1.30.0"]
 skill-rag-chroma = ["chromadb>=0.4.22"]
@@ -212,6 +221,7 @@ all = [
 Homepage = "https://github.com/vishal7090/md-generator"
 Repository = "https://github.com/vishal7090/md-generator"
 Issues = "https://github.com/vishal7090/md-generator/issues"
+Documentation = "https://vishal7090.github.io/md-generator/"
 
 [project.scripts]
 md-pdf = "md_generator.pdf.converter:main"


### PR DESCRIPTION
## Summary

Adds an **enterprise-style documentation platform** for **mdengine**: **MkDocs** with **Material** theme, structured `docs/` content (getting started, architecture, per-module guides under `docs/modules/`), **strict** builds, **Python API reference** via **mkdocstrings** on `md_generator`, and **GitHub Pages** publishing from CI.

Closes #28

## What’s included

- **`mkdocs.yml`** — site metadata (`site_url: https://vishal7090.github.io/md-generator/`), `repo_url` / `edit_uri`, `strict: true`, full **nav** tree (Getting Started, Architecture, Modules, …).
- **`docs/`** — module-oriented Markdown (`docs/index.md`, `docs/modules/<area>/…`, shared patterns: installation, configuration, API, deployment, exceptions, …).
- **CI**
  - **`.github/workflows/docs.yml`** — `mkdocs build --strict`, **configure-pages**, **upload-pages-artifact**, **deploy-pages** (requires `pages: write`).
  - **`.github/workflows/docs-pr-preview.yml`** — strict build to `site-preview` on PRs touching docs / `mkdocs.yml` (preview path per workflow config).
- **Local dev** — contributors use `mkdocs serve` / `mkdocs build` (align with existing `scripts/run-docs-cli.ps1` / `.sh` if referenced in README).

## How to verify locally

```bash
pip install -e ".[dev]"   # or docs extras documented in README
mkdocs build --strict
mkdocs serve